### PR TITLE
feat(story-1.4): 用户账号管理 — CRUD 操作、停用机制、前端页面

### DIFF
--- a/apps/web/src/api/users.api.ts
+++ b/apps/web/src/api/users.api.ts
@@ -1,0 +1,92 @@
+import request from './request';
+
+export interface User {
+  id: string;
+  username: string;
+  name: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  updated_by: string;
+}
+
+export interface CreateUserRequest {
+  username: string;
+  name: string;
+  password: string;
+}
+
+export interface UpdateUserRequest {
+  name?: string;
+  password?: string;
+}
+
+export interface UsersListResponse {
+  success: boolean;
+  data: {
+    items: User[];
+    total: number;
+    page: number;
+    pageSize: number;
+  };
+  message: string;
+  code: string;
+}
+
+export interface UserDetailResponse {
+  success: boolean;
+  data: User;
+  message: string;
+  code: string;
+}
+
+export interface UserActionResponse {
+  success: boolean;
+  data: User;
+  message: string;
+  code: string;
+}
+
+/**
+ * 获取用户列表
+ */
+export const getUsers = (
+  page: number = 1,
+  pageSize: number = 20,
+  search?: string,
+  status?: 'ACTIVE' | 'INACTIVE'
+): Promise<UsersListResponse> => {
+  const params: Record<string, any> = { page, pageSize };
+  if (search) params.search = search;
+  if (status) params.status = status;
+  return request.get('/v1/users', { params });
+};
+
+/**
+ * 获取用户详情
+ */
+export const getUserById = (id: string): Promise<UserDetailResponse> => {
+  return request.get(`/v1/users/${id}`);
+};
+
+/**
+ * 创建用户
+ */
+export const createUser = (data: CreateUserRequest): Promise<UserActionResponse> => {
+  return request.post('/v1/users', data);
+};
+
+/**
+ * 编辑用户
+ */
+export const updateUser = (id: string, data: UpdateUserRequest): Promise<UserActionResponse> => {
+  return request.patch(`/v1/users/${id}`, data);
+};
+
+/**
+ * 停用用户
+ */
+export const deactivateUser = (id: string): Promise<UserActionResponse> => {
+  return request.post(`/v1/users/${id}/deactivate`);
+};

--- a/apps/web/src/pages/settings/users/detail.tsx
+++ b/apps/web/src/pages/settings/users/detail.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import { Button, Tag, message, Spin } from 'antd';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getUserById } from '../../../api/users.api';
+
+interface User {
+  id: string;
+  username: string;
+  name: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  updated_by: string;
+}
+
+export default function UserDetail() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (id) {
+      fetchUser(id);
+    }
+  }, [id]);
+
+  const fetchUser = async (userId: string) => {
+    setLoading(true);
+    try {
+      const response = await getUserById(userId);
+      if (response.success) {
+        setUser(response.data);
+      }
+    } catch (error) {
+      message.error('获取用户详情失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const statusColor = (status: string) => {
+    return status === 'ACTIVE' ? 'green' : 'default';
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: '24px', textAlign: 'center' }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div style={{ padding: '24px' }}>
+        <p>用户不存在</p>
+        <Button onClick={() => navigate('/settings/users')}>返回列表</Button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '24px' }}>
+      <div style={{ marginBottom: '24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <Button
+            type="text"
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate('/settings/users')}
+          />
+          <h1 style={{ margin: 0 }}>用户详情</h1>
+        </div>
+        <Button onClick={() => navigate(`/settings/users/${user.id}/edit`)}>编辑</Button>
+      </div>
+
+      <div style={{ background: '#fff', borderRadius: '8px', padding: '24px', marginBottom: '24px' }}>
+        <h2 style={{ marginBottom: '16px', fontSize: '16px', fontWeight: 600 }}>基础信息</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '24px' }}>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>用户名</label>
+            <div style={{ fontSize: '14px' }}>{user.username}</div>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>姓名</label>
+            <div style={{ fontSize: '14px' }}>{user.name}</div>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>账号状态</label>
+            <Tag color={statusColor(user.status)}>{user.status === 'ACTIVE' ? '活跃' : '停用'}</Tag>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>创建时间</label>
+            <div style={{ fontSize: '14px' }}>{new Date(user.created_at).toLocaleString()}</div>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>更新时间</label>
+            <div style={{ fontSize: '14px' }}>{new Date(user.updated_at).toLocaleString()}</div>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ background: '#fff', borderRadius: '8px', padding: '24px' }}>
+        <h2 style={{ marginBottom: '16px', fontSize: '16px', fontWeight: 600 }}>操作审计</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '24px' }}>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>创建人</label>
+            <div style={{ fontSize: '14px' }}>{user.created_by}</div>
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '8px', color: '#666', fontSize: '12px' }}>更新人</label>
+            <div style={{ fontSize: '14px' }}>{user.updated_by}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings/users/form.tsx
+++ b/apps/web/src/pages/settings/users/form.tsx
@@ -1,0 +1,242 @@
+import { useState, useEffect } from 'react';
+import { Button, message, Spin } from 'antd';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createUser, updateUser, getUserById } from '../../../api/users.api';
+
+interface User {
+  id: string;
+  username: string;
+  name: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  updated_by: string;
+}
+
+interface FormData {
+  username: string;
+  name: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export default function UserForm() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const [form, setForm] = useState<FormData>({
+    username: '',
+    name: '',
+    password: '',
+    confirmPassword: '',
+  });
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const isEdit = !!id;
+
+  useEffect(() => {
+    if (id) {
+      fetchUser(id);
+    }
+  }, [id]);
+
+  const fetchUser = async (userId: string) => {
+    setLoading(true);
+    try {
+      const response = await getUserById(userId);
+      if (response.success) {
+        const userData = response.data;
+        setUser(userData);
+        setForm({
+          username: userData.username,
+          name: userData.name,
+          password: '',
+          confirmPassword: '',
+        });
+      }
+    } catch (error) {
+      message.error('获取用户信息失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!form.username.trim()) {
+      newErrors.username = '用户名不能为空';
+    }
+    if (!form.name.trim()) {
+      newErrors.name = '姓名不能为空';
+    }
+
+    if (!isEdit) {
+      if (!form.password) {
+        newErrors.password = '密码不能为空';
+      } else if (form.password.length < 6) {
+        newErrors.password = '密码长度至少 6 位';
+      }
+    } else if (form.password) {
+      if (form.password.length < 6) {
+        newErrors.password = '密码长度至少 6 位';
+      }
+    }
+
+    if (form.password && form.password !== form.confirmPassword) {
+      newErrors.confirmPassword = '两次输入的密码不一致';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validateForm()) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      if (isEdit && user) {
+        const updateData: any = { name: form.name };
+        if (form.password) {
+          updateData.password = form.password;
+        }
+        const response = await updateUser(user.id, updateData);
+        if (response.success) {
+          message.success('用户已更新');
+          navigate('/settings/users');
+        }
+      } else {
+        const response = await createUser({
+          username: form.username,
+          name: form.name,
+          password: form.password,
+        });
+        if (response.success) {
+          message.success('用户已创建');
+          navigate('/settings/users');
+        }
+      }
+    } catch (error) {
+      message.error(isEdit ? '更新用户失败' : '创建用户失败');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div style={{ padding: '24px', textAlign: 'center' }}>
+        <Spin />
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '24px' }}>
+      <div style={{ marginBottom: '24px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          onClick={() => navigate('/settings/users')}
+        />
+        <h1 style={{ margin: 0 }}>{isEdit ? '编辑用户' : '新建用户'}</h1>
+      </div>
+
+      <div style={{ background: '#fff', borderRadius: '8px', padding: '24px', maxWidth: '600px' }}>
+        <div style={{ marginBottom: '16px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 500 }}>
+            用户名 <span style={{ color: '#ff4d4f' }}>*</span>
+          </label>
+          <input
+            type="text"
+            value={form.username}
+            onChange={(e) => setForm({ ...form, username: e.target.value })}
+            disabled={isEdit}
+            placeholder="请输入用户名"
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: errors.username ? '1px solid #ff4d4f' : '1px solid #d9d9d9',
+              opacity: isEdit ? 0.6 : 1,
+            }}
+          />
+          {errors.username && <div style={{ color: '#ff4d4f', fontSize: '12px', marginTop: '4px' }}>{errors.username}</div>}
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 500 }}>
+            姓名 <span style={{ color: '#ff4d4f' }}>*</span>
+          </label>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            placeholder="请输入姓名"
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: errors.name ? '1px solid #ff4d4f' : '1px solid #d9d9d9',
+            }}
+          />
+          {errors.name && <div style={{ color: '#ff4d4f', fontSize: '12px', marginTop: '4px' }}>{errors.name}</div>}
+        </div>
+
+        <div style={{ marginBottom: '16px' }}>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 500 }}>
+            密码 {!isEdit && <span style={{ color: '#ff4d4f' }}>*</span>}
+          </label>
+          <input
+            type="password"
+            value={form.password}
+            onChange={(e) => setForm({ ...form, password: e.target.value })}
+            placeholder={isEdit ? '不修改密码请留空' : '请输入密码'}
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              borderRadius: '4px',
+              border: errors.password ? '1px solid #ff4d4f' : '1px solid #d9d9d9',
+            }}
+          />
+          {errors.password && <div style={{ color: '#ff4d4f', fontSize: '12px', marginTop: '4px' }}>{errors.password}</div>}
+        </div>
+
+        {form.password && (
+          <div style={{ marginBottom: '16px' }}>
+            <label style={{ display: 'block', marginBottom: '8px', fontWeight: 500 }}>
+              确认密码 <span style={{ color: '#ff4d4f' }}>*</span>
+            </label>
+            <input
+              type="password"
+              value={form.confirmPassword}
+              onChange={(e) => setForm({ ...form, confirmPassword: e.target.value })}
+              placeholder="请再次输入密码"
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: '4px',
+                border: errors.confirmPassword ? '1px solid #ff4d4f' : '1px solid #d9d9d9',
+              }}
+            />
+            {errors.confirmPassword && <div style={{ color: '#ff4d4f', fontSize: '12px', marginTop: '4px' }}>{errors.confirmPassword}</div>}
+          </div>
+        )}
+
+        <div style={{ marginTop: '24px', display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <Button onClick={() => navigate('/settings/users')}>取消</Button>
+          <Button type="primary" loading={submitting} onClick={handleSubmit}>
+            {isEdit ? '更新' : '创建'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/settings/users/index.tsx
+++ b/apps/web/src/pages/settings/users/index.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+import { Button, Space, Tag, message, Popconfirm } from 'antd';
+import { PlusOutlined } from '@ant-design/icons';
+import { useNavigate } from 'react-router-dom';
+import { getUsers, deactivateUser } from '../../../api/users.api';
+
+interface User {
+  id: string;
+  username: string;
+  name: string;
+  status: 'ACTIVE' | 'INACTIVE';
+  created_at: string;
+  updated_at: string;
+  created_by: string;
+  updated_by: string;
+}
+
+interface ListState {
+  data: User[];
+  total: number;
+  page: number;
+  pageSize: number;
+  loading: boolean;
+  search: string;
+  statusFilter: string;
+}
+
+export default function UsersList() {
+  const navigate = useNavigate();
+  const [state, setState] = useState<ListState>({
+    data: [],
+    total: 0,
+    page: 1,
+    pageSize: 20,
+    loading: false,
+    search: '',
+    statusFilter: '',
+  });
+
+  const fetchUsers = async (page: number = 1, search: string = '', status: string = '') => {
+    setState((prev) => ({ ...prev, loading: true }));
+    try {
+      const response = await getUsers(
+        page,
+        state.pageSize,
+        search || undefined,
+        (status as 'ACTIVE' | 'INACTIVE') || undefined
+      );
+      if (response.success) {
+        setState((prev) => ({
+          ...prev,
+          data: response.data.items,
+          total: response.data.total,
+          page: response.data.page,
+        }));
+      }
+    } catch (error) {
+      message.error('获取用户列表失败');
+    } finally {
+      setState((prev) => ({ ...prev, loading: false }));
+    }
+  };
+
+  const handleSearch = (value: string) => {
+    setState((prev) => ({ ...prev, search: value, page: 1 }));
+    fetchUsers(1, value, state.statusFilter);
+  };
+
+  const handleStatusFilter = (status: string) => {
+    setState((prev) => ({ ...prev, statusFilter: status, page: 1 }));
+    fetchUsers(1, state.search, status);
+  };
+
+  const handleDeactivate = async (id: string) => {
+    try {
+      const response = await deactivateUser(id);
+      if (response.success) {
+        message.success('用户已停用');
+        fetchUsers(state.page, state.search, state.statusFilter);
+      }
+    } catch (error) {
+      message.error('停用用户失败');
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    setState((prev) => ({ ...prev, page }));
+    fetchUsers(page, state.search, state.statusFilter);
+  };
+
+  const statusColor = (status: string) => {
+    return status === 'ACTIVE' ? 'green' : 'default';
+  };
+
+  return (
+    <div style={{ padding: '24px' }}>
+      <div style={{ marginBottom: '24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1>用户管理</h1>
+        <Button type="primary" icon={<PlusOutlined />} onClick={() => navigate('/settings/users/form')}>
+          新建用户
+        </Button>
+      </div>
+
+      <div style={{ marginBottom: '16px', display: 'flex', gap: '8px' }}>
+        <input
+          type="text"
+          placeholder="搜索用户名或姓名"
+          value={state.search}
+          onChange={(e) => handleSearch(e.target.value)}
+          style={{ padding: '8px 12px', borderRadius: '4px', border: '1px solid #d9d9d9', flex: 1 }}
+        />
+        <select
+          value={state.statusFilter}
+          onChange={(e) => handleStatusFilter(e.target.value)}
+          style={{ padding: '8px 12px', borderRadius: '4px', border: '1px solid #d9d9d9' }}
+        >
+          <option value="">全部状态</option>
+          <option value="ACTIVE">活跃</option>
+          <option value="INACTIVE">停用</option>
+        </select>
+      </div>
+
+      <div style={{ background: '#fff', borderRadius: '8px', overflow: 'hidden' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid #f0f0f0', background: '#fafafa' }}>
+              <th style={{ padding: '12px 16px', textAlign: 'left', fontWeight: 600 }}>用户名</th>
+              <th style={{ padding: '12px 16px', textAlign: 'left', fontWeight: 600 }}>姓名</th>
+              <th style={{ padding: '12px 16px', textAlign: 'left', fontWeight: 600 }}>账号状态</th>
+              <th style={{ padding: '12px 16px', textAlign: 'left', fontWeight: 600 }}>创建时间</th>
+              <th style={{ padding: '12px 16px', textAlign: 'left', fontWeight: 600 }}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {state.data.map((user) => (
+              <tr key={user.id} style={{ borderBottom: '1px solid #f0f0f0' }}>
+                <td style={{ padding: '12px 16px' }}>{user.username}</td>
+                <td style={{ padding: '12px 16px' }}>{user.name}</td>
+                <td style={{ padding: '12px 16px' }}>
+                  <Tag color={statusColor(user.status)}>{user.status === 'ACTIVE' ? '活跃' : '停用'}</Tag>
+                </td>
+                <td style={{ padding: '12px 16px' }}>{new Date(user.created_at).toLocaleDateString()}</td>
+                <td style={{ padding: '12px 16px' }}>
+                  <Space>
+                    <a onClick={() => navigate(`/settings/users/${user.id}`)}>查看</a>
+                    <a onClick={() => navigate(`/settings/users/${user.id}/edit`)}>编辑</a>
+                    {user.status === 'ACTIVE' && (
+                      <Popconfirm
+                        title="停用用户"
+                        description="确定要停用此用户吗？停用后该账号将无法登录。"
+                        onConfirm={() => handleDeactivate(user.id)}
+                        okText="确定"
+                        cancelText="取消"
+                      >
+                        <a style={{ color: '#ff4d4f' }}>停用</a>
+                      </Popconfirm>
+                    )}
+                  </Space>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: '16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span>共 {state.total} 条记录</span>
+        <div>
+          <button
+            onClick={() => handlePageChange(state.page - 1)}
+            disabled={state.page === 1}
+            style={{ marginRight: '8px', padding: '4px 8px' }}
+          >
+            上一页
+          </button>
+          <span style={{ margin: '0 8px' }}>
+            第 {state.page} 页，共 {Math.ceil(state.total / state.pageSize)} 页
+          </span>
+          <button
+            onClick={() => handlePageChange(state.page + 1)}
+            disabled={state.page >= Math.ceil(state.total / state.pageSize)}
+            style={{ marginLeft: '8px', padding: '4px 8px' }}
+          >
+            下一页
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Story 1-4: 用户账号管理

### 功能描述
实现用户账号管理的完整功能，包括创建、查看、编辑、停用用户账号。

### 后端实现
- ✅ UserStatus 枚举（ACTIVE / INACTIVE）
- ✅ User 实体扩展（status 字段）
- ✅ UsersController（5 个 API 端点）
- ✅ UsersService（CRUD 业务逻辑）
- ✅ DTO 定义（CreateUserDto、UpdateUserDto、UserResponseDto）
- ✅ JwtStrategy 更新（status 检查）
- ✅ 审计字段自动填充（created_by / updated_by）
- ✅ 后端测试

### 前端实现
- ✅ 用户 API 层（users.api.ts）
- ✅ 用户列表页（搜索、筛选、分页）
- ✅ 用户详情页（审计信息展示）
- ✅ 用户表单页（新建/编辑）
- ✅ 停用操作二次确认

### 验收标准
- ✅ 用户列表页面（搜索、筛选、分页）
- ✅ 用户详情页面（审计信息）
- ✅ 创建用户（自动记录 created_by）
- ✅ 编辑用户（自动记录 updated_by）
- ✅ 停用用户（Token 立即失效）
- ✅ 权限控制（JWT 认证）
- ✅ 构建成功（无编译错误）

### 测试
- ✅ 构建验证通过
- ✅ 后端单元测试
- ✅ 后端集成测试

### 相关 Issue
Closes #1-4