### PR TITLE
fix(users): 修复用户列表禁用功能及时间显示问题

### DIFF
--- a/apps/api/src/modules/users/users.repository.ts
+++ b/apps/api/src/modules/users/users.repository.ts
@@ -42,8 +42,9 @@ export class UsersRepository {
     return this.repo.save(user);
   }
 
-  update(id: number, user: Partial<User>): Promise<User> {
-    return this.repo.save({ id, ...user });
+  async update(id: number, user: Partial<User>): Promise<User> {
+    await this.repo.update(id, user);
+    return this.repo.findOneOrFail({ where: { id } });
   }
 
   softDelete(id: number): Promise<void> {

--- a/apps/web/src/api/users.api.ts
+++ b/apps/web/src/api/users.api.ts
@@ -4,11 +4,11 @@ export interface User {
   id: string;
   username: string;
   name: string;
-  status: 'ACTIVE' | 'INACTIVE';
-  created_at: string;
-  updated_at: string;
-  created_by: string;
-  updated_by: string;
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  updatedBy: string;
 }
 
 export interface CreateUserRequest {

--- a/apps/web/src/pages/settings/users/detail.tsx
+++ b/apps/web/src/pages/settings/users/detail.tsx
@@ -54,15 +54,15 @@ export default function UserDetail() {
           <Descriptions.Item label="用户名">{user.username}</Descriptions.Item>
           <Descriptions.Item label="姓名">{user.name}</Descriptions.Item>
           <Descriptions.Item label="账号状态">
-            <Tag color={user.status === 'ACTIVE' ? 'green' : 'default'}>
-              {user.status === 'ACTIVE' ? '活跃' : '停用'}
+            <Tag color={user.status === 'active' ? 'green' : 'red'}>
+              {user.status === 'active' ? '活跃' : '停用'}
             </Tag>
           </Descriptions.Item>
           <Descriptions.Item label="创建时间">
-            {new Date(user.created_at).toLocaleString()}
+            {new Date(user.createdAt).toLocaleString()}
           </Descriptions.Item>
           <Descriptions.Item label="更新时间">
-            {new Date(user.updated_at).toLocaleString()}
+            {new Date(user.updatedAt).toLocaleString()}
           </Descriptions.Item>
         </Descriptions>
       </div>
@@ -70,8 +70,8 @@ export default function UserDetail() {
       <div style={{ background: '#fff', borderRadius: 8, padding: 24 }}>
         <h3 style={{ marginBottom: 16, fontSize: 16, fontWeight: 600 }}>操作审计</h3>
         <Descriptions column={2} bordered size="small">
-          <Descriptions.Item label="创建人">{user.created_by}</Descriptions.Item>
-          <Descriptions.Item label="更新人">{user.updated_by}</Descriptions.Item>
+          <Descriptions.Item label="创建人">{user.createdBy}</Descriptions.Item>
+          <Descriptions.Item label="更新人">{user.updatedBy}</Descriptions.Item>
         </Descriptions>
       </div>
     </div>

--- a/apps/web/src/pages/settings/users/detail.tsx
+++ b/apps/web/src/pages/settings/users/detail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Button, Tag, Spin, Descriptions } from 'antd';
+import { Button, Tag, Spin, Descriptions, Timeline } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getUserById } from '../../../api/users.api';
@@ -68,11 +68,37 @@ export default function UserDetail() {
       </div>
 
       <div style={{ background: '#fff', borderRadius: 8, padding: 24 }}>
-        <h3 style={{ marginBottom: 16, fontSize: 16, fontWeight: 600 }}>操作审计</h3>
-        <Descriptions column={2} bordered size="small">
-          <Descriptions.Item label="创建人">{user.createdBy}</Descriptions.Item>
-          <Descriptions.Item label="更新人">{user.updatedBy}</Descriptions.Item>
-        </Descriptions>
+        <h3 style={{ marginBottom: 16, fontSize: 16, fontWeight: 600 }}>操作记录</h3>
+        <Timeline
+          items={[
+            {
+              color: '#1890FF',
+              children: (
+                <div>
+                  <div style={{ fontSize: 14, color: '#1F1F1F' }}>
+                    <span style={{ fontWeight: 500 }}>{user.updatedBy}</span> 更新了用户信息
+                  </div>
+                  <div style={{ fontSize: 12, color: '#666', marginTop: 2 }}>
+                    {new Date(user.updatedAt).toLocaleString()}
+                  </div>
+                </div>
+              ),
+            },
+            {
+              color: '#D9D9D9',
+              children: (
+                <div>
+                  <div style={{ fontSize: 14, color: '#1F1F1F' }}>
+                    <span style={{ fontWeight: 500 }}>{user.createdBy}</span> 创建了用户
+                  </div>
+                  <div style={{ fontSize: 12, color: '#666', marginTop: 2 }}>
+                    {new Date(user.createdAt).toLocaleString()}
+                  </div>
+                </div>
+              ),
+            },
+          ]}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/pages/settings/users/index.tsx
+++ b/apps/web/src/pages/settings/users/index.tsx
@@ -86,16 +86,22 @@ export default function UsersList() {
       dataIndex: 'status',
       key: 'status',
       render: (status: string) => (
-        <Tag color={status === 'ACTIVE' ? 'green' : 'default'}>
-          {status === 'ACTIVE' ? '活跃' : '停用'}
+        <Tag color={status === 'active' ? 'green' : 'red'}>
+          {status === 'active' ? '活跃' : '停用'}
         </Tag>
       ),
     },
     {
       title: '创建时间',
-      dataIndex: 'created_at',
-      key: 'created_at',
-      render: (v: string) => new Date(v).toLocaleDateString(),
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: (v: string) => new Date(v).toLocaleString(),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      key: 'updatedAt',
+      render: (v: string) => new Date(v).toLocaleString(),
     },
     {
       title: '操作',
@@ -104,7 +110,7 @@ export default function UsersList() {
         <Space>
           <a onClick={() => navigate(`/settings/users/${record.id}`)}>查看</a>
           <a onClick={() => navigate(`/settings/users/${record.id}/edit`)}>编辑</a>
-          {record.status === 'ACTIVE' && (
+          {record.status === 'active' && (
             <Popconfirm
               title="停用用户"
               description="确定要停用此用户吗？停用后该账号将无法登录。"


### PR DESCRIPTION
## Summary
- 修复 UserStatus 枚举值大小写不一致（`'active'`/`'inactive'`）导致停用按钮不显示
- 修复前端 User 接口字段名与后端返回 camelCase 不匹配，导致创建/更新时间显示异常
- 用户列表新增更新时间列，停用状态标签改为红色
- 修复 `repo.save(plainObject)` 触发 INSERT 而非 UPDATE 的 bug

## Test plan
- [ ] 活跃用户显示绿色标签，停用用户显示红色标签
- [ ] 活跃用户操作列显示"停用"按钮，点击确认后状态变为停用
- [ ] 创建时间、更新时间正常显示
- [ ] 用户详情页时间和审计信息正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)