### PR TITLE
feat(master-data): 基础参考数据管理 - 仓库/币种/国家地区模块 (Story 2-2)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-2-基础参考数据管理.md
+++ b/_bmad-output/implementation-artifacts/2-2-基础参考数据管理.md
@@ -1,0 +1,520 @@
+# Story 2.2: 基础参考数据管理（仓库、币种、国家/地区）
+
+Status: ready-for-dev
+
+## Story
+
+As a 系统管理员,
+I want 管理系统基础参考数据（仓库、币种、国家/地区）,
+So that 后续业务模块可以引用这些标准化的基础数据。
+
+> **注意**：单位管理（FR14）已在 Story 2-1 中作为模板实现完毕（`apps/api/src/modules/master-data/units/`）。本 Story 实现剩余三个模块：**仓库（FR15）、币种（FR16）、国家/地区（FR17）**，严格复用 Story 2-1 建立的所有模式。
+
+---
+
+## Acceptance Criteria
+
+**Given** 管理员已登录
+**When** 进入仓库管理页面，点击"新建"
+**Then** 可填写仓库名称（必填）、地址（可选），提交后创建成功（FR15）
+**And** 列表页显示新创建的仓库记录，状态为"启用"
+
+**Given** 管理员已登录
+**When** 在仓库列表对某条记录点击"禁用"
+**Then** 通过 `PATCH /api/warehouses/:id` 传 `{ status: 'inactive' }` 更新状态
+**And** 列表中该记录状态标签变为灰色"禁用"
+
+**Given** 管理员已登录
+**When** 进入币种管理页面创建币种
+**Then** 可填写币种代码（如 USD，必填唯一）、币种名称（如 美元，必填），提交后创建成功（FR16）
+
+**Given** 管理员已登录
+**When** 在币种列表对某条记录点击"禁用"
+**Then** 通过 `PATCH /api/currencies/:id` 更新状态为 inactive
+**And** 状态标签变为灰色"禁用"
+
+**Given** 管理员已登录
+**When** 进入国家/地区管理页面创建国家
+**Then** 可填写国家名称（必填）、国家代码（必填唯一，如 CN），提交后创建成功（FR17）
+
+**Given** 以上三个模块的列表页
+**When** 在搜索框输入关键字
+**Then** 列表按名称字段模糊匹配，实时筛选展示结果（FR18）
+
+**Given** 以上三个模块的列表页
+**When** 使用分页器切换页码或每页条数
+**Then** 列表按分页参数重新加载数据（FR20）
+
+---
+
+## Tasks / Subtasks
+
+### 共享枚举（packages/shared）
+
+- [ ] 创建 `packages/shared/src/enums/warehouse-status.enum.ts`（WarehouseStatus: ACTIVE/INACTIVE）
+- [ ] 创建 `packages/shared/src/enums/currency-status.enum.ts`（CurrencyStatus: ACTIVE/INACTIVE）
+- [ ] 在 `packages/shared/src/index.ts` 导出以上两个枚举
+
+### 后端：仓库模块
+
+- [ ] 创建 7 文件结构 `apps/api/src/modules/master-data/warehouses/`
+  - [ ] `warehouses.module.ts`
+  - [ ] `warehouses.controller.ts`
+  - [ ] `warehouses.service.ts`
+  - [ ] `warehouses.repository.ts`
+  - [ ] `entities/warehouse.entity.ts`（继承 BaseEntity，含 name/address/status/@DeleteDateColumn）
+  - [ ] `dto/create-warehouse.dto.ts`
+  - [ ] `dto/update-warehouse.dto.ts`
+  - [ ] `dto/query-warehouse.dto.ts`（继承 BaseQueryDto，加 status 字段）
+  - [ ] `tests/warehouses.service.spec.ts`
+- [ ] 创建 Migration `apps/api/src/migrations/20260420000100-create-warehouses-table.ts`（含 down()）
+- [ ] 在 AppModule 注册 WarehousesModule
+
+### 后端：币种模块
+
+- [ ] 创建 7 文件结构 `apps/api/src/modules/master-data/currencies/`
+  - [ ] `currencies.module.ts`
+  - [ ] `currencies.controller.ts`
+  - [ ] `currencies.service.ts`
+  - [ ] `currencies.repository.ts`
+  - [ ] `entities/currency.entity.ts`（code 唯一索引）
+  - [ ] `dto/create-currency.dto.ts`
+  - [ ] `dto/update-currency.dto.ts`
+  - [ ] `dto/query-currency.dto.ts`
+  - [ ] `tests/currencies.service.spec.ts`
+- [ ] 创建 Migration `apps/api/src/migrations/20260420000200-create-currencies-table.ts`（含 down()）
+- [ ] 在 AppModule 注册 CurrenciesModule
+
+### 后端：国家/地区模块
+
+- [ ] 创建 7 文件结构 `apps/api/src/modules/master-data/countries/`
+  - [ ] `countries.module.ts`
+  - [ ] `countries.controller.ts`
+  - [ ] `countries.service.ts`
+  - [ ] `countries.repository.ts`
+  - [ ] `entities/country.entity.ts`（code 唯一索引，**无 status 字段**，含 deleted_at）
+  - [ ] `dto/create-country.dto.ts`
+  - [ ] `dto/update-country.dto.ts`
+  - [ ] `dto/query-country.dto.ts`
+  - [ ] `tests/countries.service.spec.ts`
+- [ ] 创建 Migration `apps/api/src/migrations/20260420000300-create-countries-table.ts`（含 down()）
+- [ ] 在 AppModule 注册 CountriesModule
+
+### 前端：仓库模块
+
+- [ ] 创建 API 层 `apps/web/src/api/warehouses.api.ts`
+- [ ] 创建页面目录 `apps/web/src/pages/master-data/warehouses/`
+  - [ ] `index.tsx`（ProTable，含状态筛选）
+  - [ ] `detail.tsx`（ProDescriptions）
+  - [ ] `form.tsx`（ProForm，name 必填，address 可选）
+- [ ] 在 `apps/web/src/App.tsx` 注册仓库路由（4条）
+
+### 前端：币种模块
+
+- [ ] 创建 API 层 `apps/web/src/api/currencies.api.ts`
+- [ ] 创建页面目录 `apps/web/src/pages/master-data/currencies/`
+  - [ ] `index.tsx`（ProTable，含状态筛选）
+  - [ ] `detail.tsx`（ProDescriptions）
+  - [ ] `form.tsx`（ProForm，code 和 name 均必填）
+- [ ] 在 `apps/web/src/App.tsx` 注册币种路由（4条）
+
+### 前端：国家/地区模块
+
+- [ ] 创建 API 层 `apps/web/src/api/countries.api.ts`
+- [ ] 创建页面目录 `apps/web/src/pages/master-data/countries/`
+  - [ ] `index.tsx`（ProTable，**无状态筛选**）
+  - [ ] `detail.tsx`（ProDescriptions）
+  - [ ] `form.tsx`（ProForm，name 和 code 均必填）
+- [ ] 在 `apps/web/src/App.tsx` 注册国家路由（4条）
+
+---
+
+## Dev Agent Context
+
+### 关键约束
+
+#### 复用 Story 2-1 的所有模式，禁止重新发明
+
+- **模块路径规则**：`apps/api/src/modules/master-data/{module}/`
+- **Entity 必须继承 BaseEntity**：`import { BaseEntity } from '../../../../common/entities/base.entity'`（4层 `..`）
+- **每个字段必须同时加 `@Expose()` 和 `@Column({ name: 'snake_case' })`**
+- **软删除**：`@DeleteDateColumn({ name: 'deleted_at' })` + 查询时 `WHERE deleted_at IS NULL`
+- **QueryDto 继承 BaseQueryDto**：`import { BaseQueryDto } from '../../../../common/dto/base-query.dto'`
+- **findAll 返回 `{ list, total, page, pageSize, totalPages }`**（与前端 interface 一致，用 `list` 不用 `data`）
+- **ID 类型为 `number`**（BaseEntity 使用 bigint，TypeScript 层映射为 number）
+- **API 调用必须使用 `normalizeApiError` 包装**（参考 units.api.ts 已有模式）
+- **Migration 必须包含 `down()` 方法**（参考已有 migration 的 dropTable 模式）
+- **前端 API 文件必须使用 `import request from './request'`**（不是 client，不是 axios）
+
+#### 禁止事项
+
+- ❌ 禁止修改 Sidebar.tsx — 仓库/币种/国家路由条目已存在，无需改动
+- ❌ 禁止修改 packages/shared 中已有枚举（UnitStatus 等）
+- ❌ 禁止在 Entity 中省略 `@Column({ name })` 显式列名
+- ❌ 禁止用 `data` 字段替代 `list` 字段（会导致前端解析失败，这是 2-1 已修复的 bug）
+- ❌ 禁止国家模块添加 status 字段（FR17 不要求启用/禁用）
+
+---
+
+### 已存在文件（不得重复创建）
+
+| 文件 | 说明 |
+|------|------|
+| `apps/api/src/common/entities/base.entity.ts` | BaseEntity 定义 |
+| `apps/api/src/common/dto/base-query.dto.ts` | BaseQueryDto 定义 |
+| `apps/api/src/common/decorators/current-user.decorator.ts` | @CurrentUser() |
+| `apps/web/src/api/request.ts` | axios 实例，拦截器自动解包 response.data.data |
+| `apps/web/src/components/layout/Sidebar.tsx` | 已含仓库/币种/国家侧边栏条目，**不需要修改** |
+| `packages/shared/src/enums/unit-status.enum.ts` | 参考枚举写法 |
+
+### Sidebar 已有路由条目（确认）
+
+```
+{ key: '/master-data/warehouses', label: '仓库管理' },
+{ key: '/master-data/currencies', label: '币种管理' },
+{ key: '/master-data/countries', label: '国家/地区' },
+```
+
+App.tsx 中**尚未注册**以上三条路由 — 这是本 Story 需要补充的内容。
+
+---
+
+### 参考实现：单位模块（Story 2-1 已完成）
+
+以下是 Story 2-1 中建立的标准模式，三个新模块必须严格遵循。
+
+#### Entity 模式
+
+```typescript
+// apps/api/src/modules/master-data/units/entities/unit.entity.ts
+import { Column, DeleteDateColumn, Entity, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { UnitStatus } from '@infitek/shared';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('units')
+@Unique('idx_units_code', ['code'])
+export class Unit extends BaseEntity {
+  @Column({ name: 'code', type: 'varchar', length: 50 })
+  @Expose()
+  code: string;
+
+  @Column({ name: 'name', type: 'varchar', length: 100 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'status', type: 'enum', enum: Object.values(UnitStatus), default: UnitStatus.ACTIVE })
+  @Expose()
+  status: UnitStatus;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null;
+}
+```
+
+#### Repository 模式
+
+```typescript
+// 关键：返回 { list, total, page, pageSize, totalPages }（注意是 list 不是 data）
+async findAll(query: QueryUnitDto) {
+  const { keyword, page = 1, pageSize = 20, status } = query;
+  const qb = this.repo.createQueryBuilder('unit')
+    .where('unit.deleted_at IS NULL');
+  if (keyword) {
+    qb.andWhere('(unit.name LIKE :kw OR unit.code LIKE :kw)', { kw: `%${keyword}%` });
+  }
+  if (status) qb.andWhere('unit.status = :status', { status });
+  const [list, total] = await qb.orderBy('unit.created_at', 'DESC')
+    .skip((page - 1) * pageSize).take(pageSize).getManyAndCount();
+  return { list, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+}
+```
+
+#### Service 模式（含 code 唯一性校验）
+
+```typescript
+async create(dto: CreateWarehouseDto, operator?: string) {
+  return this.warehousesRepository.create({
+    name: dto.name, address: dto.address,
+    status: WarehouseStatus.ACTIVE,
+    createdBy: operator, updatedBy: operator,
+  });
+}
+// 注意：仓库名称无唯一约束，不需要 findByCode 检查
+// 币种 code 有唯一约束，需要检查重复
+```
+
+#### Controller 模式
+
+```typescript
+@Controller('warehouses')
+export class WarehousesController {
+  @Get()    findAll(@Query() query: QueryWarehouseDto) { ... }
+  @Get(':id') findById(@Param('id', ParseIntPipe) id: number) { ... }
+  @Post()   create(@Body() dto: CreateWarehouseDto, @CurrentUser() user) { ... }
+  @Patch(':id') update(@Param('id', ParseIntPipe) id: number, @Body() dto: UpdateWarehouseDto, @CurrentUser() user) { ... }
+}
+```
+
+#### Migration 模式
+
+```typescript
+// 参考 apps/api/src/migrations/20260419000100-create-units-table.ts
+// 关键：必须包含 down() 方法
+public async down(queryRunner: QueryRunner): Promise<void> {
+  await queryRunner.dropTable('warehouses'); // or currencies / countries
+}
+```
+
+#### AppModule 注册模式
+
+```typescript
+// apps/api/src/app.module.ts 中的 imports 数组，追加：
+import { WarehousesModule } from './modules/master-data/warehouses/warehouses.module';
+import { CurrenciesModule } from './modules/master-data/currencies/currencies.module';
+import { CountriesModule } from './modules/master-data/countries/countries.module';
+// 在 imports: [..., UnitsModule, WarehousesModule, CurrenciesModule, CountriesModule, FilesModule]
+```
+
+---
+
+### 数据库表结构
+
+#### warehouses 表
+
+```sql
+CREATE TABLE `warehouses` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL COMMENT '仓库名称',
+  `address` varchar(255) DEFAULT NULL COMMENT '仓库地址',
+  `status` enum('active','inactive') NOT NULL DEFAULT 'active',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `created_by` varchar(100) DEFAULT NULL,
+  `updated_by` varchar(100) DEFAULT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_warehouses_deleted_at` (`deleted_at`)
+);
+```
+
+#### currencies 表
+
+```sql
+CREATE TABLE `currencies` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `code` varchar(10) NOT NULL COMMENT '币种代码（如 USD）',
+  `name` varchar(50) NOT NULL COMMENT '币种名称（如 美元）',
+  `status` enum('active','inactive') NOT NULL DEFAULT 'active',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `created_by` varchar(100) DEFAULT NULL,
+  `updated_by` varchar(100) DEFAULT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_currencies_code` (`code`),
+  KEY `idx_currencies_deleted_at` (`deleted_at`)
+);
+```
+
+#### countries 表
+
+```sql
+CREATE TABLE `countries` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL COMMENT '国家名称',
+  `code` varchar(10) NOT NULL COMMENT '国家代码（如 CN）',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `created_by` varchar(100) DEFAULT NULL,
+  `updated_by` varchar(100) DEFAULT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_countries_code` (`code`),
+  KEY `idx_countries_deleted_at` (`deleted_at`)
+);
+-- 注意：countries 没有 status 字段（FR17 不要求启用/禁用）
+```
+
+---
+
+### 共享枚举写法
+
+严格遵循已有的 `UnitStatus` 使用 TypeScript `enum` 关键字模式：
+
+```typescript
+// packages/shared/src/enums/warehouse-status.enum.ts
+export enum WarehouseStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
+
+// packages/shared/src/enums/currency-status.enum.ts
+export enum CurrencyStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
+```
+
+在 `packages/shared/src/index.ts` 追加（保留已有内容）：
+
+```typescript
+export * from './enums/warehouse-status.enum';
+export * from './enums/currency-status.enum';
+```
+
+---
+
+### 前端 API 层规范
+
+严格复用 `apps/web/src/api/units.api.ts` 的模式：
+
+```typescript
+// apps/web/src/api/warehouses.api.ts
+import type { WarehouseStatus } from '@infitek/shared';
+import request from './request';
+
+export interface Warehouse {
+  id: number;            // bigint → number
+  name: string;
+  address?: string | null;
+  status: WarehouseStatus;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface WarehousesListData {
+  list: Warehouse[];     // 注意是 list，不是 data！
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) throw error;
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getWarehouses = (params: {...}): Promise<WarehousesListData> =>
+  request.get<any, WarehousesListData>('/warehouses', { params }).catch(normalizeApiError);
+export const getWarehouseById = (id: number): Promise<Warehouse> =>
+  request.get<any, Warehouse>(`/warehouses/${id}`).catch(normalizeApiError);
+export const createWarehouse = (payload: {...}): Promise<Warehouse> =>
+  request.post<any, Warehouse>('/warehouses', payload).catch(normalizeApiError);
+export const updateWarehouse = (id: number, payload: {...}): Promise<Warehouse> =>
+  request.patch<any, Warehouse>(`/warehouses/${id}`, payload).catch(normalizeApiError);
+```
+
+**相同模式用于 currencies.api.ts 和 countries.api.ts**（countries 无 status 字段和 status 参数）。
+
+---
+
+### 前端路由注册（App.tsx）
+
+在 `<Route element={<AppLayout />}>` 内追加（紧跟 units 路由之后）：
+
+```typescript
+// 仓库管理
+import WarehousesListPage from './pages/master-data/warehouses/index';
+import WarehouseDetailPage from './pages/master-data/warehouses/detail';
+import WarehouseFormPage from './pages/master-data/warehouses/form';
+// 币种管理
+import CurrenciesListPage from './pages/master-data/currencies/index';
+import CurrencyDetailPage from './pages/master-data/currencies/detail';
+import CurrencyFormPage from './pages/master-data/currencies/form';
+// 国家/地区
+import CountriesListPage from './pages/master-data/countries/index';
+import CountryDetailPage from './pages/master-data/countries/detail';
+import CountryFormPage from './pages/master-data/countries/form';
+
+// 路由：
+<Route path="/master-data/warehouses" element={<WarehousesListPage />} />
+<Route path="/master-data/warehouses/create" element={<WarehouseFormPage />} />
+<Route path="/master-data/warehouses/:id" element={<WarehouseDetailPage />} />
+<Route path="/master-data/warehouses/:id/edit" element={<WarehouseFormPage />} />
+<Route path="/master-data/currencies" element={<CurrenciesListPage />} />
+<Route path="/master-data/currencies/create" element={<CurrencyFormPage />} />
+<Route path="/master-data/currencies/:id" element={<CurrencyDetailPage />} />
+<Route path="/master-data/currencies/:id/edit" element={<CurrencyFormPage />} />
+<Route path="/master-data/countries" element={<CountriesListPage />} />
+<Route path="/master-data/countries/create" element={<CountryFormPage />} />
+<Route path="/master-data/countries/:id" element={<CountryDetailPage />} />
+<Route path="/master-data/countries/:id/edit" element={<CountryFormPage />} />
+```
+
+---
+
+### 前端页面规范（UX-DR04/05/06/07）
+
+严格复用 Story 2-1 单位管理页面的三态结构。以仓库为例，其他模块类推：
+
+#### 列表页（index.tsx）— 仓库/币种有状态筛选，国家没有
+
+```typescript
+// 状态映射（仓库和币种用，国家不用）
+const statusTagMap = {
+  active: { status: 'success' as const, text: '启用' },
+  inactive: { status: 'default' as const, text: '禁用' },
+};
+// 操作列：编辑（Text 蓝色）+ 禁用/启用（Text 颜色按状态变化）
+// "禁用"操作：直接调用 updateWarehouse(id, { status: WarehouseStatus.INACTIVE })
+//             用 Popconfirm 二次确认（UX-DR16）
+```
+
+#### 表单页（form.tsx）— 字段说明
+
+- **仓库**：name（必填，max 100），address（可选，max 255）；编辑时加 status Select
+- **币种**：code（必填，max 10，大写提示），name（必填，max 50）；编辑时加 status Select
+- **国家**：name（必填，max 100），code（必填，max 10）；无 status 字段
+
+#### 详情页（detail.tsx）— 面包屑路径
+
+- 仓库：`基础数据 / 仓库管理 / 仓库名称`
+- 币种：`基础数据 / 币种管理 / 币种名称`
+- 国家：`基础数据 / 国家/地区 / 国家名称`
+
+---
+
+### Story 2-1 发现的 Bug（本 Story 必须避免重蹈）
+
+| 序号 | 问题 | 正确做法 |
+|------|------|---------|
+| 1 | 前端 interface 用 `list` 但实际写成了 `data` | Repository 返回 `list`，interface 字段也用 `list` |
+| 2 | 前端 id 定义为 `string` | id 必须是 `number`（BigInt → number） |
+| 3 | API 函数缺少 catch/错误处理 | 每个 API 函数末尾 `.catch(normalizeApiError)` |
+| 4 | Migration 只有 up() 没有 down() | 必须实现 `down()` 执行 `dropTable` |
+| 5 | Entity 缺少 `@Unique()` 装饰器 | code 字段加 `@Unique('idx_xx_code', ['code'])` |
+| 6 | 前端表单缺少字段长度验证 | ProFormText 加 `rules: [{ required, max }]` |
+| 7 | 前端列表页缺少错误状态处理 | useQuery 的 isError 状态需要展示 |
+| 8 | 搜索/筛选变化时未重置 page 为 1 | keyword/status 变化时 setPage(1) |
+
+---
+
+## 完成标准
+
+- [ ] 后端：三个模块各自 `/api/warehouses`、`/api/currencies`、`/api/countries` 的 GET/POST/PATCH/:id 均可调用
+- [ ] 后端：三个 Migration 文件已创建，含 up() 和 down()
+- [ ] 后端：三个模块注册到 AppModule
+- [ ] 后端：三个模块各有 Service 单元测试
+- [ ] 共享枚举：WarehouseStatus 和 CurrencyStatus 已在 packages/shared 定义并导出
+- [ ] 前端：三套页面（列表/详情/表单）使用 ProTable/ProDescriptions/ProForm
+- [ ] 前端：仓库和币种列表有状态筛选，国家列表无状态筛选
+- [ ] 前端：仓库和币种有禁用操作（Popconfirm 确认），国家无禁用操作
+- [ ] 前端：所有 API 通过 `src/api/` 层 + TanStack Query
+- [ ] 前端：12 条路由在 App.tsx 中注册
+- [ ] 前端：Sidebar.tsx 无需修改（路由条目已存在）
+- [ ] 状态使用彩色 Tag（success=启用绿，default=禁用灰）
+- [ ] 前端表单含字段验证（必填、最大长度）
+
+---
+
+## 分支命名
+
+`story/2-2-基础参考数据管理`
+
+---
+
+*Story 由 BMad Create-Story 工作流创建 — 2026-04-20*

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20 (story-2.2-in-progress)
+last_updated: 2026-04-20 (story-2.2-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -60,7 +60,7 @@ development_status:
   # ─────────────────────────────────────────────────
   epic-2: in-progress
   2-1-标准crud组件模板: done
-  2-2-基础参考数据管理: in-progress
+  2-2-基础参考数据管理: done
   2-3-公司主体信息管理: backlog
   2-4-搜索筛选与分页横切能力: backlog
   epic-2-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20 (story-2.1-done)
+last_updated: 2026-04-20 (story-2.2-in-progress)
 project: infitek_erp
 
 project_key: NOKEY
@@ -60,7 +60,7 @@ development_status:
   # ─────────────────────────────────────────────────
   epic-2: in-progress
   2-1-标准crud组件模板: done
-  2-2-基础参考数据管理: backlog
+  2-2-基础参考数据管理: in-progress
   2-3-公司主体信息管理: backlog
   2-4-搜索筛选与分页横切能力: backlog
   epic-2-retrospective: optional

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -27,7 +27,7 @@ import databaseConfig from './config/database.config';
     }),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => ({
+      useFactory: async (configService: ConfigService) => ({
         ...configService.get('database'),
       }),
     }),

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,9 @@ import { AuthModule } from './modules/auth/auth.module';
 import { UsersModule } from './modules/users/users.module';
 import { FilesModule } from './files/files.module';
 import { UnitsModule } from './modules/master-data/units/units.module';
+import { WarehousesModule } from './modules/master-data/warehouses/warehouses.module';
+import { CurrenciesModule } from './modules/master-data/currencies/currencies.module';
+import { CountriesModule } from './modules/master-data/countries/countries.module';
 import databaseConfig from './config/database.config';
 
 @Module({
@@ -32,6 +35,9 @@ import databaseConfig from './config/database.config';
     AuthModule,
     UsersModule,
     UnitsModule,
+    WarehousesModule,
+    CurrenciesModule,
+    CountriesModule,
     FilesModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { TypeOrmModule, type TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ClassSerializerInterceptor } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -27,9 +27,8 @@ import databaseConfig from './config/database.config';
     }),
     TypeOrmModule.forRootAsync({
       inject: [ConfigService],
-      useFactory: async (configService: ConfigService) => ({
-        ...configService.get('database'),
-      }),
+      useFactory: (configService: ConfigService): TypeOrmModuleOptions =>
+        configService.get<TypeOrmModuleOptions>('database')!,
     }),
     HealthModule,
     AuthModule,

--- a/apps/api/src/migrations/20260420000100-create-warehouses-table.ts
+++ b/apps/api/src/migrations/20260420000100-create-warehouses-table.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateWarehousesTable20260420000100 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'warehouses',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'name', type: 'varchar', length: '100', isNullable: false },
+          { name: 'address', type: 'varchar', length: '255', isNullable: true },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['active', 'inactive'],
+            default: "'active'",
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+            onUpdate: 'CURRENT_TIMESTAMP(6)',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'deleted_at', type: 'datetime', precision: 6, isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('warehouses', [
+      new TableIndex({
+        name: 'idx_warehouses_deleted_at',
+        columnNames: ['deleted_at'],
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('warehouses');
+  }
+}

--- a/apps/api/src/migrations/20260420000200-create-currencies-table.ts
+++ b/apps/api/src/migrations/20260420000200-create-currencies-table.ts
@@ -1,0 +1,62 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateCurrenciesTable20260420000200 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'currencies',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'code', type: 'varchar', length: '10', isNullable: false },
+          { name: 'name', type: 'varchar', length: '50', isNullable: false },
+          {
+            name: 'status',
+            type: 'enum',
+            enum: ['active', 'inactive'],
+            default: "'active'",
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+            onUpdate: 'CURRENT_TIMESTAMP(6)',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'deleted_at', type: 'datetime', precision: 6, isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('currencies', [
+      new TableIndex({
+        name: 'idx_currencies_code',
+        columnNames: ['code'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'idx_currencies_deleted_at',
+        columnNames: ['deleted_at'],
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('currencies');
+  }
+}

--- a/apps/api/src/migrations/20260420000300-create-countries-table.ts
+++ b/apps/api/src/migrations/20260420000300-create-countries-table.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateCountriesTable20260420000300 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'countries',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'name', type: 'varchar', length: '100', isNullable: false },
+          { name: 'code', type: 'varchar', length: '10', isNullable: false },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            precision: 6,
+            default: 'CURRENT_TIMESTAMP(6)',
+            onUpdate: 'CURRENT_TIMESTAMP(6)',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'deleted_at', type: 'datetime', precision: 6, isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('countries', [
+      new TableIndex({
+        name: 'idx_countries_code',
+        columnNames: ['code'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'idx_countries_deleted_at',
+        columnNames: ['deleted_at'],
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('countries');
+  }
+}

--- a/apps/api/src/modules/master-data/countries/countries.controller.ts
+++ b/apps/api/src/modules/master-data/countries/countries.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { CreateCountryDto } from './dto/create-country.dto';
+import { QueryCountryDto } from './dto/query-country.dto';
+import { UpdateCountryDto } from './dto/update-country.dto';
+import { CountriesService } from './countries.service';
+
+@Controller('countries')
+export class CountriesController {
+  constructor(private readonly countriesService: CountriesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCountryDto) {
+    return this.countriesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.countriesService.findById(id);
+  }
+
+  @Post()
+  create(
+    @Body() dto: CreateCountryDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.countriesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateCountryDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.countriesService.update(id, dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/master-data/countries/countries.module.ts
+++ b/apps/api/src/modules/master-data/countries/countries.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Country } from './entities/country.entity';
+import { CountriesController } from './countries.controller';
+import { CountriesRepository } from './countries.repository';
+import { CountriesService } from './countries.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Country])],
+  controllers: [CountriesController],
+  providers: [CountriesRepository, CountriesService],
+  exports: [CountriesService],
+})
+export class CountriesModule {}

--- a/apps/api/src/modules/master-data/countries/countries.repository.ts
+++ b/apps/api/src/modules/master-data/countries/countries.repository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { QueryCountryDto } from './dto/query-country.dto';
+import { Country } from './entities/country.entity';
+
+@Injectable()
+export class CountriesRepository {
+  constructor(
+    @InjectRepository(Country)
+    private readonly repo: Repository<Country>,
+  ) {}
+
+  findById(id: number): Promise<Country | null> {
+    return this.repo.findOne({ where: { id, deletedAt: IsNull() } });
+  }
+
+  findByCode(code: string): Promise<Country | null> {
+    return this.repo.findOne({ where: { code, deletedAt: IsNull() } });
+  }
+
+  async findAll(query: QueryCountryDto) {
+    const { keyword, page = 1, pageSize = 20 } = query;
+
+    const qb = this.repo
+      .createQueryBuilder('country')
+      .where('country.deleted_at IS NULL');
+
+    if (keyword) {
+      qb.andWhere('(country.name LIKE :kw OR country.code LIKE :kw)', {
+        kw: `%${keyword}%`,
+      });
+    }
+
+    const [list, total] = await qb
+      .orderBy('country.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      list,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  create(data: Partial<Country>): Promise<Country> {
+    return this.repo.save(data);
+  }
+
+  async update(id: number, data: Partial<Country>): Promise<Country> {
+    await this.repo.update(id, data);
+    return this.repo.findOneOrFail({ where: { id, deletedAt: IsNull() } });
+  }
+}

--- a/apps/api/src/modules/master-data/countries/countries.service.ts
+++ b/apps/api/src/modules/master-data/countries/countries.service.ts
@@ -1,0 +1,55 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { CreateCountryDto } from './dto/create-country.dto';
+import { QueryCountryDto } from './dto/query-country.dto';
+import { UpdateCountryDto } from './dto/update-country.dto';
+import { Country } from './entities/country.entity';
+import { CountriesRepository } from './countries.repository';
+
+@Injectable()
+export class CountriesService {
+  constructor(private readonly countriesRepository: CountriesRepository) {}
+
+  findAll(query: QueryCountryDto) {
+    return this.countriesRepository.findAll(query);
+  }
+
+  async findById(id: number): Promise<Country> {
+    const country = await this.countriesRepository.findById(id);
+    if (!country) {
+      throw new NotFoundException('国家/地区不存在');
+    }
+    return country;
+  }
+
+  async create(dto: CreateCountryDto, operator?: string) {
+    const duplicate = await this.countriesRepository.findByCode(dto.code);
+    if (duplicate) {
+      throw new BadRequestException('国家代码已存在');
+    }
+    return this.countriesRepository.create({
+      name: dto.name,
+      code: dto.code,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+  }
+
+  async update(id: number, dto: UpdateCountryDto, operator?: string) {
+    const country = await this.countriesRepository.findById(id);
+    if (!country) {
+      throw new NotFoundException('国家/地区不存在');
+    }
+
+    if (dto.code && dto.code !== country.code) {
+      const duplicate = await this.countriesRepository.findByCode(dto.code);
+      if (duplicate && duplicate.id !== id) {
+        throw new BadRequestException('国家代码已存在');
+      }
+    }
+
+    return this.countriesRepository.update(id, {
+      ...dto,
+      updatedBy: operator,
+    });
+  }
+}

--- a/apps/api/src/modules/master-data/countries/dto/create-country.dto.ts
+++ b/apps/api/src/modules/master-data/countries/dto/create-country.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateCountryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10)
+  code: string;
+}

--- a/apps/api/src/modules/master-data/countries/dto/query-country.dto.ts
+++ b/apps/api/src/modules/master-data/countries/dto/query-country.dto.ts
@@ -1,0 +1,3 @@
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+
+export class QueryCountryDto extends BaseQueryDto {}

--- a/apps/api/src/modules/master-data/countries/dto/update-country.dto.ts
+++ b/apps/api/src/modules/master-data/countries/dto/update-country.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateCountryDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(10)
+  code?: string;
+}

--- a/apps/api/src/modules/master-data/countries/entities/country.entity.ts
+++ b/apps/api/src/modules/master-data/countries/entities/country.entity.ts
@@ -1,0 +1,18 @@
+import { Column, DeleteDateColumn, Entity, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('countries')
+@Unique('idx_countries_code', ['code'])
+export class Country extends BaseEntity {
+  @Column({ name: 'name', type: 'varchar', length: 100 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'code', type: 'varchar', length: 10 })
+  @Expose()
+  code: string;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null;
+}

--- a/apps/api/src/modules/master-data/countries/tests/countries.service.spec.ts
+++ b/apps/api/src/modules/master-data/countries/tests/countries.service.spec.ts
@@ -1,0 +1,109 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateCountryDto } from '../dto/create-country.dto';
+import { UpdateCountryDto } from '../dto/update-country.dto';
+import { Country } from '../entities/country.entity';
+import { CountriesRepository } from '../countries.repository';
+import { CountriesService } from '../countries.service';
+
+const mockCountry: Country = {
+  id: 1,
+  name: '中国',
+  code: 'CN',
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'admin',
+  updatedBy: 'admin',
+};
+
+const mockRepo = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  findByCode: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+};
+
+describe('CountriesService', () => {
+  let service: CountriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CountriesService,
+        { provide: CountriesRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<CountriesService>(CountriesService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('应返回分页列表', async () => {
+      const result = { list: [mockCountry], total: 1, page: 1, pageSize: 20, totalPages: 1 };
+      mockRepo.findAll.mockResolvedValue(result);
+
+      const res = await service.findAll({ page: 1, pageSize: 20 });
+      expect(res).toEqual(result);
+    });
+  });
+
+  describe('findById', () => {
+    it('应返回国家', async () => {
+      mockRepo.findById.mockResolvedValue(mockCountry);
+      const res = await service.findById(1);
+      expect(res).toEqual(mockCountry);
+    });
+
+    it('国家不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('应创建国家', async () => {
+      const dto: CreateCountryDto = { name: '美国', code: 'US' };
+      mockRepo.findByCode.mockResolvedValue(null);
+      mockRepo.create.mockResolvedValue({ ...mockCountry, ...dto });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: '美国', code: 'US', createdBy: 'admin' }),
+      );
+    });
+
+    it('code 重复时应抛出 BadRequestException', async () => {
+      const dto: CreateCountryDto = { name: '中华人民共和国', code: 'CN' };
+      mockRepo.findByCode.mockResolvedValue(mockCountry);
+
+      await expect(service.create(dto, 'admin')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('update', () => {
+    it('应更新国家名称', async () => {
+      const dto: UpdateCountryDto = { name: '中国（更新）' };
+      mockRepo.findById.mockResolvedValue(mockCountry);
+      mockRepo.update.mockResolvedValue({ ...mockCountry, name: '中国（更新）' });
+
+      const res = await service.update(1, dto, 'admin');
+      expect(res.name).toBe('中国（更新）');
+    });
+
+    it('修改 code 时应检查重复', async () => {
+      const dto: UpdateCountryDto = { code: 'US' };
+      mockRepo.findById.mockResolvedValue(mockCountry);
+      mockRepo.findByCode.mockResolvedValue({ ...mockCountry, id: 2, code: 'US' });
+
+      await expect(service.update(1, dto, 'admin')).rejects.toThrow(BadRequestException);
+    });
+
+    it('国家不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.update(999, {}, 'admin')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/master-data/currencies/currencies.controller.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { CreateCurrencyDto } from './dto/create-currency.dto';
+import { QueryCurrencyDto } from './dto/query-currency.dto';
+import { UpdateCurrencyDto } from './dto/update-currency.dto';
+import { CurrenciesService } from './currencies.service';
+
+@Controller('currencies')
+export class CurrenciesController {
+  constructor(private readonly currenciesService: CurrenciesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCurrencyDto) {
+    return this.currenciesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.currenciesService.findById(id);
+  }
+
+  @Post()
+  create(
+    @Body() dto: CreateCurrencyDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.currenciesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateCurrencyDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.currenciesService.update(id, dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/master-data/currencies/currencies.module.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Currency } from './entities/currency.entity';
+import { CurrenciesController } from './currencies.controller';
+import { CurrenciesRepository } from './currencies.repository';
+import { CurrenciesService } from './currencies.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Currency])],
+  controllers: [CurrenciesController],
+  providers: [CurrenciesRepository, CurrenciesService],
+  exports: [CurrenciesService],
+})
+export class CurrenciesModule {}

--- a/apps/api/src/modules/master-data/currencies/currencies.repository.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.repository.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { QueryCurrencyDto } from './dto/query-currency.dto';
+import { Currency } from './entities/currency.entity';
+
+@Injectable()
+export class CurrenciesRepository {
+  constructor(
+    @InjectRepository(Currency)
+    private readonly repo: Repository<Currency>,
+  ) {}
+
+  findById(id: number): Promise<Currency | null> {
+    return this.repo.findOne({ where: { id, deletedAt: IsNull() } });
+  }
+
+  findByCode(code: string): Promise<Currency | null> {
+    return this.repo.findOne({ where: { code, deletedAt: IsNull() } });
+  }
+
+  async findAll(query: QueryCurrencyDto) {
+    const { keyword, page = 1, pageSize = 20, status } = query;
+
+    const qb = this.repo
+      .createQueryBuilder('currency')
+      .where('currency.deleted_at IS NULL');
+
+    if (keyword) {
+      qb.andWhere('(currency.name LIKE :kw OR currency.code LIKE :kw)', {
+        kw: `%${keyword}%`,
+      });
+    }
+
+    if (status) {
+      qb.andWhere('currency.status = :status', { status });
+    }
+
+    const [list, total] = await qb
+      .orderBy('currency.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      list,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  create(data: Partial<Currency>): Promise<Currency> {
+    return this.repo.save(data);
+  }
+
+  async update(id: number, data: Partial<Currency>): Promise<Currency> {
+    await this.repo.update(id, data);
+    return this.repo.findOneOrFail({ where: { id, deletedAt: IsNull() } });
+  }
+}

--- a/apps/api/src/modules/master-data/currencies/currencies.service.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.service.ts
@@ -1,0 +1,57 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { CurrencyStatus } from '@infitek/shared';
+import { CreateCurrencyDto } from './dto/create-currency.dto';
+import { QueryCurrencyDto } from './dto/query-currency.dto';
+import { UpdateCurrencyDto } from './dto/update-currency.dto';
+import { Currency } from './entities/currency.entity';
+import { CurrenciesRepository } from './currencies.repository';
+
+@Injectable()
+export class CurrenciesService {
+  constructor(private readonly currenciesRepository: CurrenciesRepository) {}
+
+  findAll(query: QueryCurrencyDto) {
+    return this.currenciesRepository.findAll(query);
+  }
+
+  async findById(id: number): Promise<Currency> {
+    const currency = await this.currenciesRepository.findById(id);
+    if (!currency) {
+      throw new NotFoundException('币种不存在');
+    }
+    return currency;
+  }
+
+  async create(dto: CreateCurrencyDto, operator?: string) {
+    const duplicate = await this.currenciesRepository.findByCode(dto.code);
+    if (duplicate) {
+      throw new BadRequestException('币种代码已存在');
+    }
+    return this.currenciesRepository.create({
+      code: dto.code,
+      name: dto.name,
+      status: CurrencyStatus.ACTIVE,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+  }
+
+  async update(id: number, dto: UpdateCurrencyDto, operator?: string) {
+    const currency = await this.currenciesRepository.findById(id);
+    if (!currency) {
+      throw new NotFoundException('币种不存在');
+    }
+
+    if (dto.code && dto.code !== currency.code) {
+      const duplicate = await this.currenciesRepository.findByCode(dto.code);
+      if (duplicate && duplicate.id !== id) {
+        throw new BadRequestException('币种代码已存在');
+      }
+    }
+
+    return this.currenciesRepository.update(id, {
+      ...dto,
+      updatedBy: operator,
+    });
+  }
+}

--- a/apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts
+++ b/apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateCurrencyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10)
+  code: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  name: string;
+}

--- a/apps/api/src/modules/master-data/currencies/dto/query-currency.dto.ts
+++ b/apps/api/src/modules/master-data/currencies/dto/query-currency.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { CurrencyStatus } from '@infitek/shared';
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+
+export class QueryCurrencyDto extends BaseQueryDto {
+  @IsEnum(Object.values(CurrencyStatus))
+  @IsOptional()
+  status?: CurrencyStatus;
+}

--- a/apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts
+++ b/apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { CurrencyStatus } from '@infitek/shared';
+
+export class UpdateCurrencyDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(10)
+  code?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  name?: string;
+
+  @IsEnum(Object.values(CurrencyStatus))
+  @IsOptional()
+  status?: CurrencyStatus;
+}

--- a/apps/api/src/modules/master-data/currencies/entities/currency.entity.ts
+++ b/apps/api/src/modules/master-data/currencies/entities/currency.entity.ts
@@ -1,0 +1,28 @@
+import { Column, DeleteDateColumn, Entity, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { CurrencyStatus } from '@infitek/shared';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('currencies')
+@Unique('idx_currencies_code', ['code'])
+export class Currency extends BaseEntity {
+  @Column({ name: 'code', type: 'varchar', length: 10 })
+  @Expose()
+  code: string;
+
+  @Column({ name: 'name', type: 'varchar', length: 50 })
+  @Expose()
+  name: string;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: Object.values(CurrencyStatus),
+    default: CurrencyStatus.ACTIVE,
+  })
+  @Expose()
+  status: CurrencyStatus;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null;
+}

--- a/apps/api/src/modules/master-data/currencies/tests/currencies.service.spec.ts
+++ b/apps/api/src/modules/master-data/currencies/tests/currencies.service.spec.ts
@@ -1,0 +1,124 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CurrencyStatus } from '@infitek/shared';
+import { CreateCurrencyDto } from '../dto/create-currency.dto';
+import { UpdateCurrencyDto } from '../dto/update-currency.dto';
+import { Currency } from '../entities/currency.entity';
+import { CurrenciesRepository } from '../currencies.repository';
+import { CurrenciesService } from '../currencies.service';
+
+const mockCurrency: Currency = {
+  id: 1,
+  code: 'USD',
+  name: '美元',
+  status: CurrencyStatus.ACTIVE,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'admin',
+  updatedBy: 'admin',
+};
+
+const mockRepo = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  findByCode: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+};
+
+describe('CurrenciesService', () => {
+  let service: CurrenciesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CurrenciesService,
+        { provide: CurrenciesRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<CurrenciesService>(CurrenciesService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('应返回分页列表', async () => {
+      const result = { list: [mockCurrency], total: 1, page: 1, pageSize: 20, totalPages: 1 };
+      mockRepo.findAll.mockResolvedValue(result);
+
+      const res = await service.findAll({ page: 1, pageSize: 20 });
+      expect(res).toEqual(result);
+    });
+  });
+
+  describe('findById', () => {
+    it('应返回币种', async () => {
+      mockRepo.findById.mockResolvedValue(mockCurrency);
+      const res = await service.findById(1);
+      expect(res).toEqual(mockCurrency);
+    });
+
+    it('币种不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('应创建币种，默认状态为 ACTIVE', async () => {
+      const dto: CreateCurrencyDto = { code: 'EUR', name: '欧元' };
+      mockRepo.findByCode.mockResolvedValue(null);
+      mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'EUR', name: '欧元' });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'EUR',
+          name: '欧元',
+          status: CurrencyStatus.ACTIVE,
+        }),
+      );
+    });
+
+    it('code 重复时应抛出 BadRequestException', async () => {
+      const dto: CreateCurrencyDto = { code: 'USD', name: '美元2' };
+      mockRepo.findByCode.mockResolvedValue(mockCurrency);
+
+      await expect(service.create(dto, 'admin')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('update', () => {
+    it('应更新币种名称', async () => {
+      const dto: UpdateCurrencyDto = { name: '美元（更新）' };
+      mockRepo.findById.mockResolvedValue(mockCurrency);
+      mockRepo.update.mockResolvedValue({ ...mockCurrency, name: '美元（更新）' });
+
+      const res = await service.update(1, dto, 'admin');
+      expect(res.name).toBe('美元（更新）');
+    });
+
+    it('修改 code 时应检查重复', async () => {
+      const dto: UpdateCurrencyDto = { code: 'CNY' };
+      mockRepo.findById.mockResolvedValue(mockCurrency);
+      mockRepo.findByCode.mockResolvedValue({ ...mockCurrency, id: 2, code: 'CNY' });
+
+      await expect(service.update(1, dto, 'admin')).rejects.toThrow(BadRequestException);
+    });
+
+    it('应支持禁用币种', async () => {
+      const dto: UpdateCurrencyDto = { status: CurrencyStatus.INACTIVE };
+      mockRepo.findById.mockResolvedValue(mockCurrency);
+      mockRepo.update.mockResolvedValue({ ...mockCurrency, status: CurrencyStatus.INACTIVE });
+
+      const res = await service.update(1, dto, 'admin');
+      expect(res.status).toBe(CurrencyStatus.INACTIVE);
+    });
+
+    it('币种不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.update(999, {}, 'admin')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/master-data/warehouses/dto/create-warehouse.dto.ts
+++ b/apps/api/src/modules/master-data/warehouses/dto/create-warehouse.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateWarehouseDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  address?: string;
+}

--- a/apps/api/src/modules/master-data/warehouses/dto/query-warehouse.dto.ts
+++ b/apps/api/src/modules/master-data/warehouses/dto/query-warehouse.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum, IsOptional } from 'class-validator';
+import { WarehouseStatus } from '@infitek/shared';
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+
+export class QueryWarehouseDto extends BaseQueryDto {
+  @IsEnum(Object.values(WarehouseStatus))
+  @IsOptional()
+  status?: WarehouseStatus;
+}

--- a/apps/api/src/modules/master-data/warehouses/dto/update-warehouse.dto.ts
+++ b/apps/api/src/modules/master-data/warehouses/dto/update-warehouse.dto.ts
@@ -1,0 +1,18 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { WarehouseStatus } from '@infitek/shared';
+
+export class UpdateWarehouseDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  address?: string;
+
+  @IsEnum(Object.values(WarehouseStatus))
+  @IsOptional()
+  status?: WarehouseStatus;
+}

--- a/apps/api/src/modules/master-data/warehouses/entities/warehouse.entity.ts
+++ b/apps/api/src/modules/master-data/warehouses/entities/warehouse.entity.ts
@@ -1,0 +1,27 @@
+import { Column, DeleteDateColumn, Entity } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { WarehouseStatus } from '@infitek/shared';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('warehouses')
+export class Warehouse extends BaseEntity {
+  @Column({ name: 'name', type: 'varchar', length: 100 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'address', type: 'varchar', length: 255, nullable: true })
+  @Expose()
+  address: string | null;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: Object.values(WarehouseStatus),
+    default: WarehouseStatus.ACTIVE,
+  })
+  @Expose()
+  status: WarehouseStatus;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null;
+}

--- a/apps/api/src/modules/master-data/warehouses/tests/warehouses.service.spec.ts
+++ b/apps/api/src/modules/master-data/warehouses/tests/warehouses.service.spec.ts
@@ -1,0 +1,121 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { WarehouseStatus } from '@infitek/shared';
+import { CreateWarehouseDto } from '../dto/create-warehouse.dto';
+import { UpdateWarehouseDto } from '../dto/update-warehouse.dto';
+import { Warehouse } from '../entities/warehouse.entity';
+import { WarehousesRepository } from '../warehouses.repository';
+import { WarehousesService } from '../warehouses.service';
+
+const mockWarehouse: Warehouse = {
+  id: 1,
+  name: '深圳仓',
+  address: '深圳市宝安区',
+  status: WarehouseStatus.ACTIVE,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'admin',
+  updatedBy: 'admin',
+};
+
+const mockRepo = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+};
+
+describe('WarehousesService', () => {
+  let service: WarehousesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WarehousesService,
+        { provide: WarehousesRepository, useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<WarehousesService>(WarehousesService);
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('应返回分页列表', async () => {
+      const result = { list: [mockWarehouse], total: 1, page: 1, pageSize: 20, totalPages: 1 };
+      mockRepo.findAll.mockResolvedValue(result);
+
+      const res = await service.findAll({ page: 1, pageSize: 20 });
+      expect(res).toEqual(result);
+      expect(mockRepo.findAll).toHaveBeenCalledWith({ page: 1, pageSize: 20 });
+    });
+  });
+
+  describe('findById', () => {
+    it('应返回仓库', async () => {
+      mockRepo.findById.mockResolvedValue(mockWarehouse);
+      const res = await service.findById(1);
+      expect(res).toEqual(mockWarehouse);
+    });
+
+    it('仓库不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('应创建仓库，默认状态为 ACTIVE', async () => {
+      const dto: CreateWarehouseDto = { name: '义乌仓', address: '浙江省义乌市' };
+      mockRepo.create.mockResolvedValue({ ...mockWarehouse, ...dto });
+
+      const res = await service.create(dto, 'admin');
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: '义乌仓',
+          address: '浙江省义乌市',
+          status: WarehouseStatus.ACTIVE,
+          createdBy: 'admin',
+          updatedBy: 'admin',
+        }),
+      );
+      expect(res).toBeDefined();
+    });
+
+    it('address 可选，可为 null', async () => {
+      const dto: CreateWarehouseDto = { name: '测试仓' };
+      mockRepo.create.mockResolvedValue({ ...mockWarehouse, name: '测试仓', address: null });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ address: null }),
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('应更新仓库', async () => {
+      const dto: UpdateWarehouseDto = { name: '深圳仓-更新' };
+      mockRepo.findById.mockResolvedValue(mockWarehouse);
+      mockRepo.update.mockResolvedValue({ ...mockWarehouse, name: '深圳仓-更新' });
+
+      const res = await service.update(1, dto, 'admin');
+      expect(res.name).toBe('深圳仓-更新');
+    });
+
+    it('应支持禁用仓库', async () => {
+      const dto: UpdateWarehouseDto = { status: WarehouseStatus.INACTIVE };
+      mockRepo.findById.mockResolvedValue(mockWarehouse);
+      mockRepo.update.mockResolvedValue({ ...mockWarehouse, status: WarehouseStatus.INACTIVE });
+
+      const res = await service.update(1, dto, 'admin');
+      expect(res.status).toBe(WarehouseStatus.INACTIVE);
+    });
+
+    it('仓库不存在时应抛出 NotFoundException', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+      await expect(service.update(999, {}, 'admin')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/master-data/warehouses/warehouses.controller.ts
+++ b/apps/api/src/modules/master-data/warehouses/warehouses.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { CreateWarehouseDto } from './dto/create-warehouse.dto';
+import { QueryWarehouseDto } from './dto/query-warehouse.dto';
+import { UpdateWarehouseDto } from './dto/update-warehouse.dto';
+import { WarehousesService } from './warehouses.service';
+
+@Controller('warehouses')
+export class WarehousesController {
+  constructor(private readonly warehousesService: WarehousesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryWarehouseDto) {
+    return this.warehousesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.warehousesService.findById(id);
+  }
+
+  @Post()
+  create(
+    @Body() dto: CreateWarehouseDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.warehousesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateWarehouseDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.warehousesService.update(id, dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/master-data/warehouses/warehouses.module.ts
+++ b/apps/api/src/modules/master-data/warehouses/warehouses.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Warehouse } from './entities/warehouse.entity';
+import { WarehousesController } from './warehouses.controller';
+import { WarehousesRepository } from './warehouses.repository';
+import { WarehousesService } from './warehouses.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Warehouse])],
+  controllers: [WarehousesController],
+  providers: [WarehousesRepository, WarehousesService],
+  exports: [WarehousesService],
+})
+export class WarehousesModule {}

--- a/apps/api/src/modules/master-data/warehouses/warehouses.repository.ts
+++ b/apps/api/src/modules/master-data/warehouses/warehouses.repository.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { QueryWarehouseDto } from './dto/query-warehouse.dto';
+import { Warehouse } from './entities/warehouse.entity';
+
+@Injectable()
+export class WarehousesRepository {
+  constructor(
+    @InjectRepository(Warehouse)
+    private readonly repo: Repository<Warehouse>,
+  ) {}
+
+  findById(id: number): Promise<Warehouse | null> {
+    return this.repo.findOne({ where: { id, deletedAt: IsNull() } });
+  }
+
+  async findAll(query: QueryWarehouseDto) {
+    const { keyword, page = 1, pageSize = 20, status } = query;
+
+    const qb = this.repo
+      .createQueryBuilder('warehouse')
+      .where('warehouse.deleted_at IS NULL');
+
+    if (keyword) {
+      qb.andWhere('(warehouse.name LIKE :kw OR warehouse.address LIKE :kw)', {
+        kw: `%${keyword}%`,
+      });
+    }
+
+    if (status) {
+      qb.andWhere('warehouse.status = :status', { status });
+    }
+
+    const [list, total] = await qb
+      .orderBy('warehouse.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      list,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+
+  create(data: Partial<Warehouse>): Promise<Warehouse> {
+    return this.repo.save(data);
+  }
+
+  async update(id: number, data: Partial<Warehouse>): Promise<Warehouse> {
+    await this.repo.update(id, data);
+    return this.repo.findOneOrFail({ where: { id, deletedAt: IsNull() } });
+  }
+}

--- a/apps/api/src/modules/master-data/warehouses/warehouses.service.ts
+++ b/apps/api/src/modules/master-data/warehouses/warehouses.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { WarehouseStatus } from '@infitek/shared';
+import { CreateWarehouseDto } from './dto/create-warehouse.dto';
+import { QueryWarehouseDto } from './dto/query-warehouse.dto';
+import { UpdateWarehouseDto } from './dto/update-warehouse.dto';
+import { Warehouse } from './entities/warehouse.entity';
+import { WarehousesRepository } from './warehouses.repository';
+
+@Injectable()
+export class WarehousesService {
+  constructor(private readonly warehousesRepository: WarehousesRepository) {}
+
+  findAll(query: QueryWarehouseDto) {
+    return this.warehousesRepository.findAll(query);
+  }
+
+  async findById(id: number): Promise<Warehouse> {
+    const warehouse = await this.warehousesRepository.findById(id);
+    if (!warehouse) {
+      throw new NotFoundException('仓库不存在');
+    }
+    return warehouse;
+  }
+
+  create(dto: CreateWarehouseDto, operator?: string) {
+    return this.warehousesRepository.create({
+      name: dto.name,
+      address: dto.address ?? null,
+      status: WarehouseStatus.ACTIVE,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+  }
+
+  async update(id: number, dto: UpdateWarehouseDto, operator?: string) {
+    const warehouse = await this.warehousesRepository.findById(id);
+    if (!warehouse) {
+      throw new NotFoundException('仓库不存在');
+    }
+    return this.warehousesRepository.update(id, {
+      ...dto,
+      updatedBy: operator,
+    });
+  }
+}

--- a/apps/api/src/modules/users/__tests__/users.controller.spec.ts
+++ b/apps/api/src/modules/users/__tests__/users.controller.spec.ts
@@ -60,18 +60,18 @@ describe('UsersController - Story 1-4 自动化测试', () => {
       ];
 
       mockUsersService.findAll.mockResolvedValue({
-        data: mockUsers,
+        list: mockUsers,
         total: 2,
         page: 1,
         pageSize: 20,
+        totalPages: 1,
       });
 
       const result = await controller.findAll('1', '20', undefined);
 
-      expect(result.success).toBe(true);
-      expect(result.data.data).toHaveLength(2);
-      expect(result.data.total).toBe(2);
-      expect(mockUsersService.findAll).toHaveBeenCalledWith(1, 20, undefined);
+      expect(result.list).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(mockUsersService.findAll).toHaveBeenCalledWith(1, 20, undefined, undefined);
     });
 
     it('P1: 应该支持按用户名搜索', async () => {
@@ -89,17 +89,18 @@ describe('UsersController - Story 1-4 自动化测试', () => {
       ];
 
       mockUsersService.findAll.mockResolvedValue({
-        data: mockUsers,
+        list: mockUsers,
         total: 1,
         page: 1,
         pageSize: 20,
+        totalPages: 1,
       });
 
       const result = await controller.findAll('1', '20', 'admin');
 
-      expect(result.data.data).toHaveLength(1);
-      expect(result.data.data[0].username).toBe('admin');
-      expect(mockUsersService.findAll).toHaveBeenCalledWith(1, 20, 'admin');
+      expect(result.list).toHaveLength(1);
+      expect(result.list[0].username).toBe('admin');
+      expect(mockUsersService.findAll).toHaveBeenCalledWith(1, 20, 'admin', undefined);
     });
 
     it('P1: 应该支持分页', async () => {
@@ -115,18 +116,19 @@ describe('UsersController - Story 1-4 自动化测试', () => {
       }));
 
       mockUsersService.findAll.mockResolvedValue({
-        data: mockUsers,
+        list: mockUsers,
         total: 100,
         page: 1,
         pageSize: 20,
+        totalPages: 5,
       });
 
       const result = await controller.findAll('1', '20', undefined);
 
-      expect(result.data.data).toHaveLength(20);
-      expect(result.data.total).toBe(100);
-      expect(result.data.page).toBe(1);
-      expect(result.data.pageSize).toBe(20);
+      expect(result.list).toHaveLength(20);
+      expect(result.total).toBe(100);
+      expect(result.page).toBe(1);
+      expect(result.pageSize).toBe(20);
     });
   });
 
@@ -147,20 +149,19 @@ describe('UsersController - Story 1-4 自动化测试', () => {
 
       const result = await controller.findById(1);
 
-      expect(result.success).toBe(true);
-      expect(result.data.id).toBe(1);
-      expect(result.data.username).toBe('admin');
-      expect(result.data.createdBy).toBe('system');
-      expect(result.data.updatedBy).toBe('system');
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(1);
+      expect(result!.username).toBe('admin');
+      expect(result!.createdBy).toBe('system');
+      expect(result!.updatedBy).toBe('system');
     });
 
-    it('P1: 应该返回 404 当用户不存在', async () => {
+    it('P1: 应该返回 null 当用户不存在', async () => {
       mockUsersService.findById.mockResolvedValue(null);
 
       const result = await controller.findById(999);
 
-      expect(result.success).toBe(false);
-      expect(result.code).toBe('USER_NOT_FOUND');
+      expect(result).toBeNull();
     });
   });
 
@@ -187,10 +188,9 @@ describe('UsersController - Story 1-4 自动化测试', () => {
 
       const result = await controller.create(createUserDto, { username: 'admin' });
 
-      expect(result.success).toBe(true);
-      expect(result.data.username).toBe('newuser');
-      expect(result.data.status).toBe(UserStatus.ACTIVE);
-      expect(result.data.createdBy).toBe('admin');
+      expect(result.username).toBe('newuser');
+      expect(result.status).toBe(UserStatus.ACTIVE);
+      expect(result.createdBy).toBe('admin');
     });
   });
 
@@ -217,24 +217,20 @@ describe('UsersController - Story 1-4 自动化测试', () => {
 
       const result = await controller.update(1, updateUserDto, { username: 'admin' });
 
-      expect(result.success).toBe(true);
-      expect(result.data.name).toBe('Updated Name');
-      expect(result.data.updatedBy).toBe('admin');
+      expect(result.name).toBe('Updated Name');
+      expect(result.updatedBy).toBe('admin');
     });
 
-    it('P1: 应该返回 404 当用户不存在', async () => {
+    it('P1: 应该抛出 NotFoundException 当用户不存在', async () => {
       const updateUserDto: UpdateUserDto = {
         name: 'Updated Name',
       };
 
       mockUsersService.update.mockRejectedValue(new NotFoundException('用户不存在'));
 
-      try {
-        await controller.update(999, updateUserDto, { username: 'admin' });
-        fail('Should have thrown NotFoundException');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotFoundException);
-      }
+      await expect(controller.update(999, updateUserDto, { username: 'admin' })).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
@@ -255,8 +251,7 @@ describe('UsersController - Story 1-4 自动化测试', () => {
 
       const result = await controller.deactivate(1, { username: 'admin' });
 
-      expect(result.success).toBe(true);
-      expect(result.data.status).toBe(UserStatus.INACTIVE);
+      expect(result.status).toBe(UserStatus.INACTIVE);
     });
   });
 });

--- a/apps/api/src/modules/users/__tests__/users.controller.spec.ts
+++ b/apps/api/src/modules/users/__tests__/users.controller.spec.ts
@@ -8,7 +8,6 @@ import { NotFoundException } from '@nestjs/common';
 
 describe('UsersController - Story 1-4 自动化测试', () => {
   let controller: UsersController;
-  let service: UsersService;
 
   const mockUsersService = {
     findAll: jest.fn(),
@@ -30,7 +29,6 @@ describe('UsersController - Story 1-4 自动化测试', () => {
     }).compile();
 
     controller = module.get<UsersController>(UsersController);
-    service = module.get<UsersService>(UsersService);
     jest.clearAllMocks();
   });
 

--- a/apps/api/src/modules/users/__tests__/users.service.spec.ts
+++ b/apps/api/src/modules/users/__tests__/users.service.spec.ts
@@ -129,7 +129,7 @@ describe('UsersService - Story 1-4 自动化测试', () => {
 
       const result = await service.findAll(1, 20);
 
-      expect(result.data).toHaveLength(2);
+      expect(result.list).toHaveLength(2);
       expect(result.total).toBe(2);
       expect(result.page).toBe(1);
       expect(result.pageSize).toBe(20);
@@ -153,8 +153,8 @@ describe('UsersService - Story 1-4 自动化测试', () => {
 
       const result = await service.findAll(1, 20, 'admin');
 
-      expect(result.data).toHaveLength(1);
-      expect(result.data[0].username).toBe('admin');
+      expect(result.list).toHaveLength(1);
+      expect(result.list[0].username).toBe('admin');
     });
 
     it('P1: 应该支持按状态筛选', async () => {
@@ -175,7 +175,7 @@ describe('UsersService - Story 1-4 自动化测试', () => {
 
       const result = await service.findAll(1, 20);
 
-      expect(result.data[0].status).toBe(UserStatus.ACTIVE);
+      expect(result.list[0].status).toBe(UserStatus.ACTIVE);
     });
 
     it('P1: 应该支持分页', async () => {
@@ -194,7 +194,7 @@ describe('UsersService - Story 1-4 自动化测试', () => {
 
       const result = await service.findAll(1, 20);
 
-      expect(result.data).toHaveLength(20);
+      expect(result.list).toHaveLength(20);
       expect(result.total).toBe(100);
     });
   });

--- a/apps/api/src/modules/users/__tests__/users.service.spec.ts
+++ b/apps/api/src/modules/users/__tests__/users.service.spec.ts
@@ -9,7 +9,6 @@ jest.mock('bcrypt');
 
 describe('UsersService - Story 1-4 自动化测试', () => {
   let service: UsersService;
-  let repository: UsersRepository;
 
   const mockRepository = {
     findByUsername: jest.fn(),
@@ -32,7 +31,6 @@ describe('UsersService - Story 1-4 自动化测试', () => {
     }).compile();
 
     service = module.get<UsersService>(UsersService);
-    repository = module.get<UsersRepository>(UsersRepository);
     jest.clearAllMocks();
   });
 

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -20,7 +20,10 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect('Hello World!');
+      .expect((res: { body: { success: boolean; data: string } }) => {
+        expect(res.body.success).toBe(true);
+        expect(res.body.data).toBe('Hello World!');
+      });
   });
 
   afterEach(async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,8 +34,9 @@ queryClient.setDefaultOptions({
     staleTime: 30_000,
   },
   mutations: {
-    onError: (error: any) => {
-      const msg = error?.response?.data?.message || '操作失败，请重试';
+    onError: (error: unknown) => {
+      const err = error as { response?: { data?: { message?: string } } };
+      const msg = err?.response?.data?.message ?? '操作失败，请重试';
       message.error(msg);
     },
   },

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,15 @@ import UserForm from './pages/settings/users/form';
 import UnitsListPage from './pages/master-data/units/index';
 import UnitDetailPage from './pages/master-data/units/detail';
 import UnitFormPage from './pages/master-data/units/form';
+import WarehousesListPage from './pages/master-data/warehouses/index';
+import WarehouseDetailPage from './pages/master-data/warehouses/detail';
+import WarehouseFormPage from './pages/master-data/warehouses/form';
+import CurrenciesListPage from './pages/master-data/currencies/index';
+import CurrencyDetailPage from './pages/master-data/currencies/detail';
+import CurrencyFormPage from './pages/master-data/currencies/form';
+import CountriesListPage from './pages/master-data/countries/index';
+import CountryDetailPage from './pages/master-data/countries/detail';
+import CountryFormPage from './pages/master-data/countries/form';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -87,6 +96,18 @@ function App() {
                 <Route path="/master-data/units/create" element={<UnitFormPage />} />
                 <Route path="/master-data/units/:id" element={<UnitDetailPage />} />
                 <Route path="/master-data/units/:id/edit" element={<UnitFormPage />} />
+                <Route path="/master-data/warehouses" element={<WarehousesListPage />} />
+                <Route path="/master-data/warehouses/create" element={<WarehouseFormPage />} />
+                <Route path="/master-data/warehouses/:id" element={<WarehouseDetailPage />} />
+                <Route path="/master-data/warehouses/:id/edit" element={<WarehouseFormPage />} />
+                <Route path="/master-data/currencies" element={<CurrenciesListPage />} />
+                <Route path="/master-data/currencies/create" element={<CurrencyFormPage />} />
+                <Route path="/master-data/currencies/:id" element={<CurrencyDetailPage />} />
+                <Route path="/master-data/currencies/:id/edit" element={<CurrencyFormPage />} />
+                <Route path="/master-data/countries" element={<CountriesListPage />} />
+                <Route path="/master-data/countries/create" element={<CountryFormPage />} />
+                <Route path="/master-data/countries/:id" element={<CountryDetailPage />} />
+                <Route path="/master-data/countries/:id/edit" element={<CountryFormPage />} />
               </Route>
 
               {/* 兜底重定向 */}

--- a/apps/web/src/api/countries.api.ts
+++ b/apps/web/src/api/countries.api.ts
@@ -1,0 +1,52 @@
+import request from './request';
+
+export interface Country {
+  id: number;
+  code: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface CountriesListParams {
+  keyword?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CountriesListData {
+  list: Country[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateCountryPayload {
+  code: string;
+  name: string;
+}
+
+export interface UpdateCountryPayload {
+  code?: string;
+  name?: string;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) throw error;
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getCountries = (params: CountriesListParams): Promise<CountriesListData> =>
+  request.get<any, CountriesListData>('/countries', { params }).catch(normalizeApiError);
+
+export const getCountryById = (id: number): Promise<Country> =>
+  request.get<any, Country>(`/countries/${id}`).catch(normalizeApiError);
+
+export const createCountry = (payload: CreateCountryPayload): Promise<Country> =>
+  request.post<any, Country>('/countries', payload).catch(normalizeApiError);
+
+export const updateCountry = (id: number, payload: UpdateCountryPayload): Promise<Country> =>
+  request.patch<any, Country>(`/countries/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/api/countries.api.ts
+++ b/apps/web/src/api/countries.api.ts
@@ -40,13 +40,13 @@ function normalizeApiError(error: unknown): never {
 }
 
 export const getCountries = (params: CountriesListParams): Promise<CountriesListData> =>
-  request.get<any, CountriesListData>('/countries', { params }).catch(normalizeApiError);
+  request.get<unknown, CountriesListData>('/countries', { params }).catch(normalizeApiError);
 
 export const getCountryById = (id: number): Promise<Country> =>
-  request.get<any, Country>(`/countries/${id}`).catch(normalizeApiError);
+  request.get<unknown, Country>(`/countries/${id}`).catch(normalizeApiError);
 
 export const createCountry = (payload: CreateCountryPayload): Promise<Country> =>
-  request.post<any, Country>('/countries', payload).catch(normalizeApiError);
+  request.post<unknown, Country>('/countries', payload).catch(normalizeApiError);
 
 export const updateCountry = (id: number, payload: UpdateCountryPayload): Promise<Country> =>
-  request.patch<any, Country>(`/countries/${id}`, payload).catch(normalizeApiError);
+  request.patch<unknown, Country>(`/countries/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/api/currencies.api.ts
+++ b/apps/web/src/api/currencies.api.ts
@@ -44,13 +44,13 @@ function normalizeApiError(error: unknown): never {
 }
 
 export const getCurrencies = (params: CurrenciesListParams): Promise<CurrenciesListData> =>
-  request.get<any, CurrenciesListData>('/currencies', { params }).catch(normalizeApiError);
+  request.get<unknown, CurrenciesListData>('/currencies', { params }).catch(normalizeApiError);
 
 export const getCurrencyById = (id: number): Promise<Currency> =>
-  request.get<any, Currency>(`/currencies/${id}`).catch(normalizeApiError);
+  request.get<unknown, Currency>(`/currencies/${id}`).catch(normalizeApiError);
 
 export const createCurrency = (payload: CreateCurrencyPayload): Promise<Currency> =>
-  request.post<any, Currency>('/currencies', payload).catch(normalizeApiError);
+  request.post<unknown, Currency>('/currencies', payload).catch(normalizeApiError);
 
 export const updateCurrency = (id: number, payload: UpdateCurrencyPayload): Promise<Currency> =>
-  request.patch<any, Currency>(`/currencies/${id}`, payload).catch(normalizeApiError);
+  request.patch<unknown, Currency>(`/currencies/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/api/currencies.api.ts
+++ b/apps/web/src/api/currencies.api.ts
@@ -1,0 +1,56 @@
+import type { CurrencyStatus } from '@infitek/shared';
+import request from './request';
+
+export interface Currency {
+  id: number;
+  code: string;
+  name: string;
+  status: CurrencyStatus;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface CurrenciesListParams {
+  keyword?: string;
+  status?: CurrencyStatus;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CurrenciesListData {
+  list: Currency[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateCurrencyPayload {
+  code: string;
+  name: string;
+}
+
+export interface UpdateCurrencyPayload {
+  code?: string;
+  name?: string;
+  status?: CurrencyStatus;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) throw error;
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getCurrencies = (params: CurrenciesListParams): Promise<CurrenciesListData> =>
+  request.get<any, CurrenciesListData>('/currencies', { params }).catch(normalizeApiError);
+
+export const getCurrencyById = (id: number): Promise<Currency> =>
+  request.get<any, Currency>(`/currencies/${id}`).catch(normalizeApiError);
+
+export const createCurrency = (payload: CreateCurrencyPayload): Promise<Currency> =>
+  request.post<any, Currency>('/currencies', payload).catch(normalizeApiError);
+
+export const updateCurrency = (id: number, payload: UpdateCurrencyPayload): Promise<Currency> =>
+  request.patch<any, Currency>(`/currencies/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/api/warehouses.api.ts
+++ b/apps/web/src/api/warehouses.api.ts
@@ -1,0 +1,56 @@
+import type { WarehouseStatus } from '@infitek/shared';
+import request from './request';
+
+export interface Warehouse {
+  id: number;
+  name: string;
+  address: string | null;
+  status: WarehouseStatus;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface WarehousesListParams {
+  keyword?: string;
+  status?: WarehouseStatus;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface WarehousesListData {
+  list: Warehouse[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateWarehousePayload {
+  name: string;
+  address?: string;
+}
+
+export interface UpdateWarehousePayload {
+  name?: string;
+  address?: string;
+  status?: WarehouseStatus;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) throw error;
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getWarehouses = (params: WarehousesListParams): Promise<WarehousesListData> =>
+  request.get<any, WarehousesListData>('/warehouses', { params }).catch(normalizeApiError);
+
+export const getWarehouseById = (id: number): Promise<Warehouse> =>
+  request.get<any, Warehouse>(`/warehouses/${id}`).catch(normalizeApiError);
+
+export const createWarehouse = (payload: CreateWarehousePayload): Promise<Warehouse> =>
+  request.post<any, Warehouse>('/warehouses', payload).catch(normalizeApiError);
+
+export const updateWarehouse = (id: number, payload: UpdateWarehousePayload): Promise<Warehouse> =>
+  request.patch<any, Warehouse>(`/warehouses/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/api/warehouses.api.ts
+++ b/apps/web/src/api/warehouses.api.ts
@@ -44,13 +44,13 @@ function normalizeApiError(error: unknown): never {
 }
 
 export const getWarehouses = (params: WarehousesListParams): Promise<WarehousesListData> =>
-  request.get<any, WarehousesListData>('/warehouses', { params }).catch(normalizeApiError);
+  request.get<unknown, WarehousesListData>('/warehouses', { params }).catch(normalizeApiError);
 
 export const getWarehouseById = (id: number): Promise<Warehouse> =>
-  request.get<any, Warehouse>(`/warehouses/${id}`).catch(normalizeApiError);
+  request.get<unknown, Warehouse>(`/warehouses/${id}`).catch(normalizeApiError);
 
 export const createWarehouse = (payload: CreateWarehousePayload): Promise<Warehouse> =>
-  request.post<any, Warehouse>('/warehouses', payload).catch(normalizeApiError);
+  request.post<unknown, Warehouse>('/warehouses', payload).catch(normalizeApiError);
 
 export const updateWarehouse = (id: number, payload: UpdateWarehousePayload): Promise<Warehouse> =>
-  request.patch<any, Warehouse>(`/warehouses/${id}`, payload).catch(normalizeApiError);
+  request.patch<unknown, Warehouse>(`/warehouses/${id}`, payload).catch(normalizeApiError);

--- a/apps/web/src/pages/master-data/countries/detail.tsx
+++ b/apps/web/src/pages/master-data/countries/detail.tsx
@@ -1,0 +1,124 @@
+import { Breadcrumb, Button, Card, Flex, Result, Space, Typography } from 'antd';
+import { ProDescriptions } from '@ant-design/pro-components';
+import type { ProDescriptionsItemProps } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getCountryById, type Country } from '../../../api/countries.api';
+
+export default function CountryDetailPage() {
+  const navigate = useNavigate();
+  const { id = '' } = useParams();
+  const countryId = Number(id);
+
+  const query = useQuery({
+    queryKey: ['country-detail', countryId],
+    queryFn: () => getCountryById(countryId),
+    enabled: Number.isInteger(countryId) && countryId > 0,
+  });
+
+  if (!Number.isInteger(countryId) || countryId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="国家/地区不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/countries')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="国家/地区详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/countries')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const columns: ProDescriptionsItemProps<Country>[] = [
+    { title: '国家/地区代码', dataIndex: 'code', span: 1 },
+    { title: '国家/地区名称', dataIndex: 'name', span: 1 },
+    {
+      title: '创建时间',
+      dataIndex: 'createdAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '创建人',
+      dataIndex: 'createdBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+    {
+      title: '更新人',
+      dataIndex: 'updatedBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+  ];
+
+  if (!query.data && !query.isLoading) {
+    return (
+      <Space direction="vertical">
+        <Typography.Text>国家/地区不存在</Typography.Text>
+        <Button onClick={() => navigate('/master-data/countries')}>返回列表</Button>
+      </Space>
+    );
+  }
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Flex justify="space-between" align="center">
+        <Breadcrumb
+          items={[
+            {
+              title: (
+                <Button type="link" onClick={() => navigate('/master-data/countries')}>
+                  基础数据
+                </Button>
+              ),
+            },
+            { title: '国家/地区管理' },
+            { title: '详情' },
+          ]}
+        />
+        <Button onClick={() => navigate(`/master-data/countries/${id}/edit`)}>编辑</Button>
+      </Flex>
+
+      <Card>
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          {query.data?.code || '-'} {query.data?.name ? `（${query.data.name}）` : ''}
+        </Typography.Title>
+      </Card>
+
+      <ProDescriptions<Country>
+        title="基础信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={columns}
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/pages/master-data/countries/form.tsx
+++ b/apps/web/src/pages/master-data/countries/form.tsx
@@ -1,0 +1,144 @@
+import { Button, Card, Result, Skeleton, Space } from 'antd';
+import { ProForm, ProFormText } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  createCountry,
+  getCountryById,
+  updateCountry,
+  type CreateCountryPayload,
+  type UpdateCountryPayload,
+} from '../../../api/countries.api';
+
+export default function CountryFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const countryId = id ? Number(id) : undefined;
+  const isEdit = Boolean(id);
+
+  const detailQuery = useQuery({
+    queryKey: ['country-detail', countryId],
+    queryFn: () => getCountryById(countryId as number),
+    enabled: Boolean(isEdit && countryId && Number.isInteger(countryId) && countryId > 0),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateCountryPayload) => createCountry(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['countries'] });
+      navigate('/master-data/countries');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateCountryPayload) => updateCountry(countryId as number, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['countries'] });
+      queryClient.invalidateQueries({ queryKey: ['country-detail', countryId] });
+      navigate('/master-data/countries');
+    },
+  });
+
+  if (isEdit && (!countryId || !Number.isInteger(countryId) || countryId <= 0)) {
+    return (
+      <Result
+        status="404"
+        title="国家/地区不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/countries')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isEdit && detailQuery.isLoading) {
+    return <Skeleton active />;
+  }
+
+  if (isEdit && detailQuery.isError && !detailQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="国家/地区详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => detailQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/countries')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <Card title={isEdit ? '编辑国家/地区' : '新建国家/地区'}>
+      <ProForm<{
+        code: string;
+        name: string;
+      }>
+        grid
+        rowProps={{ gutter: [16, 0] }}
+        colProps={{ span: 12 }}
+        loading={detailQuery.isLoading}
+        submitter={{
+          render: (_, dom) => (
+            <Space>
+              <Button onClick={() => navigate('/master-data/countries')}>取消</Button>
+              {dom[1]}
+            </Space>
+          ),
+          searchConfig: {
+            submitText: isEdit ? '保存' : '创建',
+          },
+        }}
+        initialValues={
+          detailQuery.data
+            ? {
+                code: detailQuery.data.code,
+                name: detailQuery.data.name,
+              }
+            : {}
+        }
+        onFinish={async (values) => {
+          if (isEdit) {
+            await updateMutation.mutateAsync({
+              code: values.code,
+              name: values.name,
+            });
+          } else {
+            await createMutation.mutateAsync({
+              code: values.code,
+              name: values.name,
+            });
+          }
+          return true;
+        }}
+      >
+        <ProFormText
+          name="code"
+          label="国家/地区代码"
+          placeholder="如：CN、US、DE"
+          rules={[
+            { required: true, message: '请输入国家/地区代码' },
+            { max: 10, message: '国家/地区代码最多 10 个字符' },
+          ]}
+        />
+        <ProFormText
+          name="name"
+          label="国家/地区名称"
+          placeholder="如：中国、美国、德国"
+          rules={[
+            { required: true, message: '请输入国家/地区名称' },
+            { max: 100, message: '国家/地区名称最多 100 个字符' },
+          ]}
+        />
+      </ProForm>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/master-data/countries/index.tsx
+++ b/apps/web/src/pages/master-data/countries/index.tsx
@@ -40,10 +40,6 @@ export default function CountriesListPage() {
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword);
 
-  useEffect(() => {
-    setPage(1);
-  }, [keyword]);
-
   const query = useQuery({
     queryKey: ['countries', keyword, page, pageSize],
     placeholderData: (previousData) => previousData,
@@ -54,21 +50,6 @@ export default function CountriesListPage() {
         pageSize,
       }),
   });
-
-  if (query.isError && !query.data) {
-    return (
-      <Result
-        status="error"
-        title="加载国家/地区列表失败"
-        subTitle="请检查网络或稍后重试"
-        extra={
-          <Button type="primary" onClick={() => query.refetch()}>
-            重试
-          </Button>
-        }
-      />
-    );
-  }
 
   const columns: ProColumns<Country>[] = useMemo(
     () => [
@@ -121,6 +102,21 @@ export default function CountriesListPage() {
     ],
     [navigate, token.colorLink],
   );
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载国家/地区列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
 
   const emptyText = hasFilters ? (
     <Empty description="未找到匹配记录">

--- a/apps/web/src/pages/master-data/countries/index.tsx
+++ b/apps/web/src/pages/master-data/countries/index.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Empty,
+  Flex,
+  Input,
+  Result,
+  Skeleton,
+  Space,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { getCountries, type Country } from '../../../api/countries.api';
+
+function useDebouncedValue(input: string, delay = 300) {
+  const [value, setValue] = useState(input);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setValue(input), delay);
+    return () => window.clearTimeout(timer);
+  }, [input, delay]);
+
+  return value;
+}
+
+export default function CountriesListPage() {
+  const navigate = useNavigate();
+  const { token } = theme.useToken();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters = Boolean(keyword);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword]);
+
+  const query = useQuery({
+    queryKey: ['countries', keyword, page, pageSize],
+    placeholderData: (previousData) => previousData,
+    queryFn: () =>
+      getCountries({
+        keyword: keyword || undefined,
+        page,
+        pageSize,
+      }),
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载国家/地区列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const columns: ProColumns<Country>[] = useMemo(
+    () => [
+      {
+        title: '国家/地区代码',
+        dataIndex: 'code',
+        width: 160,
+        render: (_, record) => (
+          <Link to={`/master-data/countries/${record.id}`} style={{ color: token.colorLink }}>
+            {record.code}
+          </Link>
+        ),
+      },
+      {
+        title: '国家/地区名称',
+        dataIndex: 'name',
+        width: 200,
+        ellipsis: true,
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        width: 140,
+        render: (_, record) => dayjs(record.createdAt).format('YYYY-MM-DD'),
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 140,
+        fixed: 'right',
+        render: (_, record) => (
+          <Space size={12}>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/countries/${record.id}`)}
+            >
+              查看
+            </Button>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/countries/${record.id}/edit`)}
+            >
+              编辑
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [navigate, token.colorLink],
+  );
+
+  const emptyText = hasFilters ? (
+    <Empty description="未找到匹配记录">
+      <Button
+        type="link"
+        onClick={() => {
+          setKeywordInput('');
+          setPage(1);
+        }}
+      >
+        清除筛选条件
+      </Button>
+    </Empty>
+  ) : (
+    <Empty description="暂无数据">
+      <Button type="primary" onClick={() => navigate('/master-data/countries/create')}>
+        新建国家/地区
+      </Button>
+    </Empty>
+  );
+
+  const tags = [
+    keyword
+      ? {
+          key: 'keyword',
+          label: `关键词: ${keyword}`,
+          onClose: () => {
+            setKeywordInput('');
+            setPage(1);
+          },
+        }
+      : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          国家/地区管理
+        </Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/countries/create')}>
+          新建国家/地区
+        </Button>
+      </Flex>
+
+      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
+        <Flex gap={token.marginSM} wrap>
+          <Input
+            placeholder="快捷搜索国家/地区代码/名称"
+            style={{ width: 320 }}
+            value={keywordInput}
+            onChange={(e) => {
+              setKeywordInput(e.target.value);
+              setPage(1);
+            }}
+            allowClear
+          />
+        </Flex>
+
+        {tags.length > 0 ? (
+          <Space wrap>
+            {tags.map((item) => (
+              <Tag closable key={item.key} onClose={item.onClose}>
+                {item.label}
+              </Tag>
+            ))}
+            <Button
+              type="link"
+              onClick={() => {
+                setKeywordInput('');
+                setPage(1);
+              }}
+            >
+              清除全部
+            </Button>
+          </Space>
+        ) : null}
+      </Space>
+
+      <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
+        <ProTable<Country>
+          search={false}
+          options={false}
+          toolBarRender={false}
+          rowKey="id"
+          loading={query.isFetching}
+          columns={columns}
+          dataSource={query.data?.list ?? []}
+          scroll={{ x: 700, y: 540 }}
+          rowClassName={() => 'country-row-height'}
+          locale={{ emptyText }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: query.data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
+            showTotal: (total) => `共 ${total} 条记录`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+              } else {
+                setPage(nextPage);
+              }
+              setPageSize(nextPageSize);
+            },
+          }}
+        />
+      </Skeleton>
+
+      <style>{`
+        .country-row-height .ant-table-cell {
+          height: 48px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/src/pages/master-data/currencies/detail.tsx
+++ b/apps/web/src/pages/master-data/currencies/detail.tsx
@@ -1,0 +1,140 @@
+import { Breadcrumb, Button, Card, Flex, Result, Space, Tag, Typography } from 'antd';
+import { ProDescriptions } from '@ant-design/pro-components';
+import type { ProDescriptionsItemProps } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { CurrencyStatus } from '@infitek/shared';
+import { getCurrencyById, type Currency } from '../../../api/currencies.api';
+
+const statusText: Record<CurrencyStatus, string> = {
+  active: '启用',
+  inactive: '禁用',
+};
+
+const statusColor: Record<CurrencyStatus, string> = {
+  active: 'success',
+  inactive: 'default',
+};
+
+export default function CurrencyDetailPage() {
+  const navigate = useNavigate();
+  const { id = '' } = useParams();
+  const currencyId = Number(id);
+
+  const query = useQuery({
+    queryKey: ['currency-detail', currencyId],
+    queryFn: () => getCurrencyById(currencyId),
+    enabled: Number.isInteger(currencyId) && currencyId > 0,
+  });
+
+  if (!Number.isInteger(currencyId) || currencyId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="币种不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/currencies')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="币种详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/currencies')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const columns: ProDescriptionsItemProps<Currency>[] = [
+    { title: '币种代码', dataIndex: 'code', span: 1 },
+    { title: '币种名称', dataIndex: 'name', span: 1 },
+    {
+      title: '创建时间',
+      dataIndex: 'createdAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '创建人',
+      dataIndex: 'createdBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+    {
+      title: '更新人',
+      dataIndex: 'updatedBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+  ];
+
+  if (!query.data && !query.isLoading) {
+    return (
+      <Space direction="vertical">
+        <Typography.Text>币种不存在</Typography.Text>
+        <Button onClick={() => navigate('/master-data/currencies')}>返回列表</Button>
+      </Space>
+    );
+  }
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Flex justify="space-between" align="center">
+        <Breadcrumb
+          items={[
+            {
+              title: (
+                <Button type="link" onClick={() => navigate('/master-data/currencies')}>
+                  基础数据
+                </Button>
+              ),
+            },
+            { title: '币种管理' },
+            { title: '详情' },
+          ]}
+        />
+        <Button onClick={() => navigate(`/master-data/currencies/${id}/edit`)}>编辑</Button>
+      </Flex>
+
+      <Card>
+        <Flex justify="space-between" align="center">
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            {query.data?.code || '-'} {query.data?.name ? `（${query.data.name}）` : ''}
+          </Typography.Title>
+          {query.data ? (
+            <Tag color={statusColor[query.data.status]}>{statusText[query.data.status]}</Tag>
+          ) : null}
+        </Flex>
+      </Card>
+
+      <ProDescriptions<Currency>
+        title="基础信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={columns}
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/pages/master-data/currencies/form.tsx
+++ b/apps/web/src/pages/master-data/currencies/form.tsx
@@ -1,0 +1,161 @@
+import { Button, Card, Result, Skeleton, Space } from 'antd';
+import { ProForm, ProFormSelect, ProFormText } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { CurrencyStatus } from '@infitek/shared';
+import {
+  createCurrency,
+  getCurrencyById,
+  updateCurrency,
+  type CreateCurrencyPayload,
+  type UpdateCurrencyPayload,
+} from '../../../api/currencies.api';
+
+const statusOptions: Array<{ label: string; value: CurrencyStatus }> = [
+  { label: '启用', value: 'active' as CurrencyStatus },
+  { label: '禁用', value: 'inactive' as CurrencyStatus },
+];
+
+export default function CurrencyFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const currencyId = id ? Number(id) : undefined;
+  const isEdit = Boolean(id);
+
+  const detailQuery = useQuery({
+    queryKey: ['currency-detail', currencyId],
+    queryFn: () => getCurrencyById(currencyId as number),
+    enabled: Boolean(isEdit && currencyId && Number.isInteger(currencyId) && currencyId > 0),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateCurrencyPayload) => createCurrency(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['currencies'] });
+      navigate('/master-data/currencies');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateCurrencyPayload) => updateCurrency(currencyId as number, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['currencies'] });
+      queryClient.invalidateQueries({ queryKey: ['currency-detail', currencyId] });
+      navigate('/master-data/currencies');
+    },
+  });
+
+  if (isEdit && (!currencyId || !Number.isInteger(currencyId) || currencyId <= 0)) {
+    return (
+      <Result
+        status="404"
+        title="币种不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/currencies')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isEdit && detailQuery.isLoading) {
+    return <Skeleton active />;
+  }
+
+  if (isEdit && detailQuery.isError && !detailQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="币种详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => detailQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/currencies')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <Card title={isEdit ? '编辑币种' : '新建币种'}>
+      <ProForm<{
+        code: string;
+        name: string;
+        status?: CurrencyStatus;
+      }>
+        grid
+        rowProps={{ gutter: [16, 0] }}
+        colProps={{ span: 12 }}
+        loading={detailQuery.isLoading}
+        submitter={{
+          render: (_, dom) => (
+            <Space>
+              <Button onClick={() => navigate('/master-data/currencies')}>取消</Button>
+              {dom[1]}
+            </Space>
+          ),
+          searchConfig: {
+            submitText: isEdit ? '保存' : '创建',
+          },
+        }}
+        initialValues={
+          detailQuery.data
+            ? {
+                code: detailQuery.data.code,
+                name: detailQuery.data.name,
+                status: detailQuery.data.status,
+              }
+            : {}
+        }
+        onFinish={async (values) => {
+          if (isEdit) {
+            await updateMutation.mutateAsync({
+              code: values.code,
+              name: values.name,
+              status: values.status,
+            });
+          } else {
+            await createMutation.mutateAsync({
+              code: values.code,
+              name: values.name,
+            });
+          }
+          return true;
+        }}
+      >
+        <ProFormText
+          name="code"
+          label="币种代码"
+          placeholder="如：USD、EUR、CNY"
+          rules={[
+            { required: true, message: '请输入币种代码' },
+            { max: 10, message: '币种代码最多 10 个字符' },
+          ]}
+        />
+        <ProFormText
+          name="name"
+          label="币种名称"
+          placeholder="如：美元、欧元、人民币"
+          rules={[
+            { required: true, message: '请输入币种名称' },
+            { max: 50, message: '币种名称最多 50 个字符' },
+          ]}
+        />
+        {isEdit ? (
+          <ProFormSelect
+            name="status"
+            label="状态"
+            options={statusOptions}
+            rules={[{ required: true, message: '请选择状态' }]}
+          />
+        ) : null}
+      </ProForm>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/master-data/currencies/index.tsx
+++ b/apps/web/src/pages/master-data/currencies/index.tsx
@@ -61,10 +61,6 @@ export default function CurrenciesListPage() {
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword || status);
 
-  useEffect(() => {
-    setPage(1);
-  }, [keyword, status]);
-
   const query = useQuery({
     queryKey: ['currencies', keyword, status, page, pageSize],
     placeholderData: (previousData) => previousData,
@@ -85,21 +81,6 @@ export default function CurrenciesListPage() {
       message.success('操作成功');
     },
   });
-
-  if (query.isError && !query.data) {
-    return (
-      <Result
-        status="error"
-        title="加载币种列表失败"
-        subTitle="请检查网络或稍后重试"
-        extra={
-          <Button type="primary" onClick={() => query.refetch()}>
-            重试
-          </Button>
-        }
-      />
-    );
-  }
 
   const columns: ProColumns<Currency>[] = useMemo(
     () => [
@@ -178,6 +159,21 @@ export default function CurrenciesListPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [navigate, token.colorLink],
   );
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载币种列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
 
   const emptyText = hasFilters ? (
     <Empty description="未找到匹配记录">

--- a/apps/web/src/pages/master-data/currencies/index.tsx
+++ b/apps/web/src/pages/master-data/currencies/index.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Badge,
+  Button,
+  Empty,
+  Flex,
+  Input,
+  Popconfirm,
+  Result,
+  Select,
+  Skeleton,
+  Space,
+  Tag,
+  Typography,
+  message,
+  theme,
+} from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import type { CurrencyStatus } from '@infitek/shared';
+import { getCurrencies, updateCurrency, type Currency } from '../../../api/currencies.api';
+
+const CURRENCY_STATUS_ACTIVE = 'active' as CurrencyStatus;
+const CURRENCY_STATUS_INACTIVE = 'inactive' as CurrencyStatus;
+
+const statusOptions: Array<{ label: string; value: CurrencyStatus }> = [
+  { label: '启用', value: CURRENCY_STATUS_ACTIVE },
+  { label: '禁用', value: CURRENCY_STATUS_INACTIVE },
+];
+
+const statusTagMap = {
+  active: { status: 'success', text: '启用' },
+  inactive: { status: 'default', text: '禁用' },
+} satisfies Record<CurrencyStatus, { status: 'success' | 'default'; text: string }>;
+
+function useDebouncedValue(input: string, delay = 300) {
+  const [value, setValue] = useState(input);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setValue(input), delay);
+    return () => window.clearTimeout(timer);
+  }, [input, delay]);
+
+  return value;
+}
+
+export default function CurrenciesListPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { token } = theme.useToken();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [status, setStatus] = useState<CurrencyStatus | undefined>();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters = Boolean(keyword || status);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword, status]);
+
+  const query = useQuery({
+    queryKey: ['currencies', keyword, status, page, pageSize],
+    placeholderData: (previousData) => previousData,
+    queryFn: () =>
+      getCurrencies({
+        keyword: keyword || undefined,
+        status,
+        page,
+        pageSize,
+      }),
+  });
+
+  const toggleStatusMutation = useMutation({
+    mutationFn: ({ id, newStatus }: { id: number; newStatus: CurrencyStatus }) =>
+      updateCurrency(id, { status: newStatus }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['currencies'] });
+      message.success('操作成功');
+    },
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载币种列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const columns: ProColumns<Currency>[] = useMemo(
+    () => [
+      {
+        title: '币种代码',
+        dataIndex: 'code',
+        width: 160,
+        render: (_, record) => (
+          <Link to={`/master-data/currencies/${record.id}`} style={{ color: token.colorLink }}>
+            {record.code}
+          </Link>
+        ),
+      },
+      {
+        title: '币种名称',
+        dataIndex: 'name',
+        width: 200,
+        ellipsis: true,
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 120,
+        render: (_, record) => {
+          const meta = statusTagMap[record.status];
+          return <Badge status={meta.status} text={meta.text} />;
+        },
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        width: 140,
+        render: (_, record) => dayjs(record.createdAt).format('YYYY-MM-DD'),
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 180,
+        fixed: 'right',
+        render: (_, record) => (
+          <Space size={12}>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/currencies/${record.id}`)}
+            >
+              查看
+            </Button>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/currencies/${record.id}/edit`)}
+            >
+              编辑
+            </Button>
+            <Popconfirm
+              title={record.status === CURRENCY_STATUS_ACTIVE ? '确认禁用该币种？' : '确认启用该币种？'}
+              onConfirm={() =>
+                toggleStatusMutation.mutate({
+                  id: record.id,
+                  newStatus:
+                    record.status === CURRENCY_STATUS_ACTIVE
+                      ? CURRENCY_STATUS_INACTIVE
+                      : CURRENCY_STATUS_ACTIVE,
+                })
+              }
+            >
+              <Button type="link" style={{ padding: 0 }}>
+                {record.status === CURRENCY_STATUS_ACTIVE ? '禁用' : '启用'}
+              </Button>
+            </Popconfirm>
+          </Space>
+        ),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [navigate, token.colorLink],
+  );
+
+  const emptyText = hasFilters ? (
+    <Empty description="未找到匹配记录">
+      <Button
+        type="link"
+        onClick={() => {
+          setKeywordInput('');
+          setStatus(undefined);
+          setPage(1);
+        }}
+      >
+        清除筛选条件
+      </Button>
+    </Empty>
+  ) : (
+    <Empty description="暂无数据">
+      <Button type="primary" onClick={() => navigate('/master-data/currencies/create')}>
+        新建币种
+      </Button>
+    </Empty>
+  );
+
+  const tags = [
+    keyword
+      ? {
+          key: 'keyword',
+          label: `关键词: ${keyword}`,
+          onClose: () => {
+            setKeywordInput('');
+            setPage(1);
+          },
+        }
+      : null,
+    status
+      ? {
+          key: 'status',
+          label: `状态: ${statusTagMap[status].text}`,
+          onClose: () => {
+            setStatus(undefined);
+            setPage(1);
+          },
+        }
+      : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          币种管理
+        </Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/currencies/create')}>
+          新建币种
+        </Button>
+      </Flex>
+
+      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
+        <Flex gap={token.marginSM} wrap>
+          <Input
+            placeholder="快捷搜索币种代码/名称"
+            style={{ width: 320 }}
+            value={keywordInput}
+            onChange={(e) => {
+              setKeywordInput(e.target.value);
+              setPage(1);
+            }}
+            allowClear
+          />
+          <Button type="link" onClick={() => setShowAdvanced((prev) => !prev)}>
+            {showAdvanced ? '收起高级筛选' : '展开高级筛选'}
+          </Button>
+        </Flex>
+
+        {showAdvanced ? (
+          <Flex gap={token.marginSM} wrap>
+            <Select<CurrencyStatus>
+              allowClear
+              placeholder="按状态筛选"
+              options={statusOptions}
+              value={status}
+              onChange={(value) => {
+                setStatus(value);
+                setPage(1);
+              }}
+              style={{ width: 200 }}
+            />
+          </Flex>
+        ) : null}
+
+        {tags.length > 0 ? (
+          <Space wrap>
+            {tags.map((item) => (
+              <Tag closable key={item.key} onClose={item.onClose}>
+                {item.label}
+              </Tag>
+            ))}
+            <Button
+              type="link"
+              onClick={() => {
+                setKeywordInput('');
+                setStatus(undefined);
+                setPage(1);
+              }}
+            >
+              清除全部
+            </Button>
+          </Space>
+        ) : null}
+      </Space>
+
+      <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
+        <ProTable<Currency>
+          search={false}
+          options={false}
+          toolBarRender={false}
+          rowKey="id"
+          loading={query.isFetching}
+          columns={columns}
+          dataSource={query.data?.list ?? []}
+          scroll={{ x: 900, y: 540 }}
+          rowClassName={() => 'currency-row-height'}
+          locale={{ emptyText }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: query.data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
+            showTotal: (total) => `共 ${total} 条记录`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+              } else {
+                setPage(nextPage);
+              }
+              setPageSize(nextPageSize);
+            },
+          }}
+        />
+      </Skeleton>
+
+      <style>{`
+        .currency-row-height .ant-table-cell {
+          height: 48px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/web/src/pages/master-data/warehouses/detail.tsx
+++ b/apps/web/src/pages/master-data/warehouses/detail.tsx
@@ -1,0 +1,145 @@
+import { Breadcrumb, Button, Card, Flex, Result, Space, Tag, Typography } from 'antd';
+import { ProDescriptions } from '@ant-design/pro-components';
+import type { ProDescriptionsItemProps } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { WarehouseStatus } from '@infitek/shared';
+import { getWarehouseById, type Warehouse } from '../../../api/warehouses.api';
+
+const statusText: Record<WarehouseStatus, string> = {
+  active: '启用',
+  inactive: '禁用',
+};
+
+const statusColor: Record<WarehouseStatus, string> = {
+  active: 'success',
+  inactive: 'default',
+};
+
+export default function WarehouseDetailPage() {
+  const navigate = useNavigate();
+  const { id = '' } = useParams();
+  const warehouseId = Number(id);
+
+  const query = useQuery({
+    queryKey: ['warehouse-detail', warehouseId],
+    queryFn: () => getWarehouseById(warehouseId),
+    enabled: Number.isInteger(warehouseId) && warehouseId > 0,
+  });
+
+  if (!Number.isInteger(warehouseId) || warehouseId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="仓库不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/warehouses')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="仓库详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/warehouses')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const columns: ProDescriptionsItemProps<Warehouse>[] = [
+    { title: '仓库名称', dataIndex: 'name', span: 1 },
+    {
+      title: '仓库地址',
+      dataIndex: 'address',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'createdAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      span: 1,
+      renderText: (value) => dayjs(value).format('YYYY-MM-DD'),
+    },
+    {
+      title: '创建人',
+      dataIndex: 'createdBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+    {
+      title: '更新人',
+      dataIndex: 'updatedBy',
+      span: 1,
+      renderText: (value) => value || '-',
+    },
+  ];
+
+  if (!query.data && !query.isLoading) {
+    return (
+      <Space direction="vertical">
+        <Typography.Text>仓库不存在</Typography.Text>
+        <Button onClick={() => navigate('/master-data/warehouses')}>返回列表</Button>
+      </Space>
+    );
+  }
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Flex justify="space-between" align="center">
+        <Breadcrumb
+          items={[
+            {
+              title: (
+                <Button type="link" onClick={() => navigate('/master-data/warehouses')}>
+                  基础数据
+                </Button>
+              ),
+            },
+            { title: '仓库管理' },
+            { title: '详情' },
+          ]}
+        />
+        <Button onClick={() => navigate(`/master-data/warehouses/${id}/edit`)}>编辑</Button>
+      </Flex>
+
+      <Card>
+        <Flex justify="space-between" align="center">
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            {query.data?.name || '-'}
+          </Typography.Title>
+          {query.data ? (
+            <Tag color={statusColor[query.data.status]}>{statusText[query.data.status]}</Tag>
+          ) : null}
+        </Flex>
+      </Card>
+
+      <ProDescriptions<Warehouse>
+        title="基础信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={columns}
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/pages/master-data/warehouses/form.tsx
+++ b/apps/web/src/pages/master-data/warehouses/form.tsx
@@ -1,0 +1,159 @@
+import { Button, Card, Result, Skeleton, Space } from 'antd';
+import { ProForm, ProFormSelect, ProFormText, ProFormTextArea } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { WarehouseStatus } from '@infitek/shared';
+import {
+  createWarehouse,
+  getWarehouseById,
+  updateWarehouse,
+  type CreateWarehousePayload,
+  type UpdateWarehousePayload,
+} from '../../../api/warehouses.api';
+
+const statusOptions: Array<{ label: string; value: WarehouseStatus }> = [
+  { label: '启用', value: 'active' as WarehouseStatus },
+  { label: '禁用', value: 'inactive' as WarehouseStatus },
+];
+
+export default function WarehouseFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const warehouseId = id ? Number(id) : undefined;
+  const isEdit = Boolean(id);
+
+  const detailQuery = useQuery({
+    queryKey: ['warehouse-detail', warehouseId],
+    queryFn: () => getWarehouseById(warehouseId as number),
+    enabled: Boolean(isEdit && warehouseId && Number.isInteger(warehouseId) && warehouseId > 0),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateWarehousePayload) => createWarehouse(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['warehouses'] });
+      navigate('/master-data/warehouses');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateWarehousePayload) => updateWarehouse(warehouseId as number, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['warehouses'] });
+      queryClient.invalidateQueries({ queryKey: ['warehouse-detail', warehouseId] });
+      navigate('/master-data/warehouses');
+    },
+  });
+
+  if (isEdit && (!warehouseId || !Number.isInteger(warehouseId) || warehouseId <= 0)) {
+    return (
+      <Result
+        status="404"
+        title="仓库不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/warehouses')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isEdit && detailQuery.isLoading) {
+    return <Skeleton active />;
+  }
+
+  if (isEdit && detailQuery.isError && !detailQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="仓库详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => detailQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/warehouses')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <Card title={isEdit ? '编辑仓库' : '新建仓库'}>
+      <ProForm<{
+        name: string;
+        address?: string;
+        status?: WarehouseStatus;
+      }>
+        grid
+        rowProps={{ gutter: [16, 0] }}
+        colProps={{ span: 12 }}
+        loading={detailQuery.isLoading}
+        submitter={{
+          render: (_, dom) => (
+            <Space>
+              <Button onClick={() => navigate('/master-data/warehouses')}>取消</Button>
+              {dom[1]}
+            </Space>
+          ),
+          searchConfig: {
+            submitText: isEdit ? '保存' : '创建',
+          },
+        }}
+        initialValues={
+          detailQuery.data
+            ? {
+                name: detailQuery.data.name,
+                address: detailQuery.data.address ?? undefined,
+                status: detailQuery.data.status,
+              }
+            : {}
+        }
+        onFinish={async (values) => {
+          if (isEdit) {
+            await updateMutation.mutateAsync({
+              name: values.name,
+              address: values.address,
+              status: values.status,
+            });
+          } else {
+            await createMutation.mutateAsync({
+              name: values.name,
+              address: values.address,
+            });
+          }
+          return true;
+        }}
+      >
+        <ProFormText
+          name="name"
+          label="仓库名称"
+          placeholder="请输入仓库名称"
+          rules={[
+            { required: true, message: '请输入仓库名称' },
+            { max: 100, message: '仓库名称最多 100 个字符' },
+          ]}
+        />
+        <ProFormTextArea
+          name="address"
+          label="仓库地址"
+          placeholder="请输入仓库地址（可选）"
+          fieldProps={{ rows: 2 }}
+          rules={[{ max: 255, message: '仓库地址最多 255 个字符' }]}
+        />
+        {isEdit ? (
+          <ProFormSelect
+            name="status"
+            label="状态"
+            options={statusOptions}
+            rules={[{ required: true, message: '请选择状态' }]}
+          />
+        ) : null}
+      </ProForm>
+    </Card>
+  );
+}

--- a/apps/web/src/pages/master-data/warehouses/index.tsx
+++ b/apps/web/src/pages/master-data/warehouses/index.tsx
@@ -62,10 +62,6 @@ export default function WarehousesListPage() {
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword || status);
 
-  useEffect(() => {
-    setPage(1);
-  }, [keyword, status]);
-
   const query = useQuery({
     queryKey: ['warehouses', keyword, status, page, pageSize],
     placeholderData: (previousData) => previousData,
@@ -86,21 +82,6 @@ export default function WarehousesListPage() {
       message.success('操作成功');
     },
   });
-
-  if (query.isError && !query.data) {
-    return (
-      <Result
-        status="error"
-        title="加载仓库列表失败"
-        subTitle="请检查网络或稍后重试"
-        extra={
-          <Button type="primary" onClick={() => query.refetch()}>
-            重试
-          </Button>
-        }
-      />
-    );
-  }
 
   const columns: ProColumns<Warehouse>[] = useMemo(
     () => [
@@ -190,6 +171,21 @@ export default function WarehousesListPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [navigate, token.colorLink],
   );
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载仓库列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
 
   const emptyText = hasFilters ? (
     <Empty description="未找到匹配记录">

--- a/apps/web/src/pages/master-data/warehouses/index.tsx
+++ b/apps/web/src/pages/master-data/warehouses/index.tsx
@@ -1,0 +1,341 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Badge,
+  Button,
+  Empty,
+  Flex,
+  Input,
+  Popconfirm,
+  Result,
+  Select,
+  Skeleton,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+  theme,
+} from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import type { WarehouseStatus } from '@infitek/shared';
+import { getWarehouses, updateWarehouse, type Warehouse } from '../../../api/warehouses.api';
+
+const WAREHOUSE_STATUS_ACTIVE = 'active' as WarehouseStatus;
+const WAREHOUSE_STATUS_INACTIVE = 'inactive' as WarehouseStatus;
+
+const statusOptions: Array<{ label: string; value: WarehouseStatus }> = [
+  { label: '启用', value: WAREHOUSE_STATUS_ACTIVE },
+  { label: '禁用', value: WAREHOUSE_STATUS_INACTIVE },
+];
+
+const statusTagMap = {
+  active: { status: 'success', text: '启用' },
+  inactive: { status: 'default', text: '禁用' },
+} satisfies Record<WarehouseStatus, { status: 'success' | 'default'; text: string }>;
+
+function useDebouncedValue(input: string, delay = 300) {
+  const [value, setValue] = useState(input);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setValue(input), delay);
+    return () => window.clearTimeout(timer);
+  }, [input, delay]);
+
+  return value;
+}
+
+export default function WarehousesListPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { token } = theme.useToken();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [status, setStatus] = useState<WarehouseStatus | undefined>();
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters = Boolean(keyword || status);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword, status]);
+
+  const query = useQuery({
+    queryKey: ['warehouses', keyword, status, page, pageSize],
+    placeholderData: (previousData) => previousData,
+    queryFn: () =>
+      getWarehouses({
+        keyword: keyword || undefined,
+        status,
+        page,
+        pageSize,
+      }),
+  });
+
+  const toggleStatusMutation = useMutation({
+    mutationFn: ({ id, newStatus }: { id: number; newStatus: WarehouseStatus }) =>
+      updateWarehouse(id, { status: newStatus }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['warehouses'] });
+      message.success('操作成功');
+    },
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载仓库列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const columns: ProColumns<Warehouse>[] = useMemo(
+    () => [
+      {
+        title: '仓库名称',
+        dataIndex: 'name',
+        width: 220,
+        ellipsis: true,
+        render: (_, record) => (
+          <Link to={`/master-data/warehouses/${record.id}`} style={{ color: token.colorLink }}>
+            {record.name}
+          </Link>
+        ),
+      },
+      {
+        title: '仓库地址',
+        dataIndex: 'address',
+        width: 280,
+        ellipsis: true,
+        render: (_, record) =>
+          record.address ? (
+            <Tooltip title={record.address}>
+              <Typography.Text ellipsis style={{ maxWidth: 240, display: 'inline-block' }}>
+                {record.address}
+              </Typography.Text>
+            </Tooltip>
+          ) : (
+            <Typography.Text type="secondary">-</Typography.Text>
+          ),
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 120,
+        render: (_, record) => {
+          const meta = statusTagMap[record.status];
+          return <Badge status={meta.status} text={meta.text} />;
+        },
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        width: 140,
+        render: (_, record) => dayjs(record.createdAt).format('YYYY-MM-DD'),
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 180,
+        fixed: 'right',
+        render: (_, record) => (
+          <Space size={12}>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/warehouses/${record.id}`)}
+            >
+              查看
+            </Button>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/warehouses/${record.id}/edit`)}
+            >
+              编辑
+            </Button>
+            <Popconfirm
+              title={record.status === WAREHOUSE_STATUS_ACTIVE ? '确认禁用该仓库？' : '确认启用该仓库？'}
+              onConfirm={() =>
+                toggleStatusMutation.mutate({
+                  id: record.id,
+                  newStatus:
+                    record.status === WAREHOUSE_STATUS_ACTIVE
+                      ? WAREHOUSE_STATUS_INACTIVE
+                      : WAREHOUSE_STATUS_ACTIVE,
+                })
+              }
+            >
+              <Button type="link" style={{ padding: 0 }}>
+                {record.status === WAREHOUSE_STATUS_ACTIVE ? '禁用' : '启用'}
+              </Button>
+            </Popconfirm>
+          </Space>
+        ),
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [navigate, token.colorLink],
+  );
+
+  const emptyText = hasFilters ? (
+    <Empty description="未找到匹配记录">
+      <Button
+        type="link"
+        onClick={() => {
+          setKeywordInput('');
+          setStatus(undefined);
+          setPage(1);
+        }}
+      >
+        清除筛选条件
+      </Button>
+    </Empty>
+  ) : (
+    <Empty description="暂无数据">
+      <Button type="primary" onClick={() => navigate('/master-data/warehouses/create')}>
+        新建仓库
+      </Button>
+    </Empty>
+  );
+
+  const tags = [
+    keyword
+      ? {
+          key: 'keyword',
+          label: `关键词: ${keyword}`,
+          onClose: () => {
+            setKeywordInput('');
+            setPage(1);
+          },
+        }
+      : null,
+    status
+      ? {
+          key: 'status',
+          label: `状态: ${statusTagMap[status].text}`,
+          onClose: () => {
+            setStatus(undefined);
+            setPage(1);
+          },
+        }
+      : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          仓库管理
+        </Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/warehouses/create')}>
+          新建仓库
+        </Button>
+      </Flex>
+
+      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
+        <Flex gap={token.marginSM} wrap>
+          <Input
+            placeholder="快捷搜索仓库名称/地址"
+            style={{ width: 320 }}
+            value={keywordInput}
+            onChange={(e) => {
+              setKeywordInput(e.target.value);
+              setPage(1);
+            }}
+            allowClear
+          />
+          <Button type="link" onClick={() => setShowAdvanced((prev) => !prev)}>
+            {showAdvanced ? '收起高级筛选' : '展开高级筛选'}
+          </Button>
+        </Flex>
+
+        {showAdvanced ? (
+          <Flex gap={token.marginSM} wrap>
+            <Select<WarehouseStatus>
+              allowClear
+              placeholder="按状态筛选"
+              options={statusOptions}
+              value={status}
+              onChange={(value) => {
+                setStatus(value);
+                setPage(1);
+              }}
+              style={{ width: 200 }}
+            />
+          </Flex>
+        ) : null}
+
+        {tags.length > 0 ? (
+          <Space wrap>
+            {tags.map((item) => (
+              <Tag closable key={item.key} onClose={item.onClose}>
+                {item.label}
+              </Tag>
+            ))}
+            <Button
+              type="link"
+              onClick={() => {
+                setKeywordInput('');
+                setStatus(undefined);
+                setPage(1);
+              }}
+            >
+              清除全部
+            </Button>
+          </Space>
+        ) : null}
+      </Space>
+
+      <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
+        <ProTable<Warehouse>
+          search={false}
+          options={false}
+          toolBarRender={false}
+          rowKey="id"
+          loading={query.isFetching}
+          columns={columns}
+          dataSource={query.data?.list ?? []}
+          scroll={{ x: 1000, y: 540 }}
+          rowClassName={() => 'warehouse-row-height'}
+          locale={{ emptyText }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: query.data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
+            showTotal: (total) => `共 ${total} 条记录`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+              } else {
+                setPage(nextPage);
+              }
+              setPageSize(nextPageSize);
+            },
+          }}
+        />
+      </Skeleton>
+
+      <style>{`
+        .warehouse-row-height .ant-table-cell {
+          height: 48px;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/packages/shared/src/enums/currency-status.enum.ts
+++ b/packages/shared/src/enums/currency-status.enum.ts
@@ -1,0 +1,6 @@
+export const CurrencyStatus = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;
+
+export type CurrencyStatus = (typeof CurrencyStatus)[keyof typeof CurrencyStatus];

--- a/packages/shared/src/enums/warehouse-status.enum.ts
+++ b/packages/shared/src/enums/warehouse-status.enum.ts
@@ -1,0 +1,6 @@
+export const WarehouseStatus = {
+  ACTIVE: 'active',
+  INACTIVE: 'inactive',
+} as const;
+
+export type WarehouseStatus = (typeof WarehouseStatus)[keyof typeof WarehouseStatus];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,8 @@ export const UserStatus = {
 
 export type UserStatus = typeof UserStatus[keyof typeof UserStatus];
 export * from './enums/unit-status.enum';
+export * from './enums/warehouse-status.enum';
+export * from './enums/currency-status.enum';
 
 // Types
 export * from './types/api-response.types';


### PR DESCRIPTION
## Summary

- 实现仓库管理模块 (FR15)：名称/地址 CRUD、启用/禁用切换、软删除、数据库迁移
- 实现币种管理模块 (FR16)：code 唯一性校验、启用/禁用切换、软删除、数据库迁移
- 实现国家/地区管理模块 (FR17)：code 唯一性、无状态字段、软删除、数据库迁移
- 新增 `WarehouseStatus`、`CurrencyStatus` 到 `@infitek/shared`（const object 模式）
- 注册三个模块到 AppModule，前端新增 12 条路由

## Changes

**Backend**
- `apps/api/src/modules/master-data/warehouses/` — 完整 7 文件模块结构
- `apps/api/src/modules/master-data/currencies/` — 完整 7 文件模块结构
- `apps/api/src/modules/master-data/countries/` — 完整 7 文件模块结构
- `apps/api/src/migrations/` — 3 个 TypeORM 迁移文件
- `apps/api/src/app.module.ts` — 注册 3 个新模块

**Frontend**
- `apps/web/src/api/` — warehouses/currencies/countries API 层
- `apps/web/src/pages/master-data/` — 三个模块各自的 list/detail/form 页面
- `apps/web/src/App.tsx` — 新增 12 条路由

**Shared**
- `packages/shared/src/enums/` — WarehouseStatus、CurrencyStatus

## Test plan

- [x] 构建验证通过（frontend tsc + vite build，backend tsc --noEmit）
- [x] 25 个单元测试全部通过（warehouses/currencies/countries service specs）
- [x] 代码审查完成，修复了 IsNull() 类型安全问题和 enum 模式一致性问题
- [x] 验证仓库管理：创建/编辑/查看/启用禁用
- [x] 验证币种管理：创建/编辑/查看/启用禁用，重复 code 校验
- [x] 验证国家/地区管理：创建/编辑/查看（无状态字段）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
