### PR TITLE
feat(companies): 公司主体信息管理 CRUD (Story 2-3)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-3-公司主体信息管理.md
+++ b/_bmad-output/implementation-artifacts/2-3-公司主体信息管理.md
@@ -1,0 +1,475 @@
+# Story 2.3: 公司主体信息管理
+
+Status: done
+
+## Story
+
+As a 授权用户,
+I want 创建和管理公司主体信息（含纳税人识别号、海关备案号等合规字段）,
+So that 采购订单和物流单可以关联正确的签约主体。
+
+---
+
+## Acceptance Criteria
+
+**Given** 授权用户已登录 / **When** 进入公司主体管理页面，点击"新建" / **Then** 表单页按**分组卡片布局**展示：
+- 基本信息：公司名称（必填）、签订地点
+- 银行信息：开户行、银行账号、SWIFT CODE、默认币种
+- 合规信息：纳税人识别号、海关备案号、检疫备案号
+- **And** 默认币种字段为下拉选择，调用 `/api/currencies` 关联币种主数据（来自 Story 2.2）
+- **And** 必填字段标注红色星号
+
+**Given** 授权用户填写完整公司主体信息并提交 / **When** 创建成功 / **Then** 跳转至详情页，使用 ProDescriptions 分组卡片展示所有字段（FR13）
+
+**Given** 授权用户在公司主体列表页 / **When** 搜索关键字 / **Then** 按公司名称模糊匹配筛选
+
+**Given** 授权用户在公司主体详情页 / **When** 点击"编辑" / **Then** 进入表单编辑模式，可修改所有字段并保存
+
+---
+
+## Tasks / Subtasks
+
+### 后端实现
+
+- [x] 创建 CompanyModule 7 文件结构
+  - [x] `apps/api/src/modules/master-data/companies/companies.module.ts`
+  - [x] `apps/api/src/modules/master-data/companies/companies.controller.ts`
+  - [x] `apps/api/src/modules/master-data/companies/companies.service.ts`
+  - [x] `apps/api/src/modules/master-data/companies/companies.repository.ts`
+  - [x] `apps/api/src/modules/master-data/companies/entities/company.entity.ts`
+  - [x] `apps/api/src/modules/master-data/companies/dto/create-company.dto.ts`
+  - [x] `apps/api/src/modules/master-data/companies/dto/update-company.dto.ts`
+  - [x] `apps/api/src/modules/master-data/companies/dto/query-company.dto.ts`
+  - [x] `apps/api/src/modules/master-data/companies/tests/companies.service.spec.ts`
+- [x] 创建 Company Entity（继承 BaseEntity，无软删除，有 @Unique(['name'])）
+- [x] 实现 CompaniesRepository（CRUD + 分页，keyword 匹配 name）
+- [x] 实现 CompaniesService（CRUD 方法）
+- [x] 实现 CompaniesController（GET / | GET /:id | POST / | PATCH /:id）
+- [x] 创建 TypeORM Migration `20260420000100-create-companies-table.ts`（含 `up()` 和 `down()`）
+- [x] 在 AppModule 注册 CompaniesModule
+- [x] 编写 CompaniesService 单元测试
+
+### 前端实现
+
+- [x] 创建 companies 页面目录 `apps/web/src/pages/master-data/companies/`
+  - [x] `index.tsx`（列表页，ProTable）
+  - [x] `detail.tsx`（详情页，ProDescriptions 分组卡片）
+  - [x] `form.tsx`（表单页，ProForm 3 组分组卡片）
+- [x] 创建 `apps/web/src/api/companies.api.ts`
+- [x] 在 `apps/web/src/App.tsx` 注册 4 条路由
+- [x] 在 `apps/web/src/components/layout/Sidebar.tsx` 添加"公司主体"导航项
+
+---
+
+## Dev Agent Context
+
+### 关键约束（必须遵守）
+
+#### 后端约束
+
+1. **模块路径**：`apps/api/src/modules/master-data/companies/`
+2. **Entity 必须继承 BaseEntity**：`import { BaseEntity } from '../../../common/entities/base.entity'`
+3. **每个字段必须同时加 `@Expose()` 和 `@Column({ name: 'snake_case' })`**
+4. **无软删除**：公司主体不需要 `@DeleteDateColumn`；查询时不需要 `IsNull()` 过滤
+5. **唯一约束**：`name` 字段加 `@Unique()` 装饰器（Entity 级别），Migration 中同步添加唯一索引
+6. **API 前缀**：Controller 路径写 `companies`，最终为 `/api/companies`
+7. **响应格式**：全局 ResponseInterceptor 自动包装，Controller 直接 return 数据
+8. **认证**：JwtAuthGuard 已全局注册，无需在 Controller 添加
+9. **枚举**：本 Story 无需枚举（无状态字段）
+10. **Migration**：必须同时实现 `up()` 和 `down()` 方法（Story 2-1 遗漏 `down()`，本 Story 必须修正）
+11. **QueryDto**：直接继承已有的 `BaseQueryDto`（`apps/api/src/common/dto/base-query.dto.ts`），无需重新定义 page/pageSize/keyword
+
+#### 前端约束
+
+1. **列表页必须使用 ProTable**，禁止原生 `<Table>`
+2. **详情页必须使用 ProDescriptions**（分组卡片布局）
+3. **表单页必须使用 ProForm + ProFormItem 系列**（分组卡片，字段数 9，使用 `ProCard` 分组）
+4. **禁止在组件内直接调用 axios**，必须通过 `src/api/companies.api.ts`
+5. **服务端状态用 TanStack Query**（`useQuery` / `useMutation`），禁止手写 `useEffect` 请求
+6. **axios 实例**：导入 `import request from '../request'`（`apps/web/src/api/request.ts`，非 `client.ts`）
+7. **id 类型**：前端接口定义 `id: number`（非 string，Story 2-1 review 纠正项）
+8. **分页状态重置**：keyword 变化时必须重置 page 为 1
+9. **错误状态处理**：`useQuery` 的 `isError` 状态必须处理，避免页面空白
+10. **货币下拉**：使用 `ProFormSelect` 的 `request` prop 调用 currencies API；若 Story 2-2 尚未部署，下拉为空，字段设为 `required: false`
+
+### 现有代码参考（单位管理模板）
+
+#### Entity 模式（参考 `apps/api/src/modules/master-data/units/entities/unit.entity.ts`）
+
+```typescript
+import { Entity, Column, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../common/entities/base.entity';
+
+@Entity('companies')
+@Unique(['name'])
+export class Company extends BaseEntity {
+  @Column({ name: 'name', type: 'varchar', length: 200 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'signing_location', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  signingLocation: string | null;
+
+  @Column({ name: 'bank_name', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  bankName: string | null;
+
+  @Column({ name: 'bank_account', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  bankAccount: string | null;
+
+  @Column({ name: 'swift_code', type: 'varchar', length: 20, nullable: true })
+  @Expose()
+  swiftCode: string | null;
+
+  // 存储币种 code（如 "USD"）；依赖 Story 2-2 的 currencies 表，但不添加 FK 约束避免迁移顺序耦合
+  @Column({ name: 'default_currency_code', type: 'varchar', length: 20, nullable: true })
+  @Expose()
+  defaultCurrencyCode: string | null;
+
+  @Column({ name: 'tax_id', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  taxId: string | null;
+
+  @Column({ name: 'customs_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  customsCode: string | null;
+
+  @Column({ name: 'quarantine_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  quarantineCode: string | null;
+}
+```
+
+#### Repository 模式（参考 units）
+
+```typescript
+@Injectable()
+export class CompaniesRepository {
+  constructor(
+    @InjectRepository(Company)
+    private readonly repo: Repository<Company>,
+  ) {}
+
+  async findAll(query: QueryCompanyDto) {
+    const { keyword, page = 1, pageSize = 20 } = query;
+    const qb = this.repo.createQueryBuilder('company');
+
+    if (keyword) {
+      qb.where('company.name LIKE :kw', { kw: `%${keyword}%` });
+    }
+
+    const [data, total] = await qb
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return { data, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  findById(id: number) { return this.repo.findOne({ where: { id } }); }
+  create(dto: CreateCompanyDto) { return this.repo.save(this.repo.create(dto)); }
+  async update(id: number, dto: UpdateCompanyDto) {
+    await this.repo.update(id, dto);
+    return this.findById(id);
+  }
+}
+```
+
+#### QueryDto（直接继承，无需额外字段）
+
+```typescript
+// apps/api/src/modules/master-data/companies/dto/query-company.dto.ts
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+export class QueryCompanyDto extends BaseQueryDto {}
+```
+
+### 前端实现规范
+
+#### API 层（`apps/web/src/api/companies.api.ts`）
+
+```typescript
+import request from './request';
+
+export interface Company {
+  id: number;          // 必须是 number，不是 string（Story 2-1 纠正项）
+  name: string;
+  signingLocation: string | null;
+  bankName: string | null;
+  bankAccount: string | null;
+  swiftCode: string | null;
+  defaultCurrencyCode: string | null;
+  taxId: string | null;
+  customsCode: string | null;
+  quarantineCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CompanyListResponse {
+  data: Company[];     // 后端返回 data 字段（非 list）
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+// request 拦截器已自动提取 response.data.data，直接返回业务数据
+export const companiesApi = {
+  list: (params: { keyword?: string; page?: number; pageSize?: number }) =>
+    request.get<any, CompanyListResponse>('/companies', { params }),
+  get: (id: number) => request.get<any, Company>(`/companies/${id}`),
+  create: (data: Omit<Company, 'id' | 'createdAt' | 'updatedAt'>) =>
+    request.post<any, Company>('/companies', data),
+  update: (id: number, data: Partial<Omit<Company, 'id' | 'createdAt' | 'updatedAt'>>) =>
+    request.patch<any, Company>(`/companies/${id}`, data),
+};
+```
+
+#### 列表页（`index.tsx`）— 满足 UX-DR04
+
+```typescript
+// 必须包含：
+// 1. 页面标题"公司主体管理" + 右侧"新建公司主体"Primary 按钮
+// 2. 快捷搜索框（debounce 300ms，placeholder: "搜索公司名称"）
+// 3. ProTable（行高 48px，首列公司名称蓝色链接，操作列固定右侧）
+// 4. 底部分页器（10/20/50 可切换）+ "共 N 条记录"
+// 5. 空状态处理（无筛选：暂无数据 + 新建按钮；有筛选：未找到匹配记录 + 清除筛选）
+// 6. 错误状态处理（isError：显示 Result 错误组件）
+// 7. keyword 变化时重置 page 为 1
+
+// 无状态 Tag（公司主体无状态字段），操作列只需"详情"和"编辑"
+```
+
+#### 表单页（`form.tsx`）— 满足 UX-DR06（分组卡片）
+
+```typescript
+// 字段分 3 组，使用 ProCard 嵌套在 ProForm 内
+
+// Group 1: 基本信息
+// - 公司名称（必填，maxLength: 200）
+// - 签订地点（可选，maxLength: 200）
+
+// Group 2: 银行信息
+// - 开户行（可选，maxLength: 200）
+// - 银行账号（可选，maxLength: 100）
+// - SWIFT CODE（可选，maxLength: 20）
+// - 默认币种（ProFormSelect，request 调用 currencies API）
+
+// Group 3: 合规信息
+// - 纳税人识别号（可选，maxLength: 100）
+// - 海关备案号（可选，maxLength: 100）
+// - 检疫备案号（可选，maxLength: 100）
+
+import { ProForm, ProFormText, ProFormSelect } from '@ant-design/pro-components';
+import { ProCard } from '@ant-design/pro-components';
+```
+
+#### 货币下拉（依赖 Story 2-2）
+
+```typescript
+<ProFormSelect
+  name="defaultCurrencyCode"
+  label="默认币种"
+  request={async () => {
+    try {
+      const res = await request.get<any, { data: Array<{ code: string; name: string }> }>('/currencies');
+      return (res.data || []).map((c) => ({ label: `${c.name} (${c.code})`, value: c.code }));
+    } catch {
+      return [];  // Story 2-2 未部署时返回空列表，下拉显示 "无数据"
+    }
+  }}
+  placeholder="请选择默认币种"
+/>
+```
+
+#### 详情页（`detail.tsx`）— 满足 UX-DR05
+
+```typescript
+// 结构：
+// 1. 顶部操作区（面包屑：首页 > 基础数据 > 公司主体管理 > 详情 + "编辑"按钮）
+// 2. ProDescriptions 3 分组卡片（基本信息 / 银行信息 / 合规信息，两列布局）
+// 3. 无状态信息栏（公司主体无状态字段）
+```
+
+### 路由注册（`apps/web/src/App.tsx`）
+
+```typescript
+// 顶部 import：
+import CompaniesList from './pages/master-data/companies/index';
+import CompanyDetail from './pages/master-data/companies/detail';
+import CompanyForm from './pages/master-data/companies/form';
+
+// 在 <Route element={<AppLayout />}> 内添加（与 units 路由相邻）：
+<Route path="/master-data/companies" element={<CompaniesList />} />
+<Route path="/master-data/companies/create" element={<CompanyForm />} />
+<Route path="/master-data/companies/:id" element={<CompanyDetail />} />
+<Route path="/master-data/companies/:id/edit" element={<CompanyForm />} />
+```
+
+### 侧边导航（`apps/web/src/components/layout/Sidebar.tsx`）
+
+```typescript
+// "基础数据"分组 children 数组中，在 units 之后添加：
+{ key: '/master-data/companies', label: '公司主体' },
+```
+
+### 数据库表结构（Migration）
+
+```typescript
+// apps/api/src/migrations/20260420000100-create-companies-table.ts
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCompaniesTable20260420000100 implements MigrationInterface {
+  name = 'CreateCompaniesTable20260420000100';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE \`companies\` (
+        \`id\` bigint NOT NULL AUTO_INCREMENT,
+        \`name\` varchar(200) NOT NULL COMMENT '公司名称',
+        \`signing_location\` varchar(200) NULL COMMENT '签订地点',
+        \`bank_name\` varchar(200) NULL COMMENT '开户行',
+        \`bank_account\` varchar(100) NULL COMMENT '银行账号',
+        \`swift_code\` varchar(20) NULL COMMENT 'SWIFT CODE',
+        \`default_currency_code\` varchar(20) NULL COMMENT '默认币种代码',
+        \`tax_id\` varchar(100) NULL COMMENT '纳税人识别号',
+        \`customs_code\` varchar(100) NULL COMMENT '海关备案号',
+        \`quarantine_code\` varchar(100) NULL COMMENT '检疫备案号',
+        \`created_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        \`updated_at\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        \`created_by\` varchar(100) NULL,
+        \`updated_by\` varchar(100) NULL,
+        PRIMARY KEY (\`id\`),
+        UNIQUE KEY \`idx_companies_name\` (\`name\`)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='公司主体信息';
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE \`companies\``);
+  }
+}
+```
+
+**注意**：companies 表无 `deleted_at`（不需要软删除）；无 `default_currency_code` 的 FK 约束（避免迁移顺序耦合 Story 2-2）。
+
+---
+
+## Story 2-1 代码审查经验（必须在本 Story 中修正）
+
+| 问题 | Story 2-1 遗漏 | Story 2-3 要求 |
+|------|--------------|--------------|
+| Migration 缺少 down() | 只有 up() | 必须实现 up() 和 down() |
+| 前端 id 类型错误 | id: string | id: number |
+| 前端 API 响应字段 | 期望 list | 实际为 data，接口定义必须一致 |
+| 前端列表页缺少错误处理 | isError 未处理 | 必须处理 isError |
+| 前端分页未重置 | keyword 变化不重置 page | keyword/filters 变化时重置 page=1 |
+| 前端表单缺少字段验证 | 无 maxLength | 必填 + maxLength 规则 |
+| Entity 缺少 @Unique() | 仅 Migration 建索引 | Entity + Migration 双重声明 |
+
+---
+
+## 关键文件路径汇总
+
+| 文件 | 路径 |
+|------|------|
+| API 客户端 | `apps/web/src/api/request.ts`（默认导出 `request`） |
+| 路由注册 | `apps/web/src/App.tsx` |
+| 侧边导航 | `apps/web/src/components/layout/Sidebar.tsx` |
+| BaseQueryDto | `apps/api/src/common/dto/base-query.dto.ts` |
+| BaseEntity | `apps/api/src/common/entities/base.entity.ts` |
+| 现有 units 模块参考 | `apps/api/src/modules/master-data/units/` |
+| 现有 units 页面参考 | `apps/web/src/pages/master-data/units/` |
+| 现有 units API 参考 | `apps/web/src/api/units.api.ts` |
+
+---
+
+## 依赖说明
+
+- **Story 2-1（done）**：提供 BaseQueryDto、Entity 继承模式、ProTable/ProForm 页面结构模板
+- **Story 2-2（backlog）**：提供币种主数据 `/api/currencies` 端点；在 Story 2-2 部署前，货币下拉显示空列表（功能可用，数据为空）
+
+---
+
+## 完成标准
+
+- [ ] 后端：`/api/companies` 的 GET（列表+分页）、GET/:id（详情）、POST（创建）、PATCH/:id（编辑）均可正常调用
+- [ ] 后端：Migration 文件已创建（含 up + down），`companies` 表结构正确
+- [ ] 后端：CompaniesService 单元测试通过
+- [ ] 前端：列表页使用 ProTable，满足 UX-DR04（搜索、分页、空状态、错误状态）
+- [ ] 前端：详情页使用 ProDescriptions 分组卡片（3 组），满足 UX-DR05
+- [ ] 前端：表单页使用 ProForm 分组卡片（3 组 + ProCard），满足 UX-DR06（必填星号、字段验证）
+- [ ] 前端：货币下拉通过 request prop 调用 `/api/currencies`，异常时优雅降级
+- [ ] 前端：所有 API 调用通过 `src/api/companies.api.ts` + TanStack Query
+- [ ] 前端：keyword 变化时重置 page=1
+- [ ] 路由和导航已注册
+
+---
+
+*Story 由 BMad Create-Story Workflow 创建 — 2026-04-20*
+
+---
+
+## Dev Agent Record
+
+### Implementation Summary
+
+实现了完整的公司主体信息管理 CRUD 功能，包含后端 NestJS 模块（7 文件结构）、TypeORM Migration、前端 React 三页面（列表/详情/表单）及路由导航注册。
+
+**关键决策**：
+- `defaultCurrencyCode` 存储为 `VARCHAR(20)` 软引用，无 FK 约束，避免与 Story 2-2 迁移顺序耦合
+- 货币下拉使用 `try/catch` 优雅降级：Story 2-2 未部署时返回空数组，不阻断页面功能
+- 修正了 Story 2-1 中所有 review 问题：migration `down()`、`id: number`、`isError` 处理、分页重置
+
+### Test Results
+
+- CompaniesService 单元测试：**7/7 通过**
+- 预存在的 users 模块测试（12 个）在 main 分支上已失败，与本 Story 无关
+
+### Files Changed / Created
+
+#### 后端（`apps/api/`）
+
+| 文件 | 操作 |
+|------|------|
+| `src/modules/master-data/companies/entities/company.entity.ts` | 新建 |
+| `src/modules/master-data/companies/dto/create-company.dto.ts` | 新建 |
+| `src/modules/master-data/companies/dto/update-company.dto.ts` | 新建 |
+| `src/modules/master-data/companies/dto/query-company.dto.ts` | 新建 |
+| `src/modules/master-data/companies/companies.repository.ts` | 新建 |
+| `src/modules/master-data/companies/companies.service.ts` | 新建 |
+| `src/modules/master-data/companies/companies.controller.ts` | 新建 |
+| `src/modules/master-data/companies/companies.module.ts` | 新建 |
+| `src/modules/master-data/companies/tests/companies.service.spec.ts` | 新建 |
+| `src/migrations/20260420000100-create-companies-table.ts` | 新建 |
+| `src/app.module.ts` | 修改（注册 CompaniesModule） |
+
+#### 前端（`apps/web/`）
+
+| 文件 | 操作 |
+|------|------|
+| `src/api/companies.api.ts` | 新建 |
+| `src/pages/master-data/companies/index.tsx` | 新建 |
+| `src/pages/master-data/companies/detail.tsx` | 新建 |
+| `src/pages/master-data/companies/form.tsx` | 新建 |
+| `src/App.tsx` | 修改（注册 4 条路由） |
+| `src/components/layout/Sidebar.tsx` | 修改（添加公司主体导航项） |
+
+### Review Findings
+
+- [x] [Review][Defer] TOCTOU 竞态：create/update 中的名称唯一性检查与写入非原子操作 [companies.service.ts] — deferred, 需数据库事务保障，超出本 Story 范围
+- [x] [Review][Defer] update 方法直接将 dto spread 传入 repository，无白名单过滤 [companies.service.ts:58] — deferred, DTO 类型已约束字段范围，当前可接受
+- [x] [Review][Defer] findByName 大小写敏感，与 DB 排序规则存在差异 [companies.repository.ts:18] — deferred, DB 唯一约束保障正确性，应用层 400 为尽力而为
+- [x] [Review][Defer] 无 DELETE 接口，公司主体无法删除 [companies.controller.ts] — deferred, 本 Story 未要求删除功能
+- [x] [Review][Defer] normalizeApiError 对非对象类型错误仅返回通用消息 [companies.api.ts] — deferred, 项目中原始类型错误极少见
+- [x] [Review][Defer] PATCH 允许空 body（UpdateCompanyDto 全字段可选）[companies.service.ts] — deferred, 空更新是幂等无害操作
+- [x] [Review][Defer] update 在 findById 与 repo.update 之间存在并发删除的极端情况 [companies.repository.ts:42] — deferred, 极低概率，超出本 Story 范围
+- [x] [Review][Defer] 货币下拉 Silent 降级为 []，用户无法感知加载失败 [form.tsx] — deferred, 设计意图，spec 明确要求优雅降级
+- [x] [Review][Defer] 创建成功后跳转详情页存在短暂 loading 状态 [form.tsx] — deferred, React Query 自动重取，体验可接受
+- [x] [Review][Defer] pageSize 切换无 debounce 可能触发多个并行请求 [index.tsx] — deferred, 超出本 Story 范围
+- [x] [Review][Defer] hasFilters 仅基于 keyword，未考虑未来新增筛选项 [index.tsx] — deferred, 本 Story 无其他筛选条件
+- [x] [Review][Defer] 编辑表单加载的是快照数据，无并发冲突检测 [form.tsx] — deferred, 无乐观锁需求，超出本 Story 范围
+- [x] [Review][Defer] 货币选项直接在 form.tsx 内调用 request，未经 companies.api.ts [form.tsx:19] — deferred, 货币数据属跨模块依赖，request 包装器已使用，spirit 满足

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,17 @@
+# Deferred Work
+
+## Deferred from: code review of 2-3-公司主体信息管理 (2026-04-20)
+
+- TOCTOU 竞态：create/update 中的名称唯一性检查与写入非原子操作 — 需数据库事务保障，超出本 Story 范围
+- update 方法直接将 dto spread 传入 repository，无白名单过滤 — DTO 类型已约束字段范围，当前可接受
+- findByName 大小写敏感，与 DB 排序规则存在差异 — DB 唯一约束保障正确性，应用层 400 为尽力而为
+- 无 DELETE 接口，公司主体无法删除 — 本 Story 未要求删除功能
+- normalizeApiError 对非对象类型错误仅返回通用消息 — 项目中原始类型错误极少见
+- PATCH 允许空 body（UpdateCompanyDto 全字段可选）— 空更新是幂等无害操作
+- update 在 findById 与 repo.update 之间存在并发删除的极端情况 — 极低概率，超出本 Story 范围
+- 货币下拉 Silent 降级为 []，用户无法感知加载失败 — 设计意图，spec 明确要求优雅降级
+- 创建成功后跳转详情页存在短暂 loading 状态 — React Query 自动重取，体验可接受
+- pageSize 切换无 debounce 可能触发多个并行请求 — 超出本 Story 范围
+- hasFilters 仅基于 keyword，未考虑未来新增筛选项 — 本 Story 无其他筛选条件
+- 编辑表单加载的是快照数据，无并发冲突检测 — 无乐观锁需求，超出本 Story 范围
+- 货币选项直接在 form.tsx 内调用 request，未经 companies.api.ts — 货币数据属跨模块依赖，request 包装器已使用，spirit 满足

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20 (story-2.2-done)
+last_updated: 2026-04-20 (story-2.3-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -61,7 +61,7 @@ development_status:
   epic-2: in-progress
   2-1-标准crud组件模板: done
   2-2-基础参考数据管理: done
-  2-3-公司主体信息管理: backlog
+  2-3-公司主体信息管理: done
   2-4-搜索筛选与分页横切能力: backlog
   epic-2-retrospective: optional
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { UnitsModule } from './modules/master-data/units/units.module';
 import { WarehousesModule } from './modules/master-data/warehouses/warehouses.module';
 import { CurrenciesModule } from './modules/master-data/currencies/currencies.module';
 import { CountriesModule } from './modules/master-data/countries/countries.module';
+import { CompaniesModule } from './modules/master-data/companies/companies.module';
 import databaseConfig from './config/database.config';
 
 @Module({
@@ -37,6 +38,7 @@ import databaseConfig from './config/database.config';
     WarehousesModule,
     CurrenciesModule,
     CountriesModule,
+    CompaniesModule,
     FilesModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/migrations/20260420000100-create-companies-table.ts
+++ b/apps/api/src/migrations/20260420000100-create-companies-table.ts
@@ -1,0 +1,58 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateCompaniesTable20260420000100 implements MigrationInterface {
+  name = 'CreateCompaniesTable20260420000100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'companies',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'name', type: 'varchar', length: '200', isNullable: false },
+          { name: 'signing_location', type: 'varchar', length: '200', isNullable: true },
+          { name: 'bank_name', type: 'varchar', length: '200', isNullable: true },
+          { name: 'bank_account', type: 'varchar', length: '100', isNullable: true },
+          { name: 'swift_code', type: 'varchar', length: '20', isNullable: true },
+          { name: 'default_currency_code', type: 'varchar', length: '20', isNullable: true, comment: '币种代码，软引用 currencies.code' },
+          { name: 'tax_id', type: 'varchar', length: '100', isNullable: true },
+          { name: 'customs_code', type: 'varchar', length: '100', isNullable: true },
+          { name: 'quarantine_code', type: 'varchar', length: '100', isNullable: true },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('companies', [
+      new TableIndex({
+        name: 'idx_companies_name',
+        columnNames: ['name'],
+        isUnique: true,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('companies');
+  }
+}

--- a/apps/api/src/modules/master-data/companies/companies.controller.ts
+++ b/apps/api/src/modules/master-data/companies/companies.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { CreateCompanyDto } from './dto/create-company.dto';
+import { QueryCompanyDto } from './dto/query-company.dto';
+import { UpdateCompanyDto } from './dto/update-company.dto';
+import { CompaniesService } from './companies.service';
+
+@Controller('companies')
+export class CompaniesController {
+  constructor(private readonly companiesService: CompaniesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCompanyDto) {
+    return this.companiesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.companiesService.findById(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateCompanyDto, @CurrentUser() user: { username?: string }) {
+    return this.companiesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateCompanyDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.companiesService.update(id, dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/master-data/companies/companies.module.ts
+++ b/apps/api/src/modules/master-data/companies/companies.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Company } from './entities/company.entity';
+import { CompaniesController } from './companies.controller';
+import { CompaniesRepository } from './companies.repository';
+import { CompaniesService } from './companies.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Company])],
+  controllers: [CompaniesController],
+  providers: [CompaniesRepository, CompaniesService],
+  exports: [CompaniesService],
+})
+export class CompaniesModule {}

--- a/apps/api/src/modules/master-data/companies/companies.repository.ts
+++ b/apps/api/src/modules/master-data/companies/companies.repository.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { QueryCompanyDto } from './dto/query-company.dto';
+import { Company } from './entities/company.entity';
+
+@Injectable()
+export class CompaniesRepository {
+  constructor(
+    @InjectRepository(Company)
+    private readonly repo: Repository<Company>,
+  ) {}
+
+  findById(id: number): Promise<Company | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  findByName(name: string): Promise<Company | null> {
+    return this.repo.findOne({ where: { name } });
+  }
+
+  async findAll(query: QueryCompanyDto) {
+    const { keyword, page = 1, pageSize = 20 } = query;
+
+    const qb = this.repo.createQueryBuilder('company');
+
+    if (keyword) {
+      qb.where('company.name LIKE :kw', { kw: `%${keyword}%` });
+    }
+
+    const [list, total] = await qb
+      .orderBy('company.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return { list, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  create(data: Partial<Company>): Promise<Company> {
+    return this.repo.save(data);
+  }
+
+  async update(id: number, data: Partial<Company>): Promise<Company> {
+    await this.repo.update(id, data);
+    return this.repo.findOneOrFail({ where: { id } });
+  }
+}

--- a/apps/api/src/modules/master-data/companies/companies.service.ts
+++ b/apps/api/src/modules/master-data/companies/companies.service.ts
@@ -1,0 +1,63 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { CreateCompanyDto } from './dto/create-company.dto';
+import { QueryCompanyDto } from './dto/query-company.dto';
+import { UpdateCompanyDto } from './dto/update-company.dto';
+import { Company } from './entities/company.entity';
+import { CompaniesRepository } from './companies.repository';
+
+@Injectable()
+export class CompaniesService {
+  constructor(private readonly companiesRepository: CompaniesRepository) {}
+
+  findAll(query: QueryCompanyDto) {
+    return this.companiesRepository.findAll(query);
+  }
+
+  async findById(id: number): Promise<Company> {
+    const company = await this.companiesRepository.findById(id);
+    if (!company) {
+      throw new NotFoundException('公司主体不存在');
+    }
+    return company;
+  }
+
+  async create(dto: CreateCompanyDto, operator?: string): Promise<Company> {
+    const duplicate = await this.companiesRepository.findByName(dto.name);
+    if (duplicate) {
+      throw new BadRequestException('公司名称已存在');
+    }
+
+    return this.companiesRepository.create({
+      name: dto.name,
+      signingLocation: dto.signingLocation ?? null,
+      bankName: dto.bankName ?? null,
+      bankAccount: dto.bankAccount ?? null,
+      swiftCode: dto.swiftCode ?? null,
+      defaultCurrencyCode: dto.defaultCurrencyCode ?? null,
+      taxId: dto.taxId ?? null,
+      customsCode: dto.customsCode ?? null,
+      quarantineCode: dto.quarantineCode ?? null,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+  }
+
+  async update(id: number, dto: UpdateCompanyDto, operator?: string): Promise<Company> {
+    const company = await this.companiesRepository.findById(id);
+    if (!company) {
+      throw new NotFoundException('公司主体不存在');
+    }
+
+    if (dto.name && dto.name !== company.name) {
+      const duplicate = await this.companiesRepository.findByName(dto.name);
+      if (duplicate && duplicate.id !== id) {
+        throw new BadRequestException('公司名称已存在');
+      }
+    }
+
+    return this.companiesRepository.update(id, {
+      ...dto,
+      updatedBy: operator,
+    });
+  }
+}

--- a/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
@@ -1,0 +1,48 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateCompanyDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  signingLocation?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  bankName?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  bankAccount?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(20)
+  swiftCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(20)
+  defaultCurrencyCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  taxId?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  customsCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  quarantineCode?: string;
+}

--- a/apps/api/src/modules/master-data/companies/dto/query-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/query-company.dto.ts
@@ -1,0 +1,3 @@
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+
+export class QueryCompanyDto extends BaseQueryDto {}

--- a/apps/api/src/modules/master-data/companies/dto/update-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/update-company.dto.ts
@@ -1,0 +1,48 @@
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateCompanyDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  signingLocation?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  bankName?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  bankAccount?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(20)
+  swiftCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(20)
+  defaultCurrencyCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  taxId?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  customsCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  quarantineCode?: string;
+}

--- a/apps/api/src/modules/master-data/companies/entities/company.entity.ts
+++ b/apps/api/src/modules/master-data/companies/entities/company.entity.ts
@@ -1,0 +1,43 @@
+import { Column, Entity, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('companies')
+@Unique('idx_companies_name', ['name'])
+export class Company extends BaseEntity {
+  @Column({ name: 'name', type: 'varchar', length: 200 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'signing_location', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  signingLocation: string | null;
+
+  @Column({ name: 'bank_name', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  bankName: string | null;
+
+  @Column({ name: 'bank_account', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  bankAccount: string | null;
+
+  @Column({ name: 'swift_code', type: 'varchar', length: 20, nullable: true })
+  @Expose()
+  swiftCode: string | null;
+
+  @Column({ name: 'default_currency_code', type: 'varchar', length: 20, nullable: true })
+  @Expose()
+  defaultCurrencyCode: string | null;
+
+  @Column({ name: 'tax_id', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  taxId: string | null;
+
+  @Column({ name: 'customs_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  customsCode: string | null;
+
+  @Column({ name: 'quarantine_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  quarantineCode: string | null;
+}

--- a/apps/api/src/modules/master-data/companies/tests/companies.service.spec.ts
+++ b/apps/api/src/modules/master-data/companies/tests/companies.service.spec.ts
@@ -1,0 +1,149 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CompaniesRepository } from '../companies.repository';
+import { CompaniesService } from '../companies.service';
+
+describe('CompaniesService', () => {
+  let service: CompaniesService;
+
+  const repoMock = {
+    findAll: jest.fn(),
+    findById: jest.fn(),
+    findByName: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CompaniesService,
+        {
+          provide: CompaniesRepository,
+          useValue: repoMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<CompaniesService>(CompaniesService);
+    jest.clearAllMocks();
+  });
+
+  it('应分页查询公司主体列表', async () => {
+    const payload = {
+      list: [
+        {
+          id: 1,
+          name: '星辰科技有限公司',
+          signingLocation: '上海市',
+          bankName: null,
+          bankAccount: null,
+          swiftCode: null,
+          defaultCurrencyCode: null,
+          taxId: null,
+          customsCode: null,
+          quarantineCode: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    };
+    repoMock.findAll.mockResolvedValue(payload);
+
+    const result = await service.findAll({ page: 1, pageSize: 20 });
+
+    expect(result).toEqual(payload);
+    expect(repoMock.findAll).toHaveBeenCalledWith({ page: 1, pageSize: 20 });
+  });
+
+  it('应创建公司主体', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.create.mockResolvedValue({
+      id: 1,
+      name: '星辰科技有限公司',
+      signingLocation: '上海市',
+      bankName: null,
+      bankAccount: null,
+      swiftCode: null,
+      defaultCurrencyCode: 'USD',
+      taxId: '91310000XXXXXXXXXX',
+      customsCode: null,
+      quarantineCode: null,
+      createdBy: 'admin',
+      updatedBy: 'admin',
+    });
+
+    const result = await service.create(
+      {
+        name: '星辰科技有限公司',
+        signingLocation: '上海市',
+        defaultCurrencyCode: 'USD',
+        taxId: '91310000XXXXXXXXXX',
+      },
+      'admin',
+    );
+
+    expect(result.name).toBe('星辰科技有限公司');
+    expect(repoMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '星辰科技有限公司',
+        createdBy: 'admin',
+        updatedBy: 'admin',
+      }),
+    );
+  });
+
+  it('创建时公司名称重复应抛错', async () => {
+    repoMock.findByName.mockResolvedValue({ id: 99, name: '星辰科技有限公司' });
+
+    await expect(
+      service.create({ name: '星辰科技有限公司' }, 'admin'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('应更新公司主体', async () => {
+    repoMock.findById.mockResolvedValue({ id: 1, name: '星辰科技有限公司' });
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.update.mockResolvedValue({
+      id: 1,
+      name: '星辰科技股份有限公司',
+      signingLocation: '北京市',
+      updatedBy: 'admin',
+    });
+
+    const result = await service.update(
+      1,
+      { name: '星辰科技股份有限公司', signingLocation: '北京市' },
+      'admin',
+    );
+
+    expect(result.name).toBe('星辰科技股份有限公司');
+    expect(repoMock.update).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ name: '星辰科技股份有限公司', updatedBy: 'admin' }),
+    );
+  });
+
+  it('更新名称重复应抛错', async () => {
+    repoMock.findById.mockResolvedValue({ id: 1, name: '星辰科技有限公司' });
+    repoMock.findByName.mockResolvedValue({ id: 2, name: '另一公司' });
+
+    await expect(
+      service.update(1, { name: '另一公司' }, 'admin'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('更新不存在的公司主体应抛错', async () => {
+    repoMock.findById.mockResolvedValue(null);
+
+    await expect(service.update(404, { name: 'x' }, 'admin')).rejects.toThrow(NotFoundException);
+  });
+
+  it('查询详情不存在应抛错', async () => {
+    repoMock.findById.mockResolvedValue(null);
+
+    await expect(service.findById(404)).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -20,6 +20,9 @@ import CurrencyFormPage from './pages/master-data/currencies/form';
 import CountriesListPage from './pages/master-data/countries/index';
 import CountryDetailPage from './pages/master-data/countries/detail';
 import CountryFormPage from './pages/master-data/countries/form';
+import CompaniesListPage from './pages/master-data/companies/index';
+import CompanyDetailPage from './pages/master-data/companies/detail';
+import CompanyFormPage from './pages/master-data/companies/form';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -109,6 +112,10 @@ function App() {
                 <Route path="/master-data/countries/create" element={<CountryFormPage />} />
                 <Route path="/master-data/countries/:id" element={<CountryDetailPage />} />
                 <Route path="/master-data/countries/:id/edit" element={<CountryFormPage />} />
+                <Route path="/master-data/companies" element={<CompaniesListPage />} />
+                <Route path="/master-data/companies/create" element={<CompanyFormPage />} />
+                <Route path="/master-data/companies/:id" element={<CompanyDetailPage />} />
+                <Route path="/master-data/companies/:id/edit" element={<CompanyFormPage />} />
               </Route>
 
               {/* 兜底重定向 */}

--- a/apps/web/src/api/companies.api.ts
+++ b/apps/web/src/api/companies.api.ts
@@ -1,0 +1,69 @@
+import request from './request';
+
+export interface Company {
+  id: number;
+  name: string;
+  signingLocation: string | null;
+  bankName: string | null;
+  bankAccount: string | null;
+  swiftCode: string | null;
+  defaultCurrencyCode: string | null;
+  taxId: string | null;
+  customsCode: string | null;
+  quarantineCode: string | null;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface CompaniesListParams {
+  keyword?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CompaniesListData {
+  list: Company[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateCompanyPayload {
+  name: string;
+  signingLocation?: string;
+  bankName?: string;
+  bankAccount?: string;
+  swiftCode?: string;
+  defaultCurrencyCode?: string;
+  taxId?: string;
+  customsCode?: string;
+  quarantineCode?: string;
+}
+
+export type UpdateCompanyPayload = Partial<CreateCompanyPayload>;
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) {
+    throw error;
+  }
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getCompanies = (params: CompaniesListParams): Promise<CompaniesListData> => {
+  return request.get<any, CompaniesListData>('/companies', { params }).catch(normalizeApiError);
+};
+
+export const getCompanyById = (id: number): Promise<Company> => {
+  return request.get<any, Company>(`/companies/${id}`).catch(normalizeApiError);
+};
+
+export const createCompany = (payload: CreateCompanyPayload): Promise<Company> => {
+  return request.post<any, Company>('/companies', payload).catch(normalizeApiError);
+};
+
+export const updateCompany = (id: number, payload: UpdateCompanyPayload): Promise<Company> => {
+  return request.patch<any, Company>(`/companies/${id}`, payload).catch(normalizeApiError);
+};

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -91,6 +91,7 @@ const menuItems = [
     ),
     children: [
       { key: '/master-data/units', label: '单位管理' },
+      { key: '/master-data/companies', label: '公司主体' },
       { key: '/settings/users', label: '用户管理' },
       { key: '/master-data/warehouses', label: '仓库管理' },
       { key: '/master-data/currencies', label: '币种管理' },

--- a/apps/web/src/pages/master-data/companies/detail.tsx
+++ b/apps/web/src/pages/master-data/companies/detail.tsx
@@ -1,0 +1,126 @@
+import { Breadcrumb, Button, Result, Space } from 'antd';
+import { ProDescriptions } from '@ant-design/pro-components';
+import type { ProDescriptionsItemProps } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useNavigate, useParams } from 'react-router-dom';
+import { getCompanyById, type Company } from '../../../api/companies.api';
+
+export default function CompanyDetailPage() {
+  const navigate = useNavigate();
+  const { id = '' } = useParams();
+  const companyId = Number(id);
+
+  const query = useQuery({
+    queryKey: ['company-detail', companyId],
+    queryFn: () => getCompanyById(companyId),
+    enabled: Number.isInteger(companyId) && companyId > 0,
+  });
+
+  if (!Number.isInteger(companyId) || companyId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="公司主体不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/companies')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="公司主体详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/companies')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const basicColumns: ProDescriptionsItemProps<Company>[] = [
+    { title: '公司名称', dataIndex: 'name', span: 1 },
+    { title: '签订地点', dataIndex: 'signingLocation', span: 1, renderText: (v) => v || '-' },
+    {
+      title: '创建时间',
+      dataIndex: 'createdAt',
+      span: 1,
+      renderText: (v) => dayjs(v).format('YYYY-MM-DD'),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      span: 1,
+      renderText: (v) => dayjs(v).format('YYYY-MM-DD'),
+    },
+  ];
+
+  const bankColumns: ProDescriptionsItemProps<Company>[] = [
+    { title: '开户行', dataIndex: 'bankName', span: 1, renderText: (v) => v || '-' },
+    { title: '银行账号', dataIndex: 'bankAccount', span: 1, renderText: (v) => v || '-' },
+    { title: 'SWIFT CODE', dataIndex: 'swiftCode', span: 1, renderText: (v) => v || '-' },
+    { title: '默认币种', dataIndex: 'defaultCurrencyCode', span: 1, renderText: (v) => v || '-' },
+  ];
+
+  const complianceColumns: ProDescriptionsItemProps<Company>[] = [
+    { title: '纳税人识别号', dataIndex: 'taxId', span: 1, renderText: (v) => v || '-' },
+    { title: '海关备案号', dataIndex: 'customsCode', span: 1, renderText: (v) => v || '-' },
+    { title: '检疫备案号', dataIndex: 'quarantineCode', span: 1, renderText: (v) => v || '-' },
+  ];
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Breadcrumb
+        items={[
+          {
+            title: (
+              <Button type="link" style={{ padding: 0 }} onClick={() => navigate('/master-data/companies')}>
+                公司主体管理
+              </Button>
+            ),
+          },
+          { title: '详情' },
+        ]}
+      />
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button onClick={() => navigate(`/master-data/companies/${id}/edit`)}>编辑</Button>
+      </div>
+
+      <ProDescriptions<Company>
+        title="基本信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={basicColumns}
+      />
+
+      <ProDescriptions<Company>
+        title="银行信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={bankColumns}
+      />
+
+      <ProDescriptions<Company>
+        title="合规信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={complianceColumns}
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/pages/master-data/companies/form.tsx
+++ b/apps/web/src/pages/master-data/companies/form.tsx
@@ -1,0 +1,230 @@
+import { Button, Result, Skeleton } from 'antd';
+import { ProCard, ProForm, ProFormSelect, ProFormText } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  createCompany,
+  getCompanyById,
+  updateCompany,
+  type CreateCompanyPayload,
+  type UpdateCompanyPayload,
+} from '../../../api/companies.api';
+import request from '../../../api/request';
+
+interface CurrencyOption {
+  label: string;
+  value: string;
+}
+
+async function fetchCurrencyOptions(): Promise<CurrencyOption[]> {
+  try {
+    const res = await request.get<any, { list: Array<{ code: string; name: string }> }>('/currencies');
+    return (res.list || []).map((c) => ({ label: `${c.name} (${c.code})`, value: c.code }));
+  } catch {
+    return [];
+  }
+}
+
+export default function CompanyFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const companyId = id ? Number(id) : undefined;
+  const isEdit = Boolean(id);
+
+  const detailQuery = useQuery({
+    queryKey: ['company-detail', companyId],
+    queryFn: () => getCompanyById(companyId as number),
+    enabled: Boolean(isEdit && companyId && Number.isInteger(companyId) && companyId > 0),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateCompanyPayload) => createCompany(payload),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['companies'] });
+      navigate(`/master-data/companies/${data.id}`);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateCompanyPayload) =>
+      updateCompany(companyId as number, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['companies'] });
+      queryClient.invalidateQueries({ queryKey: ['company-detail', companyId] });
+      navigate(`/master-data/companies/${companyId}`);
+    },
+  });
+
+  if (isEdit && (!companyId || !Number.isInteger(companyId) || companyId <= 0)) {
+    return (
+      <Result
+        status="404"
+        title="公司主体不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate('/master-data/companies')}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (isEdit && detailQuery.isLoading) {
+    return <Skeleton active />;
+  }
+
+  if (isEdit && detailQuery.isError && !detailQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="加载公司主体信息失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => detailQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate('/master-data/companies')}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const initialValues = detailQuery.data
+    ? {
+        name: detailQuery.data.name,
+        signingLocation: detailQuery.data.signingLocation ?? undefined,
+        bankName: detailQuery.data.bankName ?? undefined,
+        bankAccount: detailQuery.data.bankAccount ?? undefined,
+        swiftCode: detailQuery.data.swiftCode ?? undefined,
+        defaultCurrencyCode: detailQuery.data.defaultCurrencyCode ?? undefined,
+        taxId: detailQuery.data.taxId ?? undefined,
+        customsCode: detailQuery.data.customsCode ?? undefined,
+        quarantineCode: detailQuery.data.quarantineCode ?? undefined,
+      }
+    : {};
+
+  return (
+    <ProForm
+      title={isEdit ? '编辑公司主体' : '新建公司主体'}
+      loading={detailQuery.isLoading}
+      submitter={{
+        searchConfig: {
+          submitText: isEdit ? '保存' : '创建',
+        },
+        render: (_, dom) => (
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Button onClick={() => navigate(isEdit ? `/master-data/companies/${companyId}` : '/master-data/companies')}>
+              取消
+            </Button>
+            {dom[1]}
+          </div>
+        ),
+      }}
+      initialValues={initialValues}
+      onFinish={async (values) => {
+        const payload: CreateCompanyPayload = {
+          name: values.name,
+          signingLocation: values.signingLocation || undefined,
+          bankName: values.bankName || undefined,
+          bankAccount: values.bankAccount || undefined,
+          swiftCode: values.swiftCode || undefined,
+          defaultCurrencyCode: values.defaultCurrencyCode || undefined,
+          taxId: values.taxId || undefined,
+          customsCode: values.customsCode || undefined,
+          quarantineCode: values.quarantineCode || undefined,
+        };
+
+        if (isEdit) {
+          await updateMutation.mutateAsync(payload);
+        } else {
+          await createMutation.mutateAsync(payload);
+        }
+        return true;
+      }}
+    >
+      <ProCard title="基本信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="name"
+            label="公司名称"
+            placeholder="请输入公司名称"
+            width="md"
+            rules={[
+              { required: true, message: '请输入公司名称' },
+              { max: 200, message: '公司名称最多 200 个字符' },
+            ]}
+          />
+          <ProFormText
+            name="signingLocation"
+            label="签订地点"
+            placeholder="请输入签订地点"
+            width="md"
+            rules={[{ max: 200, message: '签订地点最多 200 个字符' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="银行信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="bankName"
+            label="开户行"
+            placeholder="请输入开户行名称"
+            width="md"
+            rules={[{ max: 200, message: '开户行名称最多 200 个字符' }]}
+          />
+          <ProFormText
+            name="bankAccount"
+            label="银行账号"
+            placeholder="请输入银行账号"
+            width="md"
+            rules={[{ max: 100, message: '银行账号最多 100 个字符' }]}
+          />
+          <ProFormText
+            name="swiftCode"
+            label="SWIFT CODE"
+            placeholder="请输入 SWIFT CODE"
+            width="sm"
+            rules={[{ max: 20, message: 'SWIFT CODE 最多 20 个字符' }]}
+          />
+          <ProFormSelect
+            name="defaultCurrencyCode"
+            label="默认币种"
+            placeholder="请选择默认币种"
+            width="sm"
+            request={fetchCurrencyOptions}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="合规信息" bordered>
+        <ProForm.Group>
+          <ProFormText
+            name="taxId"
+            label="纳税人识别号"
+            placeholder="请输入纳税人识别号"
+            width="md"
+            rules={[{ max: 100, message: '纳税人识别号最多 100 个字符' }]}
+          />
+          <ProFormText
+            name="customsCode"
+            label="海关备案号"
+            placeholder="请输入海关备案号"
+            width="md"
+            rules={[{ max: 100, message: '海关备案号最多 100 个字符' }]}
+          />
+          <ProFormText
+            name="quarantineCode"
+            label="检疫备案号"
+            placeholder="请输入检疫备案号"
+            width="md"
+            rules={[{ max: 100, message: '检疫备案号最多 100 个字符' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+    </ProForm>
+  );
+}

--- a/apps/web/src/pages/master-data/companies/index.tsx
+++ b/apps/web/src/pages/master-data/companies/index.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Empty,
+  Flex,
+  Input,
+  Result,
+  Skeleton,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { getCompanies, type Company } from '../../../api/companies.api';
+
+function useDebouncedValue(input: string, delay = 300) {
+  const [value, setValue] = useState(input);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setValue(input), delay);
+    return () => window.clearTimeout(timer);
+  }, [input, delay]);
+
+  return value;
+}
+
+export default function CompaniesListPage() {
+  const navigate = useNavigate();
+  const { token } = theme.useToken();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters = Boolean(keyword);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword]);
+
+  const query = useQuery({
+    queryKey: ['companies', keyword, page, pageSize],
+    placeholderData: (previousData) => previousData,
+    queryFn: () =>
+      getCompanies({
+        keyword: keyword || undefined,
+        page,
+        pageSize,
+      }),
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载公司主体列表失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const columns: ProColumns<Company>[] = useMemo(
+    () => [
+      {
+        title: '公司名称',
+        dataIndex: 'name',
+        width: 280,
+        ellipsis: true,
+        render: (_, record) => (
+          <Link to={`/master-data/companies/${record.id}`} style={{ color: token.colorLink }}>
+            {record.name}
+          </Link>
+        ),
+      },
+      {
+        title: '签订地点',
+        dataIndex: 'signingLocation',
+        width: 160,
+        ellipsis: true,
+        render: (_, record) =>
+          record.signingLocation ? (
+            <Tooltip title={record.signingLocation}>
+              <Typography.Text ellipsis style={{ maxWidth: 140, display: 'inline-block' }}>
+                {record.signingLocation}
+              </Typography.Text>
+            </Tooltip>
+          ) : (
+            <Typography.Text type="secondary">-</Typography.Text>
+          ),
+      },
+      {
+        title: '默认币种',
+        dataIndex: 'defaultCurrencyCode',
+        width: 120,
+        render: (_, record) =>
+          record.defaultCurrencyCode ? (
+            <Tag>{record.defaultCurrencyCode}</Tag>
+          ) : (
+            <Typography.Text type="secondary">-</Typography.Text>
+          ),
+      },
+      {
+        title: '纳税人识别号',
+        dataIndex: 'taxId',
+        width: 180,
+        ellipsis: true,
+        render: (_, record) => record.taxId || <Typography.Text type="secondary">-</Typography.Text>,
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        width: 140,
+        render: (_, record) => dayjs(record.createdAt).format('YYYY-MM-DD'),
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 160,
+        fixed: 'right',
+        render: (_, record) => (
+          <Space size={12}>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/companies/${record.id}`)}
+            >
+              查看
+            </Button>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/companies/${record.id}/edit`)}
+            >
+              编辑
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [navigate, token.colorLink],
+  );
+
+  const emptyText = hasFilters ? (
+    <Empty description="未找到匹配记录">
+      <Button
+        type="link"
+        onClick={() => {
+          setKeywordInput('');
+          setPage(1);
+        }}
+      >
+        清除筛选条件
+      </Button>
+    </Empty>
+  ) : (
+    <Empty description="暂无数据">
+      <Button type="primary" onClick={() => navigate('/master-data/companies/create')}>
+        新建公司主体
+      </Button>
+    </Empty>
+  );
+
+  const tags = [
+    keyword
+      ? {
+          key: 'keyword',
+          label: `关键词: ${keyword}`,
+          onClose: () => {
+            setKeywordInput('');
+            setPage(1);
+          },
+        }
+      : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          公司主体管理
+        </Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/companies/create')}>
+          新建公司主体
+        </Button>
+      </Flex>
+
+      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
+        <Input
+          placeholder="快捷搜索公司名称"
+          style={{ width: 320 }}
+          value={keywordInput}
+          onChange={(e) => {
+            setKeywordInput(e.target.value);
+            setPage(1);
+          }}
+          allowClear
+        />
+
+        {tags.length > 0 ? (
+          <Space wrap>
+            {tags.map((item) => (
+              <Tag closable key={item.key} onClose={item.onClose}>
+                {item.label}
+              </Tag>
+            ))}
+            <Button
+              type="link"
+              onClick={() => {
+                setKeywordInput('');
+                setPage(1);
+              }}
+            >
+              清除全部
+            </Button>
+          </Space>
+        ) : null}
+      </Space>
+
+      <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
+        <ProTable<Company>
+          search={false}
+          options={false}
+          toolBarRender={false}
+          rowKey="id"
+          loading={query.isFetching}
+          columns={columns}
+          dataSource={query.data?.list ?? []}
+          scroll={{ x: 1060, y: 540 }}
+          rowClassName={() => 'company-row-height'}
+          locale={{ emptyText }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: query.data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
+            showTotal: (total) => `共 ${total} 条记录`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) {
+                setPage(1);
+              } else {
+                setPage(nextPage);
+              }
+              setPageSize(nextPageSize);
+            },
+          }}
+        />
+      </Skeleton>
+
+      <style>{`
+        .company-row-height .ant-table-cell {
+          height: 48px;
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- 新增 `Company` 实体及 TypeORM 迁移（`companies` 表，唯一索引 `idx_companies_name`）
- 后端 NestJS 模块：entity / DTOs / repository / service / controller / module，注册至 `AppModule`
- 前端三页：列表页（ProTable + 关键词搜索）、详情页（ProDescriptions 分组卡片）、表单页（创建/编辑，ProForm + ProCard）
- 4 条路由注册至 `App.tsx`，侧边栏添加"公司主体"导航项
- 单元测试 7/7 通过；TypeScript 编译零错误

## Story

`_bmad-output/implementation-artifacts/2-3-公司主体信息管理.md`

## Test Plan

- [x] 后端单元测试：`apps/api` — 7 tests pass
- [x] TypeScript typecheck：`apps/api` + `apps/web` — 0 errors
- [x] 手动验证：新建 / 编辑 / 查看公司主体，关键词搜索，分页

## Notes

- `defaultCurrencyCode` 存为 `VARCHAR(20)` 软引用，无 FK 约束（解耦 Story 2-2 迁移顺序）
- 前端货币下拉调用 `/api/currencies`，接口不存在时优雅降级为空数组

🤖 Generated with [Claude Code](https://claude.com/claude-code)