### PR TITLE
feat(master-data): Story 3.1 — 三级产品分类管理

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20 (story-2.4-done)
+last_updated: 2026-04-20 (story-3.1-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -68,8 +68,8 @@ development_status:
   # ─────────────────────────────────────────────────
   # Epic 3: 产品体系管理
   # ─────────────────────────────────────────────────
-  epic-3: backlog
-  3-1-三级产品分类管理: backlog
+  epic-3: in-progress
+  3-1-三级产品分类管理: done
   3-2-spu基础信息管理: backlog
   3-3-sku变体管理: backlog
   3-4-产品faq维护: backlog

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { WarehousesModule } from './modules/master-data/warehouses/warehouses.mo
 import { CurrenciesModule } from './modules/master-data/currencies/currencies.module';
 import { CountriesModule } from './modules/master-data/countries/countries.module';
 import { CompaniesModule } from './modules/master-data/companies/companies.module';
+import { ProductCategoriesModule } from './modules/master-data/product-categories/product-categories.module';
 import databaseConfig from './config/database.config';
 
 @Module({
@@ -39,6 +40,7 @@ import databaseConfig from './config/database.config';
     CurrenciesModule,
     CountriesModule,
     CompaniesModule,
+    ProductCategoriesModule,
     FilesModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/migrations/20260420000400-create-product-categories-table.ts
+++ b/apps/api/src/migrations/20260420000400-create-product-categories-table.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateProductCategoriesTable20260420000400 implements MigrationInterface {
+  name = 'CreateProductCategoriesTable20260420000400';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'product_categories',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'name', type: 'varchar', length: '100', isNullable: false },
+          { name: 'parent_id', type: 'bigint', unsigned: true, isNullable: true },
+          { name: 'level', type: 'tinyint', unsigned: true, isNullable: false },
+          { name: 'sort_order', type: 'int', default: '0', isNullable: false },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('product_categories', [
+      new TableIndex({
+        name: 'idx_product_categories_parent_id',
+        columnNames: ['parent_id'],
+      }),
+      new TableIndex({
+        name: 'idx_product_categories_name',
+        columnNames: ['name'],
+        isUnique: true,
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('product_categories');
+  }
+}

--- a/apps/api/src/modules/master-data/product-categories/dto/create-product-category.dto.ts
+++ b/apps/api/src/modules/master-data/product-categories/dto/create-product-category.dto.ts
@@ -1,0 +1,13 @@
+import { IsInt, IsNotEmpty, IsOptional, IsPositive, IsString, MaxLength } from 'class-validator';
+
+export class CreateProductCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsInt()
+  @IsOptional()
+  @IsPositive()
+  parentId?: number;
+}

--- a/apps/api/src/modules/master-data/product-categories/dto/query-product-category.dto.ts
+++ b/apps/api/src/modules/master-data/product-categories/dto/query-product-category.dto.ts
@@ -1,0 +1,10 @@
+import { IsInt, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+
+export class QueryProductCategoryDto extends BaseQueryDto {
+  @IsInt()
+  @IsOptional()
+  @Type(() => Number)
+  parentId?: number;
+}

--- a/apps/api/src/modules/master-data/product-categories/dto/update-product-category.dto.ts
+++ b/apps/api/src/modules/master-data/product-categories/dto/update-product-category.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateProductCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  @IsOptional()
+  name?: string;
+}

--- a/apps/api/src/modules/master-data/product-categories/entities/product-category.entity.ts
+++ b/apps/api/src/modules/master-data/product-categories/entities/product-category.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, Index, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+
+@Entity('product_categories')
+@Index('idx_product_categories_parent_id', ['parentId'])
+@Unique('idx_product_categories_name', ['name'])
+export class ProductCategory extends BaseEntity {
+  @Column({ name: 'name', type: 'varchar', length: 100 })
+  @Expose()
+  name: string;
+
+  @Column({ name: 'parent_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  parentId: number | null;
+
+  @Column({ name: 'level', type: 'tinyint', unsigned: true })
+  @Expose()
+  level: number;
+
+  @Column({ name: 'sort_order', type: 'int', default: 0 })
+  @Expose()
+  sortOrder: number;
+}

--- a/apps/api/src/modules/master-data/product-categories/product-categories.controller.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { ProductCategoriesService } from './product-categories.service';
+import { CreateProductCategoryDto } from './dto/create-product-category.dto';
+import { UpdateProductCategoryDto } from './dto/update-product-category.dto';
+import { QueryProductCategoryDto } from './dto/query-product-category.dto';
+
+@Controller('product-categories')
+export class ProductCategoriesController {
+  constructor(private readonly productCategoriesService: ProductCategoriesService) {}
+
+  @Get('tree')
+  getTree() {
+    return this.productCategoriesService.findTree();
+  }
+
+  @Get()
+  findAll(@Query() query: QueryProductCategoryDto) {
+    return this.productCategoriesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.productCategoriesService.findById(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateProductCategoryDto, @CurrentUser() user: { username?: string }) {
+    return this.productCategoriesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateProductCategoryDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.productCategoriesService.update(id, dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/master-data/product-categories/product-categories.module.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProductCategory } from './entities/product-category.entity';
+import { ProductCategoriesController } from './product-categories.controller';
+import { ProductCategoriesRepository } from './product-categories.repository';
+import { ProductCategoriesService } from './product-categories.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ProductCategory])],
+  controllers: [ProductCategoriesController],
+  providers: [ProductCategoriesRepository, ProductCategoriesService],
+  exports: [ProductCategoriesService],
+})
+export class ProductCategoriesModule {}

--- a/apps/api/src/modules/master-data/product-categories/product-categories.repository.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.repository.ts
@@ -1,0 +1,71 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProductCategory } from './entities/product-category.entity';
+import { QueryProductCategoryDto } from './dto/query-product-category.dto';
+
+export interface ProductCategoryNode extends ProductCategory {
+  children: ProductCategoryNode[];
+}
+
+@Injectable()
+export class ProductCategoriesRepository {
+  constructor(
+    @InjectRepository(ProductCategory)
+    private readonly repo: Repository<ProductCategory>,
+  ) {}
+
+  async findTree(): Promise<ProductCategoryNode[]> {
+    const all = await this.repo.find({ order: { sortOrder: 'ASC', createdAt: 'ASC' } });
+    return this.buildTree(all);
+  }
+
+  private buildTree(items: ProductCategory[], parentId: number | null = null): ProductCategoryNode[] {
+    return items
+      .filter((item) => item.parentId === parentId)
+      .map((item) => ({
+        ...item,
+        children: this.buildTree(items, item.id),
+      }));
+  }
+
+  async findAll(query: QueryProductCategoryDto) {
+    const { keyword, page = 1, pageSize = 20, parentId } = query;
+
+    const qb = this.repo.createQueryBuilder('pc');
+
+    if (keyword) {
+      qb.where('pc.name LIKE :kw', { kw: `%${keyword}%` });
+    }
+
+    if (parentId !== undefined) {
+      qb.andWhere('pc.parent_id = :parentId', { parentId });
+    }
+
+    const [list, total] = await qb
+      .orderBy('pc.sort_order', 'ASC')
+      .addOrderBy('pc.created_at', 'ASC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return { list, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  findById(id: number): Promise<ProductCategory | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  findByName(name: string): Promise<ProductCategory | null> {
+    return this.repo.findOne({ where: { name } });
+  }
+
+  create(data: Partial<ProductCategory>): Promise<ProductCategory> {
+    return this.repo.save(data);
+  }
+
+  async update(id: number, data: Partial<ProductCategory>): Promise<ProductCategory> {
+    await this.repo.update(id, data);
+    return this.repo.findOneOrFail({ where: { id } });
+  }
+}

--- a/apps/api/src/modules/master-data/product-categories/product-categories.service.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.service.ts
@@ -1,0 +1,58 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { ProductCategoriesRepository, ProductCategoryNode } from './product-categories.repository';
+import { CreateProductCategoryDto } from './dto/create-product-category.dto';
+import { UpdateProductCategoryDto } from './dto/update-product-category.dto';
+import { QueryProductCategoryDto } from './dto/query-product-category.dto';
+
+@Injectable()
+export class ProductCategoriesService {
+  constructor(private readonly repo: ProductCategoriesRepository) {}
+
+  findTree(): Promise<ProductCategoryNode[]> {
+    return this.repo.findTree();
+  }
+
+  findAll(query: QueryProductCategoryDto) {
+    return this.repo.findAll(query);
+  }
+
+  async findById(id: number) {
+    const cat = await this.repo.findById(id);
+    if (!cat) throw new NotFoundException('产品分类不存在');
+    return cat;
+  }
+
+  async create(dto: CreateProductCategoryDto, operator?: string) {
+    const dup = await this.repo.findByName(dto.name);
+    if (dup) throw new BadRequestException('分类名称已存在');
+
+    let level = 1;
+    if (dto.parentId) {
+      const parent = await this.repo.findById(dto.parentId);
+      if (!parent) throw new NotFoundException('父级分类不存在');
+      if (parent.level >= 3) throw new BadRequestException('已达最大层级（3级），不能继续添加子分类');
+      level = parent.level + 1;
+    }
+
+    return this.repo.create({
+      name: dto.name,
+      parentId: dto.parentId ?? null,
+      level,
+      sortOrder: 0,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+  }
+
+  async update(id: number, dto: UpdateProductCategoryDto, operator?: string) {
+    const cat = await this.repo.findById(id);
+    if (!cat) throw new NotFoundException('产品分类不存在');
+
+    if (dto.name && dto.name !== cat.name) {
+      const dup = await this.repo.findByName(dto.name);
+      if (dup && dup.id !== id) throw new BadRequestException('分类名称已存在');
+    }
+
+    return this.repo.update(id, { name: dto.name, updatedBy: operator });
+  }
+}

--- a/apps/api/src/modules/master-data/product-categories/tests/product-categories.service.spec.ts
+++ b/apps/api/src/modules/master-data/product-categories/tests/product-categories.service.spec.ts
@@ -1,0 +1,115 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductCategoriesRepository } from '../product-categories.repository';
+import { ProductCategoriesService } from '../product-categories.service';
+
+describe('ProductCategoriesService', () => {
+  let service: ProductCategoriesService;
+
+  const repoMock = {
+    findTree: jest.fn(),
+    findAll: jest.fn(),
+    findById: jest.fn(),
+    findByName: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProductCategoriesService,
+        {
+          provide: ProductCategoriesRepository,
+          useValue: repoMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProductCategoriesService>(ProductCategoriesService);
+    jest.clearAllMocks();
+  });
+
+  it('创建一级分类，level=1', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.create.mockResolvedValue({ id: 1, name: '灯具', parentId: null, level: 1, sortOrder: 0 });
+
+    const result = await service.create({ name: '灯具' }, 'admin');
+
+    expect(result.level).toBe(1);
+    expect(repoMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: '灯具', parentId: null, level: 1 }),
+    );
+  });
+
+  it('创建二级分类（有 parentId），level=2', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.findById.mockResolvedValue({ id: 1, name: '灯具', parentId: null, level: 1 });
+    repoMock.create.mockResolvedValue({ id: 2, name: '户外灯', parentId: 1, level: 2, sortOrder: 0 });
+
+    const result = await service.create({ name: '户外灯', parentId: 1 }, 'admin');
+
+    expect(result.level).toBe(2);
+    expect(repoMock.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: '户外灯', parentId: 1, level: 2 }),
+    );
+  });
+
+  it('创建三级分类（有 parentId），level=3', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.findById.mockResolvedValue({ id: 2, name: '户外灯', parentId: 1, level: 2 });
+    repoMock.create.mockResolvedValue({ id: 3, name: '洗墙灯', parentId: 2, level: 3, sortOrder: 0 });
+
+    const result = await service.create({ name: '洗墙灯', parentId: 2 }, 'admin');
+
+    expect(result.level).toBe(3);
+  });
+
+  it('三级分类下创建子分类 → BadRequestException', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.findById.mockResolvedValue({ id: 3, name: '洗墙灯', parentId: 2, level: 3 });
+
+    await expect(service.create({ name: '子分类', parentId: 3 }, 'admin')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('名称重复 → BadRequestException', async () => {
+    repoMock.findByName.mockResolvedValue({ id: 99, name: '灯具' });
+
+    await expect(service.create({ name: '灯具' }, 'admin')).rejects.toThrow(BadRequestException);
+  });
+
+  it('parentId 不存在 → NotFoundException', async () => {
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.findById.mockResolvedValue(null);
+
+    await expect(service.create({ name: '新分类', parentId: 999 }, 'admin')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('更新名称成功', async () => {
+    repoMock.findById.mockResolvedValue({ id: 1, name: '灯具', level: 1 });
+    repoMock.findByName.mockResolvedValue(null);
+    repoMock.update.mockResolvedValue({ id: 1, name: '照明设备', level: 1 });
+
+    const result = await service.update(1, { name: '照明设备' }, 'admin');
+
+    expect(result.name).toBe('照明设备');
+    expect(repoMock.update).toHaveBeenCalledWith(1, expect.objectContaining({ name: '照明设备', updatedBy: 'admin' }));
+  });
+
+  it('更新名称重复 → BadRequestException', async () => {
+    repoMock.findById.mockResolvedValue({ id: 1, name: '灯具', level: 1 });
+    repoMock.findByName.mockResolvedValue({ id: 2, name: '户外灯' });
+
+    await expect(service.update(1, { name: '户外灯' }, 'admin')).rejects.toThrow(BadRequestException);
+  });
+
+  it('更新不存在分类 → NotFoundException', async () => {
+    repoMock.findById.mockResolvedValue(null);
+
+    await expect(service.update(404, { name: '新名称' }, 'admin')).rejects.toThrow(NotFoundException);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -23,6 +23,8 @@ import CountryFormPage from './pages/master-data/countries/form';
 import CompaniesListPage from './pages/master-data/companies/index';
 import CompanyDetailPage from './pages/master-data/companies/detail';
 import CompanyFormPage from './pages/master-data/companies/form';
+import ProductCategoriesPage from './pages/master-data/product-categories/index';
+import ProductCategoryFormPage from './pages/master-data/product-categories/form';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -116,6 +118,9 @@ function App() {
                 <Route path="/master-data/companies/create" element={<CompanyFormPage />} />
                 <Route path="/master-data/companies/:id" element={<CompanyDetailPage />} />
                 <Route path="/master-data/companies/:id/edit" element={<CompanyFormPage />} />
+                <Route path="/master-data/product-categories" element={<ProductCategoriesPage />} />
+                <Route path="/master-data/product-categories/create" element={<ProductCategoryFormPage />} />
+                <Route path="/master-data/product-categories/:id/edit" element={<ProductCategoryFormPage />} />
               </Route>
 
               {/* 兜底重定向 */}

--- a/apps/web/src/api/product-categories.api.ts
+++ b/apps/web/src/api/product-categories.api.ts
@@ -1,0 +1,68 @@
+import request from './request';
+
+export interface ProductCategory {
+  id: number;
+  name: string;
+  parentId: number | null;
+  level: number;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface ProductCategoryNode extends ProductCategory {
+  children: ProductCategoryNode[];
+}
+
+export interface ProductCategoriesListParams {
+  keyword?: string;
+  page?: number;
+  pageSize?: number;
+  parentId?: number;
+}
+
+export interface ProductCategoriesListData {
+  list: ProductCategory[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateProductCategoryPayload {
+  name: string;
+  parentId?: number;
+}
+
+export interface UpdateProductCategoryPayload {
+  name?: string;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) {
+    throw error;
+  }
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getProductCategoryTree = (): Promise<ProductCategoryNode[]> => {
+  return request.get<any, ProductCategoryNode[]>('/product-categories/tree').catch(normalizeApiError);
+};
+
+export const getProductCategories = (params: ProductCategoriesListParams): Promise<ProductCategoriesListData> => {
+  return request.get<any, ProductCategoriesListData>('/product-categories', { params }).catch(normalizeApiError);
+};
+
+export const getProductCategoryById = (id: number): Promise<ProductCategory> => {
+  return request.get<any, ProductCategory>(`/product-categories/${id}`).catch(normalizeApiError);
+};
+
+export const createProductCategory = (payload: CreateProductCategoryPayload): Promise<ProductCategory> => {
+  return request.post<any, ProductCategory>('/product-categories', payload).catch(normalizeApiError);
+};
+
+export const updateProductCategory = (id: number, payload: UpdateProductCategoryPayload): Promise<ProductCategory> => {
+  return request.patch<any, ProductCategory>(`/product-categories/${id}`, payload).catch(normalizeApiError);
+};

--- a/apps/web/src/pages/master-data/product-categories/form.tsx
+++ b/apps/web/src/pages/master-data/product-categories/form.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Button, Card, Form, Input, message, Skeleton, TreeSelect, Typography } from 'antd';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createProductCategory,
+  getProductCategoryById,
+  getProductCategoryTree,
+  updateProductCategory,
+  type ProductCategoryNode,
+} from '../../../api/product-categories.api';
+
+interface TreeSelectNode {
+  title: string;
+  value: number;
+  selectable: boolean;
+  children?: TreeSelectNode[];
+}
+
+function buildTreeSelectData(nodes: ProductCategoryNode[]): TreeSelectNode[] {
+  return nodes.map((node) => ({
+    title: node.name,
+    value: node.id,
+    selectable: node.level < 3,
+    children: node.children.length > 0 ? buildTreeSelectData(node.children) : undefined,
+  }));
+}
+
+export default function ProductCategoryFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
+  const [searchParams] = useSearchParams();
+  const queryClient = useQueryClient();
+  const [form] = Form.useForm();
+
+  const isEdit = Boolean(id);
+  const parentIdFromQuery = searchParams.get('parentId');
+
+  const treeQuery = useQuery({
+    queryKey: ['product-categories', 'tree'],
+    queryFn: getProductCategoryTree,
+  });
+
+  const detailQuery = useQuery({
+    queryKey: ['product-categories', Number(id)],
+    queryFn: () => getProductCategoryById(Number(id)),
+    enabled: isEdit,
+  });
+
+  useEffect(() => {
+    if (isEdit && detailQuery.data) {
+      form.setFieldsValue({ name: detailQuery.data.name });
+    } else if (!isEdit && parentIdFromQuery) {
+      form.setFieldsValue({ parentId: Number(parentIdFromQuery) });
+    }
+  }, [isEdit, detailQuery.data, parentIdFromQuery, form]);
+
+  const createMutation = useMutation({
+    mutationFn: createProductCategory,
+    onSuccess: () => {
+      message.success('创建成功', 3);
+      queryClient.invalidateQueries({ queryKey: ['product-categories', 'tree'] });
+      navigate('/master-data/product-categories');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ payload }: { payload: { name?: string } }) =>
+      updateProductCategory(Number(id), payload),
+    onSuccess: () => {
+      message.success('保存成功', 3);
+      queryClient.invalidateQueries({ queryKey: ['product-categories', 'tree'] });
+      navigate('/master-data/product-categories');
+    },
+  });
+
+  const loading = isEdit && detailQuery.isLoading;
+  const submitting = createMutation.isPending || updateMutation.isPending;
+
+  const treeSelectData = buildTreeSelectData(treeQuery.data ?? []);
+
+  const handleSubmit = (values: { name: string; parentId?: number }) => {
+    if (isEdit) {
+      updateMutation.mutate({ payload: { name: values.name } });
+    } else {
+      createMutation.mutate({ name: values.name, parentId: values.parentId });
+    }
+  };
+
+  return (
+    <div>
+      <Typography.Title level={3} style={{ marginBottom: 24 }}>
+        {isEdit ? '编辑产品分类' : '新建产品分类'}
+      </Typography.Title>
+
+      <Card style={{ maxWidth: 600 }}>
+        <Skeleton active loading={loading}>
+          <Form form={form} layout="vertical" onFinish={handleSubmit}>
+            <Form.Item
+              label="分类名称"
+              name="name"
+              rules={[
+                { required: true, message: '请输入分类名称' },
+                { max: 100, message: '分类名称不能超过100个字符' },
+              ]}
+            >
+              <Input placeholder="请输入分类名称" />
+            </Form.Item>
+
+            {!isEdit && (
+              <Form.Item label="父级分类" name="parentId">
+                <TreeSelect
+                  placeholder="不选则为一级分类"
+                  allowClear
+                  treeData={treeSelectData}
+                  loading={treeQuery.isLoading}
+                  treeDefaultExpandAll
+                />
+              </Form.Item>
+            )}
+
+            <Form.Item style={{ marginBottom: 0 }}>
+              <Button
+                type="primary"
+                htmlType="submit"
+                loading={submitting}
+                style={{ marginRight: 8 }}
+              >
+                {isEdit ? '保存' : '创建'}
+              </Button>
+              <Button onClick={() => navigate('/master-data/product-categories')}>取消</Button>
+            </Form.Item>
+          </Form>
+        </Skeleton>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/master-data/product-categories/index.tsx
+++ b/apps/web/src/pages/master-data/product-categories/index.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Col,
+  Empty,
+  Flex,
+  Result,
+  Row,
+  Skeleton,
+  Space,
+  Tree,
+  Typography,
+  theme,
+} from 'antd';
+import type { DataNode } from 'antd/es/tree';
+import { useQuery } from '@tanstack/react-query';
+import { getProductCategoryTree, type ProductCategoryNode } from '../../../api/product-categories.api';
+
+function buildTreeData(nodes: ProductCategoryNode[]): DataNode[] {
+  return nodes.map((node) => ({
+    title: node.name,
+    key: node.id,
+    children: node.children.length > 0 ? buildTreeData(node.children) : undefined,
+  }));
+}
+
+function findNodeById(nodes: ProductCategoryNode[], id: number): ProductCategoryNode | null {
+  for (const node of nodes) {
+    if (node.id === id) return node;
+    const found = findNodeById(node.children, id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function buildBreadcrumb(nodes: ProductCategoryNode[], id: number): string {
+  const path: string[] = [];
+
+  function traverse(items: ProductCategoryNode[], targetId: number): boolean {
+    for (const item of items) {
+      if (item.id === targetId) {
+        path.push(item.name);
+        return true;
+      }
+      if (traverse(item.children, targetId)) {
+        path.unshift(item.name);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  traverse(nodes, id);
+  return path.join(' / ');
+}
+
+export default function ProductCategoriesPage() {
+  const navigate = useNavigate();
+  const { token } = theme.useToken();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const query = useQuery({
+    queryKey: ['product-categories', 'tree'],
+    queryFn: getProductCategoryTree,
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载产品分类失败"
+        subTitle="请检查网络或稍后重试"
+        extra={
+          <Button type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>
+        }
+      />
+    );
+  }
+
+  const treeNodes = query.data ?? [];
+  const treeData = buildTreeData(treeNodes);
+  const selectedNode = selectedId ? findNodeById(treeNodes, selectedId) : null;
+  const breadcrumb = selectedId ? buildBreadcrumb(treeNodes, selectedId) : '';
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>
+          产品分类管理
+        </Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/product-categories/create')}>
+          新建一级分类
+        </Button>
+      </Flex>
+
+      <Skeleton active loading={query.isLoading && !query.data}>
+        <Row gutter={token.marginMD} style={{ minHeight: 500 }}>
+          {/* 左侧 Tree 面板 */}
+          <Col
+            span={8}
+            style={{
+              borderRight: `1px solid ${token.colorBorder}`,
+              paddingRight: token.paddingMD,
+            }}
+          >
+            {treeNodes.length === 0 ? (
+              <Empty description="暂无分类">
+                <Button
+                  type="primary"
+                  onClick={() => navigate('/master-data/product-categories/create')}
+                >
+                  新建一级分类
+                </Button>
+              </Empty>
+            ) : (
+              <Tree
+                treeData={treeData}
+                defaultExpandAll
+                selectedKeys={selectedId ? [selectedId] : []}
+                onSelect={(keys) => {
+                  if (keys.length > 0) {
+                    setSelectedId(Number(keys[0]));
+                  } else {
+                    setSelectedId(null);
+                  }
+                }}
+              />
+            )}
+          </Col>
+
+          {/* 右侧详情面板 */}
+          <Col span={16} style={{ paddingLeft: token.paddingMD }}>
+            {!selectedNode ? (
+              <Empty description="请选择左侧分类节点" />
+            ) : (
+              <div>
+                <Typography.Title level={4} style={{ marginTop: 0 }}>
+                  {selectedNode.name}
+                </Typography.Title>
+
+                <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
+                  <div>
+                    <Typography.Text type="secondary">层级路径：</Typography.Text>
+                    <Typography.Text>{breadcrumb}</Typography.Text>
+                  </div>
+
+                  <div>
+                    <Typography.Text type="secondary">下属 SPU 数量：</Typography.Text>
+                    <Typography.Text>0</Typography.Text>
+                  </div>
+
+                  <Space style={{ marginTop: token.marginSM }}>
+                    <Button
+                      onClick={() =>
+                        navigate(`/master-data/product-categories/${selectedNode.id}/edit`)
+                      }
+                    >
+                      编辑
+                    </Button>
+                    <Button
+                      type="dashed"
+                      disabled={selectedNode.level >= 3}
+                      onClick={() =>
+                        navigate(
+                          `/master-data/product-categories/create?parentId=${selectedNode.id}`,
+                        )
+                      }
+                    >
+                      新建子分类
+                    </Button>
+                  </Space>
+                </Space>
+              </div>
+            )}
+          </Col>
+        </Row>
+      </Skeleton>
+    </div>
+  );
+}

--- a/apps/web/src/pages/master-data/product-categories/index.tsx
+++ b/apps/web/src/pages/master-data/product-categories/index.tsx
@@ -20,26 +20,26 @@ import { getProductCategoryTree, type ProductCategoryNode } from '../../../api/p
 function buildTreeData(nodes: ProductCategoryNode[]): DataNode[] {
   return nodes.map((node) => ({
     title: node.name,
-    key: node.id,
+    key: String(node.id),
     children: node.children.length > 0 ? buildTreeData(node.children) : undefined,
   }));
 }
 
-function findNodeById(nodes: ProductCategoryNode[], id: number): ProductCategoryNode | null {
+function findNodeById(nodes: ProductCategoryNode[], id: string): ProductCategoryNode | null {
   for (const node of nodes) {
-    if (node.id === id) return node;
+    if (String(node.id) === id) return node;
     const found = findNodeById(node.children, id);
     if (found) return found;
   }
   return null;
 }
 
-function buildBreadcrumb(nodes: ProductCategoryNode[], id: number): string {
+function buildBreadcrumb(nodes: ProductCategoryNode[], id: string): string {
   const path: string[] = [];
 
-  function traverse(items: ProductCategoryNode[], targetId: number): boolean {
+  function traverse(items: ProductCategoryNode[], targetId: string): boolean {
     for (const item of items) {
-      if (item.id === targetId) {
+      if (String(item.id) === targetId) {
         path.push(item.name);
         return true;
       }
@@ -58,7 +58,7 @@ function buildBreadcrumb(nodes: ProductCategoryNode[], id: number): string {
 export default function ProductCategoriesPage() {
   const navigate = useNavigate();
   const { token } = theme.useToken();
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const query = useQuery({
     queryKey: ['product-categories', 'tree'],
@@ -122,7 +122,7 @@ export default function ProductCategoriesPage() {
                 selectedKeys={selectedId ? [selectedId] : []}
                 onSelect={(keys) => {
                   if (keys.length > 0) {
-                    setSelectedId(Number(keys[0]));
+                    setSelectedId(String(keys[0]));
                   } else {
                     setSelectedId(null);
                   }


### PR DESCRIPTION
## Summary

- 实现三级产品分类树形结构管理（最多3级，自引用 parent_id）
- 后端 `GET /product-categories/tree` 端点返回完整嵌套树（内存组装，无 N+1）
- Service 层自动计算 level、校验最大层级、全局名称唯一性
- 前端双面板布局：左侧 antd Tree + 右侧详情面板
- 表单页支持新建/编辑，TreeSelect 中三级节点不可选作为父级

## Test plan

- [x] 后端 Service 单元测试 9 个全部通过
- [x] 后端 TypeScript 编译无错误
- [x] 前端 TypeScript 编译无错误
- [x] `GET /api/v1/product-categories/tree` 返回正确嵌套结构
- [x] `POST /api/v1/product-categories` 正确计算并存储 level
- [x] 在 level=3 节点下创建子分类返回 400
- [x] 前端 Tree 选中节点显示详情（名称、层级路径、SPU 数量）
- [x] 表单新建一级/子分类正常工作，提交后树刷新
- [x] 编辑分类名称正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
