### PR TITLE
feat(product-categories): CC补丁 — 补充英文名/分类编号/采购负责人/产品负责人字段

### DIFF
--- a/apps/api/src/migrations/20260420000401-add-fields-to-product-categories.ts
+++ b/apps/api/src/migrations/20260420000401-add-fields-to-product-categories.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddFieldsToProductCategories20260420000401 implements MigrationInterface {
+  name = 'AddFieldsToProductCategories20260420000401';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('product_categories', [
+      new TableColumn({ name: 'name_en', type: 'varchar', length: '100', isNullable: true, after: 'name' }),
+      new TableColumn({ name: 'code', type: 'varchar', length: '20', isNullable: true, after: 'name_en' }),
+      new TableColumn({ name: 'purchase_owner', type: 'varchar', length: '100', isNullable: true, after: 'sort_order' }),
+      new TableColumn({ name: 'product_owner', type: 'varchar', length: '100', isNullable: true, after: 'purchase_owner' }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('product_categories', 'product_owner');
+    await queryRunner.dropColumn('product_categories', 'purchase_owner');
+    await queryRunner.dropColumn('product_categories', 'code');
+    await queryRunner.dropColumn('product_categories', 'name_en');
+  }
+}

--- a/apps/api/src/migrations/20260420000401-add-fields-to-product-categories.ts
+++ b/apps/api/src/migrations/20260420000401-add-fields-to-product-categories.ts
@@ -5,10 +5,10 @@ export class AddFieldsToProductCategories20260420000401 implements MigrationInte
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumns('product_categories', [
-      new TableColumn({ name: 'name_en', type: 'varchar', length: '100', isNullable: true, after: 'name' }),
-      new TableColumn({ name: 'code', type: 'varchar', length: '20', isNullable: true, after: 'name_en' }),
-      new TableColumn({ name: 'purchase_owner', type: 'varchar', length: '100', isNullable: true, after: 'sort_order' }),
-      new TableColumn({ name: 'product_owner', type: 'varchar', length: '100', isNullable: true, after: 'purchase_owner' }),
+      new TableColumn({ name: 'name_en', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'code', type: 'varchar', length: '20', isNullable: true }),
+      new TableColumn({ name: 'purchase_owner', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'product_owner', type: 'varchar', length: '100', isNullable: true }),
     ]);
   }
 

--- a/apps/api/src/modules/master-data/product-categories/dto/create-product-category.dto.ts
+++ b/apps/api/src/modules/master-data/product-categories/dto/create-product-category.dto.ts
@@ -6,8 +6,23 @@ export class CreateProductCategoryDto {
   @MaxLength(100)
   name: string;
 
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  nameEn?: string;
+
   @IsInt()
   @IsOptional()
   @IsPositive()
   parentId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  purchaseOwner?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  productOwner?: string;
 }

--- a/apps/api/src/modules/master-data/product-categories/dto/update-product-category.dto.ts
+++ b/apps/api/src/modules/master-data/product-categories/dto/update-product-category.dto.ts
@@ -6,4 +6,19 @@ export class UpdateProductCategoryDto {
   @MaxLength(100)
   @IsOptional()
   name?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  nameEn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  purchaseOwner?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  productOwner?: string;
 }

--- a/apps/api/src/modules/master-data/product-categories/entities/product-category.entity.ts
+++ b/apps/api/src/modules/master-data/product-categories/entities/product-category.entity.ts
@@ -10,6 +10,14 @@ export class ProductCategory extends BaseEntity {
   @Expose()
   name: string;
 
+  @Column({ name: 'name_en', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  nameEn: string | null;
+
+  @Column({ name: 'code', type: 'varchar', length: 20, nullable: true })
+  @Expose()
+  code: string | null;
+
   @Column({ name: 'parent_id', type: 'bigint', unsigned: true, nullable: true })
   @Expose()
   parentId: number | null;
@@ -21,4 +29,12 @@ export class ProductCategory extends BaseEntity {
   @Column({ name: 'sort_order', type: 'int', default: 0 })
   @Expose()
   sortOrder: number;
+
+  @Column({ name: 'purchase_owner', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  purchaseOwner: string | null;
+
+  @Column({ name: 'product_owner', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  productOwner: string | null;
 }

--- a/apps/api/src/modules/master-data/product-categories/product-categories.repository.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.repository.ts
@@ -60,6 +60,22 @@ export class ProductCategoriesRepository {
     return this.repo.findOne({ where: { name } });
   }
 
+  async generateCode(): Promise<string> {
+    const result = await this.repo
+      .createQueryBuilder('pc')
+      .select('MAX(pc.code)', 'maxCode')
+      .where('pc.code LIKE :prefix', { prefix: 'CPDL%' })
+      .getRawOne<{ maxCode: string | null }>();
+
+    const maxCode = result?.maxCode;
+    let nextSeq = 1;
+    if (maxCode) {
+      const num = parseInt(maxCode.replace('CPDL', ''), 10);
+      if (!isNaN(num)) nextSeq = num + 1;
+    }
+    return `CPDL${String(nextSeq).padStart(3, '0')}`;
+  }
+
   create(data: Partial<ProductCategory>): Promise<ProductCategory> {
     return this.repo.save(data);
   }

--- a/apps/api/src/modules/master-data/product-categories/product-categories.service.ts
+++ b/apps/api/src/modules/master-data/product-categories/product-categories.service.ts
@@ -34,11 +34,17 @@ export class ProductCategoriesService {
       level = parent.level + 1;
     }
 
+    const code = await this.repo.generateCode();
+
     return this.repo.create({
       name: dto.name,
+      nameEn: dto.nameEn ?? null,
+      code,
       parentId: dto.parentId ?? null,
       level,
       sortOrder: 0,
+      purchaseOwner: dto.purchaseOwner ?? null,
+      productOwner: dto.productOwner ?? null,
       createdBy: operator,
       updatedBy: operator,
     });
@@ -53,6 +59,12 @@ export class ProductCategoriesService {
       if (dup && dup.id !== id) throw new BadRequestException('分类名称已存在');
     }
 
-    return this.repo.update(id, { name: dto.name, updatedBy: operator });
+    return this.repo.update(id, {
+      name: dto.name,
+      nameEn: dto.nameEn,
+      purchaseOwner: dto.purchaseOwner,
+      productOwner: dto.productOwner,
+      updatedBy: operator,
+    });
   }
 }

--- a/apps/web/src/api/product-categories.api.ts
+++ b/apps/web/src/api/product-categories.api.ts
@@ -3,9 +3,13 @@ import request from './request';
 export interface ProductCategory {
   id: number;
   name: string;
+  nameEn: string | null;
+  code: string | null;
   parentId: number | null;
   level: number;
   sortOrder: number;
+  purchaseOwner: string | null;
+  productOwner: string | null;
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
@@ -33,11 +37,17 @@ export interface ProductCategoriesListData {
 
 export interface CreateProductCategoryPayload {
   name: string;
+  nameEn?: string;
   parentId?: number;
+  purchaseOwner?: string;
+  productOwner?: string;
 }
 
 export interface UpdateProductCategoryPayload {
   name?: string;
+  nameEn?: string;
+  purchaseOwner?: string;
+  productOwner?: string;
 }
 
 function normalizeApiError(error: unknown): never {

--- a/apps/web/src/pages/master-data/product-categories/form.tsx
+++ b/apps/web/src/pages/master-data/product-categories/form.tsx
@@ -49,7 +49,12 @@ export default function ProductCategoryFormPage() {
 
   useEffect(() => {
     if (isEdit && detailQuery.data) {
-      form.setFieldsValue({ name: detailQuery.data.name });
+      form.setFieldsValue({
+        name: detailQuery.data.name,
+        nameEn: detailQuery.data.nameEn ?? undefined,
+        purchaseOwner: detailQuery.data.purchaseOwner ?? undefined,
+        productOwner: detailQuery.data.productOwner ?? undefined,
+      });
     } else if (!isEdit && parentIdFromQuery) {
       form.setFieldsValue({ parentId: Number(parentIdFromQuery) });
     }
@@ -65,7 +70,7 @@ export default function ProductCategoryFormPage() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ payload }: { payload: { name?: string } }) =>
+    mutationFn: ({ payload }: { payload: { name?: string; nameEn?: string; purchaseOwner?: string; productOwner?: string } }) =>
       updateProductCategory(Number(id), payload),
     onSuccess: () => {
       message.success('保存成功', 3);
@@ -79,11 +84,24 @@ export default function ProductCategoryFormPage() {
 
   const treeSelectData = buildTreeSelectData(treeQuery.data ?? []);
 
-  const handleSubmit = (values: { name: string; parentId?: number }) => {
+  const handleSubmit = (values: { name: string; nameEn?: string; parentId?: number; purchaseOwner?: string; productOwner?: string }) => {
     if (isEdit) {
-      updateMutation.mutate({ payload: { name: values.name } });
+      updateMutation.mutate({
+        payload: {
+          name: values.name,
+          nameEn: values.nameEn,
+          purchaseOwner: values.purchaseOwner,
+          productOwner: values.productOwner,
+        },
+      });
     } else {
-      createMutation.mutate({ name: values.name, parentId: values.parentId });
+      createMutation.mutate({
+        name: values.name,
+        nameEn: values.nameEn,
+        parentId: values.parentId,
+        purchaseOwner: values.purchaseOwner,
+        productOwner: values.productOwner,
+      });
     }
   };
 
@@ -107,6 +125,14 @@ export default function ProductCategoryFormPage() {
               <Input placeholder="请输入分类名称" />
             </Form.Item>
 
+            <Form.Item
+              label="英文名"
+              name="nameEn"
+              rules={[{ max: 100, message: '英文名不能超过100个字符' }]}
+            >
+              <Input placeholder="请输入英文名（可选）" />
+            </Form.Item>
+
             {!isEdit && (
               <Form.Item label="父级分类" name="parentId">
                 <TreeSelect
@@ -118,6 +144,22 @@ export default function ProductCategoryFormPage() {
                 />
               </Form.Item>
             )}
+
+            <Form.Item
+              label="采购负责人"
+              name="purchaseOwner"
+              rules={[{ max: 100, message: '采购负责人不能超过100个字符' }]}
+            >
+              <Input placeholder="请输入采购负责人（可选）" />
+            </Form.Item>
+
+            <Form.Item
+              label="产品负责人"
+              name="productOwner"
+              rules={[{ max: 100, message: '产品负责人不能超过100个字符' }]}
+            >
+              <Input placeholder="请输入产品负责人（可选）" />
+            </Form.Item>
 
             <Form.Item style={{ marginBottom: 0 }}>
               <Button

--- a/apps/web/src/pages/master-data/product-categories/index.tsx
+++ b/apps/web/src/pages/master-data/product-categories/index.tsx
@@ -147,6 +147,34 @@ export default function ProductCategoriesPage() {
                     <Typography.Text>{breadcrumb}</Typography.Text>
                   </div>
 
+                  {selectedNode.code && (
+                    <div>
+                      <Typography.Text type="secondary">分类编号：</Typography.Text>
+                      <Typography.Text>{selectedNode.code}</Typography.Text>
+                    </div>
+                  )}
+
+                  {selectedNode.nameEn && (
+                    <div>
+                      <Typography.Text type="secondary">英文名：</Typography.Text>
+                      <Typography.Text>{selectedNode.nameEn}</Typography.Text>
+                    </div>
+                  )}
+
+                  {selectedNode.purchaseOwner && (
+                    <div>
+                      <Typography.Text type="secondary">采购负责人：</Typography.Text>
+                      <Typography.Text>{selectedNode.purchaseOwner}</Typography.Text>
+                    </div>
+                  )}
+
+                  {selectedNode.productOwner && (
+                    <div>
+                      <Typography.Text type="secondary">产品负责人：</Typography.Text>
+                      <Typography.Text>{selectedNode.productOwner}</Typography.Text>
+                    </div>
+                  )}
+
                   <div>
                     <Typography.Text type="secondary">下属 SPU 数量：</Typography.Text>
                     <Typography.Text>0</Typography.Text>


### PR DESCRIPTION
## Summary

- 后端新增 `name_en`、`code`、`purchase_owner`、`product_owner` 四个字段（Entity + Migration）
- `code` 在创建时由后端自动生成，格式为 `CPDL001`、`CPDL002`...（Repository `generateCode()`）
- Service/DTO 支持新字段的创建与更新
- 前端表单新增英文名、采购负责人、产品负责人输入项
- 右侧详情面板展示分类编号、英文名、采购负责人、产品负责人

## Test plan

- [x] 新建分类，确认 `code` 自动生成（CPDL001 起） ✅ 已验证（示例：`CPDL002`）
- [x] 编辑分类，确认可修改英文名、采购负责人、产品负责人 ✅ 已验证
- [x] 右侧详情面板各字段正常展示 ✅ 已通过接口字段回归验证（tree/detail 返回正确）
- [x] 后端 TypeScript 编译无报错 ✅ 通过（`pnpm --filter api build`）
- [x] 前端 TypeScript 编译无报错 ✅ 通过（`pnpm --filter web build`）

## Validation notes (local, 2026-04-20)

- 已使用用户提供的数据库配置完成本地验证
- 数据库连通性验证通过（`SELECT 1`）
- 阻断问题已修复：migration 不再使用不兼容 `after` 选项
- 本次回归中 PR 测试项全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
