### PR TITLE
feat(master-data): Story 2-2b — 币种字段补全（CC 补丁）

### DIFF
--- a/_bmad-output/implementation-artifacts/2-2b-币种字段补全-cc补丁.md
+++ b/_bmad-output/implementation-artifacts/2-2b-币种字段补全-cc补丁.md
@@ -1,0 +1,561 @@
+# Story 2-2b: 币种字段补全（CC 补丁）
+
+Status: done
+
+## Story
+
+As a 系统管理员,
+I want 币种记录能完整记录币种符号和本位币标识,
+So that 后续财务模块、销售订单、采购订单可引用带符号的完整币种信息，并明确系统本位币。
+
+> **背景**：Story 2-2 实现币种模块时，后端 Entity / Migration / 前端表单仅包含 `code`、`name`、`status` 三个字段，
+> 未对照 `docs/系统模块对应字段清单.md` 币种信息管理表单（FormUUID: FORM-6E10CA4B09EE422F9EE38350C2F85B06PZNB）。
+> 本 Story 为纯字段补丁，**不新增 API 端点，不改变现有路由结构**，只在已有币种模块的各层追加 2 个字段，
+> 并在 Service 层增加"本位币互斥"业务约束。
+
+---
+
+## Acceptance Criteria
+
+**Given** 管理员进入新建/编辑币种表单
+**When** 填写币种信息提交
+**Then** 可选填币种符号（symbol，如 $、¥、€，最多 10 个字符）
+**And** 可切换是否本位币（isBaseCurrency）开关，tooltip 提示"同一时间只能有一种本位币"
+
+**Given** 某币种被设置为本位币（isBaseCurrency = 1）
+**When** 调用 create 或 update 接口且 isBaseCurrency = 1
+**Then** Service 层先将所有其他记录的 is_base_currency 置为 0，再将当前记录设为 1
+**And** 同一时刻数据库中有且仅有一条 is_base_currency = 1 的记录
+
+**Given** 管理员查看币种列表页
+**When** 某条币种记录的 isBaseCurrency = 1
+**Then** 列表该行展示蓝色"本位币"Tag（ant design `processing` 状态）
+
+**Given** 管理员查看币种详情页
+**When** 币种记录包含 symbol 或 isBaseCurrency 数据
+**Then** 详情页正确展示币种符号和本位币状态
+
+**Given** 数据库已运行 Story 2-2 的 Migration
+**When** 执行本补丁 Migration
+**Then** `currencies` 表新增 2 列，现有数据不受影响（symbol 为 NULL，is_base_currency 默认 0）
+
+**Given** 开发者运行 TypeScript 编译
+**When** Entity / DTO / 前端 API 层包含全部新字段
+**Then** `tsc --noEmit` 零报错
+
+---
+
+## Tasks / Subtasks
+
+### 1. 后端：Entity 追加字段
+
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/entities/currency.entity.ts`
+  - 追加 `symbol` 和 `isBaseCurrency` 两个字段（见下方"字段清单"）
+
+### 2. 后端：Migration
+
+- [ ] 创建 `apps/api/src/migrations/20260420001100-alter-currencies-add-fields.ts`
+  - `up()`: ALTER TABLE currencies ADD COLUMN symbol / is_base_currency
+  - `down()`: ALTER TABLE currencies DROP COLUMN（逆序）
+
+### 3. 后端：DTO 更新
+
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts`
+  - 追加 `symbol`（可选）和 `isBaseCurrency`（可选，默认 0）
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts`
+  - 同步追加相同字段（全部 optional）
+
+### 4. 后端：Repository 追加方法
+
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/currencies.repository.ts`
+  - 追加 `clearBaseCurrency()` 方法（将所有记录的 isBaseCurrency 置为 0）
+
+### 5. 后端：Service 追加互斥逻辑
+
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/currencies.service.ts`
+  - `create()` 方法：若 `dto.isBaseCurrency === 1`，先调用 `clearBaseCurrency()`
+  - `update()` 方法：若 `dto.isBaseCurrency === 1`，先调用 `clearBaseCurrency()`
+
+### 6. 前端：API 层更新
+
+- [ ] 编辑 `apps/web/src/api/currencies.api.ts`
+  - `Currency` 接口追加 `symbol` 和 `isBaseCurrency` 字段
+  - `CreateCurrencyPayload` 追加可选字段
+  - `UpdateCurrencyPayload` 追加可选字段
+
+### 7. 前端：表单页更新
+
+- [ ] 编辑 `apps/web/src/pages/master-data/currencies/form.tsx`
+  - 追加 `symbol`（ProFormText）和 `isBaseCurrency`（ProFormSwitch）控件
+  - initialValues 包含新字段（编辑时回填）
+  - onFinish payload 包含新字段
+
+### 8. 前端：列表页更新
+
+- [ ] 编辑 `apps/web/src/pages/master-data/currencies/index.tsx`
+  - 在"币种名称"列之后追加"本位币"列，isBaseCurrency = 1 时展示蓝色 `<Tag color="processing">本位币</Tag>`
+
+### 9. 前端：详情页更新
+
+- [ ] 编辑 `apps/web/src/pages/master-data/currencies/detail.tsx`
+  - ProDescriptions columns 追加 `symbol` 和 `isBaseCurrency` 展示项
+
+### 10. 测试更新
+
+- [ ] 编辑 `apps/api/src/modules/master-data/currencies/tests/currencies.service.spec.ts`
+  - 补充测试：设置本位币时自动清除其他记录的 isBaseCurrency
+  - 补充测试：create 时 isBaseCurrency 默认为 0
+
+---
+
+## Dev Agent Context
+
+### 关键约束（严格遵守）
+
+- **这是纯补丁 Story，禁止新增 API 端点或修改路由结构**
+- **禁止修改 AppModule、Sidebar.tsx、App.tsx**（币种模块已注册）
+- **每个新字段必须同时加 `@Expose()` 和 `@Column({ name: 'snake_case' })`**
+- **Migration 必须包含 down() 方法**（DROP COLUMN 逆序）
+- **本位币互斥逻辑必须在 Service 层实现**，不能依赖前端
+- **`clearBaseCurrency()` 必须在同一次操作中（同一请求）完成 clear → set，避免并发问题**
+
+### 字段清单（Entity 追加）
+
+完整的 `currency.entity.ts` 追加内容（在 `deletedAt` 之前插入）：
+
+```typescript
+// apps/api/src/modules/master-data/currencies/entities/currency.entity.ts
+// 在 status 字段之后、@DeleteDateColumn 之前插入：
+
+@Column({ name: 'symbol', type: 'varchar', length: 10, nullable: true })
+@Expose()
+symbol: string | null;
+
+@Column({ name: 'is_base_currency', type: 'tinyint', width: 1, default: 0 })
+@Expose()
+isBaseCurrency: number;
+```
+
+> **注意**：`is_base_currency` 使用 `tinyint width: 1` 与已有的 `is_virtual` 字段（Story 2-2a）保持一致。
+
+### Migration 文件完整规范
+
+```typescript
+// 文件名：apps/api/src/migrations/20260420001100-alter-currencies-add-fields.ts
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterCurrenciesAddFields20260420001100 implements MigrationInterface {
+  name = 'AlterCurrenciesAddFields20260420001100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`currencies\`
+        ADD COLUMN \`symbol\`           varchar(10) NULL     COMMENT '币种符号（如 $、¥、€）',
+        ADD COLUMN \`is_base_currency\` tinyint(1)  NOT NULL DEFAULT 0 COMMENT '是否本位币'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`currencies\`
+        DROP COLUMN \`is_base_currency\`,
+        DROP COLUMN \`symbol\`
+    `);
+  }
+}
+```
+
+### DTO 追加内容
+
+```typescript
+// create-currency.dto.ts 追加（在现有字段之后）：
+import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+@IsString()
+@IsOptional()
+@MaxLength(10)
+symbol?: string;
+
+@IsInt()
+@Min(0)
+@Max(1)
+@IsOptional()
+isBaseCurrency?: number;   // 0 = 否, 1 = 是，默认 0
+```
+
+`update-currency.dto.ts` 同步追加相同两个字段（全部 optional）。
+
+### Repository 追加方法
+
+```typescript
+// currencies.repository.ts 追加方法：
+async clearBaseCurrency(): Promise<void> {
+  await this.repo.update({}, { isBaseCurrency: 0 });
+}
+```
+
+> **注意**：`repo.update({}, ...)` 会更新所有记录，TypeORM 会生成 `UPDATE currencies SET is_base_currency = 0`（无 WHERE 条件）。
+> 这是本业务约束的正确实现：设置新本位币前，先清除全部。
+
+### Service 互斥逻辑（完整 create/update 方法）
+
+```typescript
+// currencies.service.ts 完整更新
+
+async create(dto: CreateCurrencyDto, operator?: string) {
+  const duplicate = await this.currenciesRepository.findByCode(dto.code);
+  if (duplicate) {
+    throw new BadRequestException('币种代码已存在');
+  }
+
+  // 本位币互斥：若新币种设为本位币，先清除其他记录
+  if (dto.isBaseCurrency === 1) {
+    await this.currenciesRepository.clearBaseCurrency();
+  }
+
+  return this.currenciesRepository.create({
+    code: dto.code,
+    name: dto.name,
+    status: CurrencyStatus.ACTIVE,
+    symbol: dto.symbol ?? null,
+    isBaseCurrency: dto.isBaseCurrency ?? 0,
+    createdBy: operator,
+    updatedBy: operator,
+  });
+}
+
+async update(id: number, dto: UpdateCurrencyDto, operator?: string) {
+  const currency = await this.currenciesRepository.findById(id);
+  if (!currency) {
+    throw new NotFoundException('币种不存在');
+  }
+
+  if (dto.code && dto.code !== currency.code) {
+    const duplicate = await this.currenciesRepository.findByCode(dto.code);
+    if (duplicate && duplicate.id !== id) {
+      throw new BadRequestException('币种代码已存在');
+    }
+  }
+
+  // 本位币互斥：若将当前币种设为本位币，先清除其他记录
+  if (dto.isBaseCurrency === 1) {
+    await this.currenciesRepository.clearBaseCurrency();
+  }
+
+  return this.currenciesRepository.update(id, {
+    ...dto,
+    updatedBy: operator,
+  });
+}
+```
+
+### 前端 API 层更新（currencies.api.ts）
+
+```typescript
+// Currency interface 追加：
+export interface Currency {
+  id: number;
+  code: string;
+  name: string;
+  status: CurrencyStatus;
+  // 新增字段
+  symbol?: string | null;
+  isBaseCurrency?: number;   // 0 | 1
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+// CreateCurrencyPayload 追加（全部 optional）：
+export interface CreateCurrencyPayload {
+  code: string;
+  name: string;
+  symbol?: string;
+  isBaseCurrency?: number;
+}
+
+// UpdateCurrencyPayload 追加：
+export interface UpdateCurrencyPayload {
+  code?: string;
+  name?: string;
+  status?: CurrencyStatus;
+  symbol?: string;
+  isBaseCurrency?: number;
+}
+```
+
+### 前端控件规范（form.tsx 追加）
+
+所有新字段追加在现有 `name` 字段之后、`status` ProFormSelect 之前：
+
+```tsx
+// 导入追加：
+import { ProForm, ProFormSelect, ProFormSwitch, ProFormText } from '@ant-design/pro-components';
+
+// 1. 币种符号（可选文本）
+<ProFormText
+  name="symbol"
+  label="币种符号"
+  placeholder="如：$、¥、€（可选，最多 10 个字符）"
+  rules={[{ max: 10, message: '币种符号最多 10 个字符' }]}
+/>
+
+// 2. 是否本位币（Switch，默认关闭）
+<ProFormSwitch
+  name="isBaseCurrency"
+  label="是否本位币"
+  tooltip="同一时间只能有一种本位币，开启后将自动取消其他币种的本位币状态"
+  fieldProps={{
+    checkedChildren: '是',
+    unCheckedChildren: '否',
+  }}
+/>
+```
+
+**initialValues 更新（编辑模式回填）：**
+
+```typescript
+initialValues={
+  detailQuery.data
+    ? {
+        code: detailQuery.data.code,
+        name: detailQuery.data.name,
+        status: detailQuery.data.status,
+        // 新增字段
+        symbol: detailQuery.data.symbol ?? undefined,
+        isBaseCurrency: Boolean(detailQuery.data.isBaseCurrency),
+      }
+    : {}
+}
+```
+
+**onFinish payload 更新：**
+
+```typescript
+onFinish={async (values) => {
+  if (isEdit) {
+    await updateMutation.mutateAsync({
+      code: values.code,
+      name: values.name,
+      status: values.status,
+      symbol: values.symbol || undefined,
+      isBaseCurrency: values.isBaseCurrency ? 1 : 0,
+    });
+  } else {
+    await createMutation.mutateAsync({
+      code: values.code,
+      name: values.name,
+      symbol: values.symbol || undefined,
+      isBaseCurrency: values.isBaseCurrency ? 1 : 0,
+    });
+  }
+  return true;
+}}
+```
+
+> **ProForm 类型声明更新**：`ProForm<{ code: string; name: string; status?: CurrencyStatus; symbol?: string; isBaseCurrency?: boolean }>` （isBaseCurrency 在表单层为 boolean，onFinish 中转换为 0/1 再传给后端）
+
+### 前端列表页追加（index.tsx）
+
+在"币种名称"列（`dataIndex: 'name'`）之后、"状态"列之前，插入"本位币"列：
+
+```tsx
+// 在 columns 数组中，name 列之后插入：
+{
+  title: '本位币',
+  dataIndex: 'isBaseCurrency',
+  width: 100,
+  render: (_, record) =>
+    record.isBaseCurrency === 1 ? (
+      <Tag color="processing">本位币</Tag>
+    ) : null,
+},
+```
+
+> **导入确认**：`Tag` 已在现有 import 中（`import { ..., Tag, ... } from 'antd'`），无需重复导入。
+
+### 前端详情页追加（detail.tsx）
+
+在 `columns` 数组中，`name` 相关项之后追加：
+
+```typescript
+// columns 数组追加（在 createdAt 之前插入）：
+{
+  title: '币种符号',
+  dataIndex: 'symbol',
+  span: 1,
+  renderText: (value: string | null) => value || '-',
+},
+{
+  title: '本位币',
+  dataIndex: 'isBaseCurrency',
+  span: 1,
+  render: (_: unknown, record: Currency) =>
+    record.isBaseCurrency === 1 ? (
+      <Tag color="processing">本位币</Tag>
+    ) : (
+      <span>-</span>
+    ),
+},
+```
+
+> **注意**：`Tag` 已在 `detail.tsx` 现有 import 中引入（`import { ..., Tag, ... } from 'antd'`）。
+
+### 已知文件位置（不得误建）
+
+| 文件 | 当前状态 |
+|------|---------|
+| `apps/api/src/modules/master-data/currencies/entities/currency.entity.ts` | 存在，追加 2 个字段 |
+| `apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts` | 存在，追加 2 个字段 |
+| `apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts` | 存在，追加 2 个字段 |
+| `apps/api/src/modules/master-data/currencies/currencies.repository.ts` | 存在，追加 clearBaseCurrency() |
+| `apps/api/src/modules/master-data/currencies/currencies.service.ts` | 存在，更新 create() / update() |
+| `apps/web/src/api/currencies.api.ts` | 存在，追加类型 |
+| `apps/web/src/pages/master-data/currencies/form.tsx` | 存在，追加控件 |
+| `apps/web/src/pages/master-data/currencies/index.tsx` | 存在，追加本位币列 |
+| `apps/web/src/pages/master-data/currencies/detail.tsx` | 存在，追加展示项 |
+
+### 须创建的新文件
+
+| 文件 | 说明 |
+|------|------|
+| `apps/api/src/migrations/20260420001100-alter-currencies-add-fields.ts` | 新建 Migration |
+
+### 与 Story 2-2a 的差异（避免混淆）
+
+| 维度 | Story 2-2a（仓库） | Story 2-2b（币种）|
+|------|-------------------|------------------|
+| 补丁字段数 | 8 个 | 2 个 |
+| 新建枚举 | WarehouseType / WarehouseOwnership | 无 |
+| 特殊业务逻辑 | 供应商字段暂禁用 / 省市 Cascader | 本位币互斥（clearBaseCurrency） |
+| Migration 文件名 | `20260420001000-...` | `20260420001100-...` |
+| 列表页变更 | 无 | 新增"本位币"Tag 列 |
+
+### 已知 Bug 规避（来自 Story 2-2 / 2-2a 历史）
+
+| 序号 | 问题 | 正确做法 |
+|------|------|---------|
+| 1 | `list` vs `data` 字段名混淆 | Repository 始终返回 `list`，前端 interface 也用 `list` |
+| 2 | `id` 定义为 `string` | id 必须是 `number` |
+| 3 | API 函数缺少 `.catch(normalizeApiError)` | 所有 API 函数末尾必须有 catch |
+| 4 | Migration 缺少 `down()` | **必须实现 down() DROP COLUMN**（逆序执行） |
+| 5 | 前端表单缺字段验证 | text 字段加 `rules: [{ max }]` |
+
+### 测试用例规范（currencies.service.spec.ts 追加）
+
+```typescript
+// mockCurrency 更新（补充新字段）：
+const mockCurrency: Currency = {
+  id: 1,
+  code: 'USD',
+  name: '美元',
+  status: CurrencyStatus.ACTIVE,
+  symbol: '$',
+  isBaseCurrency: 0,
+  deletedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'admin',
+  updatedBy: 'admin',
+};
+
+// mockRepo 追加：
+const mockRepo = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  findByCode: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  clearBaseCurrency: jest.fn(),  // 新增
+};
+
+// 新增测试用例：
+describe('create - 本位币互斥', () => {
+  it('isBaseCurrency=1 时应先调用 clearBaseCurrency 再创建', async () => {
+    const dto: CreateCurrencyDto = { code: 'CNY', name: '人民币', isBaseCurrency: 1 };
+    mockRepo.findByCode.mockResolvedValue(null);
+    mockRepo.clearBaseCurrency.mockResolvedValue(undefined);
+    mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'CNY', isBaseCurrency: 1 });
+
+    await service.create(dto, 'admin');
+    expect(mockRepo.clearBaseCurrency).toHaveBeenCalledTimes(1);
+    expect(mockRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ isBaseCurrency: 1 }),
+    );
+  });
+
+  it('isBaseCurrency=0 时不应调用 clearBaseCurrency', async () => {
+    const dto: CreateCurrencyDto = { code: 'EUR', name: '欧元', isBaseCurrency: 0 };
+    mockRepo.findByCode.mockResolvedValue(null);
+    mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'EUR', isBaseCurrency: 0 });
+
+    await service.create(dto, 'admin');
+    expect(mockRepo.clearBaseCurrency).not.toHaveBeenCalled();
+  });
+
+  it('create 时 isBaseCurrency 未传入应默认为 0', async () => {
+    const dto: CreateCurrencyDto = { code: 'JPY', name: '日元' };
+    mockRepo.findByCode.mockResolvedValue(null);
+    mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'JPY', isBaseCurrency: 0 });
+
+    await service.create(dto, 'admin');
+    expect(mockRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({ isBaseCurrency: 0 }),
+    );
+    expect(mockRepo.clearBaseCurrency).not.toHaveBeenCalled();
+  });
+});
+
+describe('update - 本位币互斥', () => {
+  it('update isBaseCurrency=1 时应先调用 clearBaseCurrency', async () => {
+    const dto: UpdateCurrencyDto = { isBaseCurrency: 1 };
+    mockRepo.findById.mockResolvedValue(mockCurrency);
+    mockRepo.clearBaseCurrency.mockResolvedValue(undefined);
+    mockRepo.update.mockResolvedValue({ ...mockCurrency, isBaseCurrency: 1 });
+
+    await service.update(1, dto, 'admin');
+    expect(mockRepo.clearBaseCurrency).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+---
+
+## 完成标准
+
+- [ ] `currency.entity.ts` 包含 `symbol` 和 `isBaseCurrency` 字段，每字段均有 `@Expose()` 和 `@Column({ name })`
+- [ ] Migration 文件 `20260420001100-alter-currencies-add-fields.ts` 存在，包含 `up()` 和 `down()`
+- [ ] `create-currency.dto.ts` / `update-currency.dto.ts` 含新字段验证
+- [ ] `currencies.repository.ts` 新增 `clearBaseCurrency()` 方法
+- [ ] `currencies.service.ts` 的 `create()` / `update()` 在 `isBaseCurrency === 1` 时调用 `clearBaseCurrency()`
+- [ ] `currencies.api.ts` 的 `Currency` / `CreateCurrencyPayload` / `UpdateCurrencyPayload` 接口包含新字段
+- [ ] `form.tsx` 追加 `symbol`（ProFormText）和 `isBaseCurrency`（ProFormSwitch）控件，含 tooltip
+- [ ] `form.tsx` 编辑模式可正确回填 `symbol` 和 `isBaseCurrency`
+- [ ] `index.tsx` 列表新增"本位币"列，isBaseCurrency = 1 时展示 `<Tag color="processing">本位币</Tag>`
+- [ ] `detail.tsx` 展示 `symbol` 和 `isBaseCurrency` 字段
+- [ ] `currencies.service.spec.ts` 包含本位币互斥逻辑的 3 个新测试用例
+- [ ] TypeScript 编译无报错（`pnpm --filter api build` / `pnpm --filter web build`）
+
+---
+
+## 分支命名
+
+`story/2-2b-币种字段补全-cc补丁`
+
+---
+
+### Review Findings
+
+- [x] [Review][Patch] `clearBaseCurrency()` 应过滤软删除记录，避免修改已软删除行的数据 [currencies.repository.ts:62] — fixed
+- [x] [Review][Defer] 缺乏事务保护（clearBaseCurrency + create/update 竞态）[currencies.service.ts:32,59] — deferred，spec 未强制要求 DB 事务，属架构层面优化
+- [x] [Review][Defer] `isBaseCurrency` 使用 `number`（0/1）而非 `boolean` 类型 — deferred，与 spec 设计一致，类型变更超出本补丁范围
+- [x] [Review][Defer] `symbol` 空字符串可通过 DTO 验证 [create-currency.dto.ts, update-currency.dto.ts] — deferred，前端已用 `|| undefined` 过滤，直接 API 滥用可后续统一处理
+- [x] [Review][Defer] 测试 mock 未在 `beforeEach` 中显式重置 [currencies.service.spec.ts] — deferred，测试 13/13 通过，说明已有机制保证隔离
+- [x] [Review][Defer] Migration `up()` 缺少幂等性保护 — deferred，标准 migration 实践，不需要 IF NOT EXISTS
+- [x] [Review][Defer] 前端 `Boolean(undefined)` 处理（迁移前旧记录无 isBaseCurrency 字段） — deferred，migration 运行后所有记录均有默认值 0，窗口期极短
+- [x] [Review][Defer] `update()` 中 `...dto` 展开依赖 TypeORM 对 `undefined` 的隐式忽略行为 — deferred，TypeORM 稳定行为，现有测试覆盖
+
+---
+
+*Story 由 BMad Create-Story 工作流创建 — 2026-04-20*

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,10 @@
 # Deferred Work
 
+## Deferred from: code review of 2-2a-仓库字段补全-cc补丁 (2026-04-20)
+
+- `@IsEnum(Object.values(...))` 应传枚举对象而非数组：项目中 WarehouseStatus / WarehouseType / WarehouseOwnership 等枚举均使用此模式，需统一修复
+- `supplierId` Entity 声明 `number` 但 DB 列为 `bigint`（TypeORM 默认返回 string）：与 `supplier_id` 相关的字段存在精度隐患，待供应商模块（Epic 4）开发时一并处理
+
 ## Deferred from: code review of 2-3-公司主体信息管理 (2026-04-20)
 
 - TOCTOU 竞态：create/update 中的名称唯一性检查与写入非原子操作 — 需数据库事务保障，超出本 Story 范围
@@ -23,3 +28,10 @@
 - `applyKeywordFilter` alias/fields 直接插值入 SQL（当前均为开发者硬编码，不是用户输入）。若将来开放动态字段选择，需改为白名单校验。
 - `applyKeywordFilter` 参数名 kw0/kw1 若在同一 QB 多次调用会冲突，建议未来版本引入调用计数器或前缀避免冲突。
 - `onClearAll` prop 为 undefined 时不显示"清除全部"；UX 规范要求仅由 activeTags.length>0 控制，建议后续使用时始终传入回调或改为 required prop。
+
+## Deferred from: code review of 2-3a-公司主体字段补全-cc补丁 (2026-04-21)
+
+- `findAll` 关键词搜索仅覆盖 `nameCn`，未搜索 `nameEn` / `abbreviation`（`companies.repository.ts`）— 搜索范围扩展留待后续 story
+- `UpdateCompanyDto.nameCn` 缺少 `@IsNotEmpty()`，空字符串可绕过唯一性检查（`update-company.dto.ts`）— pre-existing 模式，与其他 DTO 一致
+- `contactPhone` 仅有 `MaxLength(50)` 无格式校验（`create-company.dto.ts`）— pre-existing 设计决策
+- `bigint` DB 列（country_id / chief_accountant_id）TypeScript 层类型为 `number`，超大 ID 精度风险（`company.entity.ts`）— pre-existing 项目级模式，实际 ID 范围安全

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-20 (story-3.1-done)
+last_updated: 2026-04-21 (story-2-2b-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -61,7 +61,11 @@ development_status:
   epic-2: in-progress
   2-1-标准crud组件模板: done
   2-2-基础参考数据管理: done
+  2-2a-仓库字段补全-cc补丁: done  # CC补丁：仓库编号/类型/供应商/发运城市/归属/是否虚拟仓 | story file created 2026-04-20
+  2-2b-币种字段补全-cc补丁: done  # CC补丁：币种符号/是否本位币 | story file created 2026-04-21
+  2-2c-国家字段补全-cc补丁: done  # CC补丁：英文名称/简称
   2-3-公司主体信息管理: done
+  2-3a-公司主体字段补全-cc补丁: done  # CC补丁：英文名/简称/国家/地址/联系人/总账会计
   2-4-搜索筛选与分页横切能力: done
   epic-2-retrospective: done
 
@@ -69,7 +73,7 @@ development_status:
   # Epic 3: 产品体系管理
   # ─────────────────────────────────────────────────
   epic-3: in-progress
-  3-1-三级产品分类管理: done
+  3-1-三级产品分类管理: in-progress  # CC补丁：补充英文名/分类编号(CPDL自动生成)/采购负责人/产品负责人
   3-2-spu基础信息管理: backlog
   3-3-sku变体管理: backlog
   3-4-产品faq维护: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -61,11 +61,11 @@ development_status:
   epic-2: in-progress
   2-1-标准crud组件模板: done
   2-2-基础参考数据管理: done
-  2-2a-仓库字段补全-cc补丁: done  # CC补丁：仓库编号/类型/供应商/发运城市/归属/是否虚拟仓 | story file created 2026-04-20
+  2-2a-仓库字段补全-cc补丁: review  # CC补丁：仓库编号/类型/供应商/发运城市/归属/是否虚拟仓
   2-2b-币种字段补全-cc补丁: done  # CC补丁：币种符号/是否本位币 | story file created 2026-04-21
   2-2c-国家字段补全-cc补丁: done  # CC补丁：英文名称/简称
   2-3-公司主体信息管理: done
-  2-3a-公司主体字段补全-cc补丁: done  # CC补丁：英文名/简称/国家/地址/联系人/总账会计
+  2-3a-公司主体字段补全-cc补丁: ready-for-dev  # CC补丁：英文名/简称/国家/地址/联系人/总账会计
   2-4-搜索筛选与分页横切能力: done
   epic-2-retrospective: done
 
@@ -73,7 +73,7 @@ development_status:
   # Epic 3: 产品体系管理
   # ─────────────────────────────────────────────────
   epic-3: in-progress
-  3-1-三级产品分类管理: in-progress  # CC补丁：补充英文名/分类编号(CPDL自动生成)/采购负责人/产品负责人
+  3-1-三级产品分类管理: done
   3-2-spu基础信息管理: backlog
   3-3-sku变体管理: backlog
   3-4-产品faq维护: backlog

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,11 +19,17 @@
     "predev": "pnpm --filter @infitek/shared build",
     "dev": "nest start --watch",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "migration:run": "typeorm-ts-node-commonjs migration:run -d src/typeorm.config.ts",
+    "migration:revert": "typeorm-ts-node-commonjs migration:revert -d src/typeorm.config.ts",
+    "migration:show": "typeorm-ts-node-commonjs migration:show -d src/typeorm.config.ts",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@infitek/shared": "workspace:*",

--- a/apps/api/src/migrations/20260420001100-alter-currencies-add-fields.ts
+++ b/apps/api/src/migrations/20260420001100-alter-currencies-add-fields.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterCurrenciesAddFields20260420001100 implements MigrationInterface {
+  name = 'AlterCurrenciesAddFields20260420001100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`currencies\`
+        ADD COLUMN \`symbol\`           varchar(10) NULL     COMMENT '币种符号（如 $、¥、€）',
+        ADD COLUMN \`is_base_currency\` tinyint(1)  NOT NULL DEFAULT 0 COMMENT '是否本位币'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`currencies\`
+        DROP COLUMN \`is_base_currency\`,
+        DROP COLUMN \`symbol\`
+    `);
+  }
+}

--- a/apps/api/src/modules/master-data/currencies/currencies.repository.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.repository.ts
@@ -59,4 +59,8 @@ export class CurrenciesRepository {
     await this.repo.update(id, data);
     return this.repo.findOneOrFail({ where: { id, deletedAt: IsNull() } });
   }
+
+  async clearBaseCurrency(): Promise<void> {
+    await this.repo.update({ deletedAt: IsNull() }, { isBaseCurrency: 0 });
+  }
 }

--- a/apps/api/src/modules/master-data/currencies/currencies.service.ts
+++ b/apps/api/src/modules/master-data/currencies/currencies.service.ts
@@ -27,10 +27,17 @@ export class CurrenciesService {
     if (duplicate) {
       throw new BadRequestException('币种代码已存在');
     }
+
+    if (dto.isBaseCurrency === 1) {
+      await this.currenciesRepository.clearBaseCurrency();
+    }
+
     return this.currenciesRepository.create({
       code: dto.code,
       name: dto.name,
       status: CurrencyStatus.ACTIVE,
+      symbol: dto.symbol ?? null,
+      isBaseCurrency: dto.isBaseCurrency ?? 0,
       createdBy: operator,
       updatedBy: operator,
     });
@@ -47,6 +54,10 @@ export class CurrenciesService {
       if (duplicate && duplicate.id !== id) {
         throw new BadRequestException('币种代码已存在');
       }
+    }
+
+    if (dto.isBaseCurrency === 1) {
+      await this.currenciesRepository.clearBaseCurrency();
     }
 
     return this.currenciesRepository.update(id, {

--- a/apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts
+++ b/apps/api/src/modules/master-data/currencies/dto/create-currency.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 
 export class CreateCurrencyDto {
   @IsString()
@@ -10,4 +10,15 @@ export class CreateCurrencyDto {
   @IsNotEmpty()
   @MaxLength(50)
   name: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(10)
+  symbol?: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(1)
+  @IsOptional()
+  isBaseCurrency?: number;
 }

--- a/apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts
+++ b/apps/api/src/modules/master-data/currencies/dto/update-currency.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
 import { CurrencyStatus } from '@infitek/shared';
 
 export class UpdateCurrencyDto {
@@ -15,4 +15,15 @@ export class UpdateCurrencyDto {
   @IsEnum(Object.values(CurrencyStatus))
   @IsOptional()
   status?: CurrencyStatus;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(10)
+  symbol?: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(1)
+  @IsOptional()
+  isBaseCurrency?: number;
 }

--- a/apps/api/src/modules/master-data/currencies/entities/currency.entity.ts
+++ b/apps/api/src/modules/master-data/currencies/entities/currency.entity.ts
@@ -23,6 +23,14 @@ export class Currency extends BaseEntity {
   @Expose()
   status: CurrencyStatus;
 
+  @Column({ name: 'symbol', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  symbol: string | null;
+
+  @Column({ name: 'is_base_currency', type: 'tinyint', width: 1, default: 0 })
+  @Expose()
+  isBaseCurrency: number;
+
   @DeleteDateColumn({ name: 'deleted_at' })
   deletedAt: Date | null;
 }

--- a/apps/api/src/modules/master-data/currencies/tests/currencies.service.spec.ts
+++ b/apps/api/src/modules/master-data/currencies/tests/currencies.service.spec.ts
@@ -12,6 +12,8 @@ const mockCurrency: Currency = {
   code: 'USD',
   name: '美元',
   status: CurrencyStatus.ACTIVE,
+  symbol: '$',
+  isBaseCurrency: 0,
   deletedAt: null,
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -25,6 +27,7 @@ const mockRepo = {
   findByCode: jest.fn(),
   create: jest.fn(),
   update: jest.fn(),
+  clearBaseCurrency: jest.fn(),
 };
 
 describe('CurrenciesService', () => {
@@ -119,6 +122,54 @@ describe('CurrenciesService', () => {
     it('币种不存在时应抛出 NotFoundException', async () => {
       mockRepo.findById.mockResolvedValue(null);
       await expect(service.update(999, {}, 'admin')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create - 本位币互斥', () => {
+    it('isBaseCurrency=1 时应先调用 clearBaseCurrency 再创建', async () => {
+      const dto: CreateCurrencyDto = { code: 'CNY', name: '人民币', isBaseCurrency: 1 };
+      mockRepo.findByCode.mockResolvedValue(null);
+      mockRepo.clearBaseCurrency.mockResolvedValue(undefined);
+      mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'CNY', isBaseCurrency: 1 });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.clearBaseCurrency).toHaveBeenCalledTimes(1);
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isBaseCurrency: 1 }),
+      );
+    });
+
+    it('isBaseCurrency=0 时不应调用 clearBaseCurrency', async () => {
+      const dto: CreateCurrencyDto = { code: 'EUR', name: '欧元', isBaseCurrency: 0 };
+      mockRepo.findByCode.mockResolvedValue(null);
+      mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'EUR', isBaseCurrency: 0 });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.clearBaseCurrency).not.toHaveBeenCalled();
+    });
+
+    it('create 时 isBaseCurrency 未传入应默认为 0', async () => {
+      const dto: CreateCurrencyDto = { code: 'JPY', name: '日元' };
+      mockRepo.findByCode.mockResolvedValue(null);
+      mockRepo.create.mockResolvedValue({ ...mockCurrency, code: 'JPY', isBaseCurrency: 0 });
+
+      await service.create(dto, 'admin');
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ isBaseCurrency: 0 }),
+      );
+      expect(mockRepo.clearBaseCurrency).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update - 本位币互斥', () => {
+    it('update isBaseCurrency=1 时应先调用 clearBaseCurrency', async () => {
+      const dto: UpdateCurrencyDto = { isBaseCurrency: 1 };
+      mockRepo.findById.mockResolvedValue(mockCurrency);
+      mockRepo.clearBaseCurrency.mockResolvedValue(undefined);
+      mockRepo.update.mockResolvedValue({ ...mockCurrency, isBaseCurrency: 1 });
+
+      await service.update(1, dto, 'admin');
+      expect(mockRepo.clearBaseCurrency).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/typeorm.config.ts
+++ b/apps/api/src/typeorm.config.ts
@@ -9,7 +9,10 @@ const dataSource = new DataSource({
   password: process.env.DB_PASS || '',
   database: process.env.DB_NAME || 'infitek_erp',
   entities: [path.join(__dirname, '**/*.entity{.ts,.js}')],
-  migrations: [path.join(__dirname, 'migrations/*{.ts,.js}')],
+  migrations: [
+    path.join(__dirname, 'migrations/*.ts'),
+    path.join(__dirname, 'migrations/*.js'),
+  ],
   synchronize: false,
 });
 

--- a/apps/web/src/api/currencies.api.ts
+++ b/apps/web/src/api/currencies.api.ts
@@ -6,6 +6,8 @@ export interface Currency {
   code: string;
   name: string;
   status: CurrencyStatus;
+  symbol?: string | null;
+  isBaseCurrency?: number;
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
@@ -30,12 +32,16 @@ export interface CurrenciesListData {
 export interface CreateCurrencyPayload {
   code: string;
   name: string;
+  symbol?: string;
+  isBaseCurrency?: number;
 }
 
 export interface UpdateCurrencyPayload {
   code?: string;
   name?: string;
   status?: CurrencyStatus;
+  symbol?: string;
+  isBaseCurrency?: number;
 }
 
 function normalizeApiError(error: unknown): never {

--- a/apps/web/src/pages/master-data/currencies/detail.tsx
+++ b/apps/web/src/pages/master-data/currencies/detail.tsx
@@ -64,6 +64,23 @@ export default function CurrencyDetailPage() {
     { title: '币种代码', dataIndex: 'code', span: 1 },
     { title: '币种名称', dataIndex: 'name', span: 1 },
     {
+      title: '币种符号',
+      dataIndex: 'symbol',
+      span: 1,
+      renderText: (value: string | null) => value || '-',
+    },
+    {
+      title: '本位币',
+      dataIndex: 'isBaseCurrency',
+      span: 1,
+      render: (_: unknown, record: Currency) =>
+        record.isBaseCurrency === 1 ? (
+          <Tag color="processing">本位币</Tag>
+        ) : (
+          <span>-</span>
+        ),
+    },
+    {
       title: '创建时间',
       dataIndex: 'createdAt',
       span: 1,

--- a/apps/web/src/pages/master-data/currencies/form.tsx
+++ b/apps/web/src/pages/master-data/currencies/form.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, Result, Skeleton, Space } from 'antd';
-import { ProForm, ProFormSelect, ProFormText } from '@ant-design/pro-components';
+import { ProForm, ProFormSelect, ProFormSwitch, ProFormText } from '@ant-design/pro-components';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { CurrencyStatus } from '@infitek/shared';
@@ -88,6 +88,8 @@ export default function CurrencyFormPage() {
         code: string;
         name: string;
         status?: CurrencyStatus;
+        symbol?: string;
+        isBaseCurrency?: boolean;
       }>
         grid
         rowProps={{ gutter: [16, 0] }}
@@ -110,6 +112,8 @@ export default function CurrencyFormPage() {
                 code: detailQuery.data.code,
                 name: detailQuery.data.name,
                 status: detailQuery.data.status,
+                symbol: detailQuery.data.symbol ?? undefined,
+                isBaseCurrency: Boolean(detailQuery.data.isBaseCurrency),
               }
             : {}
         }
@@ -119,11 +123,15 @@ export default function CurrencyFormPage() {
               code: values.code,
               name: values.name,
               status: values.status,
+              symbol: values.symbol || undefined,
+              isBaseCurrency: values.isBaseCurrency ? 1 : 0,
             });
           } else {
             await createMutation.mutateAsync({
               code: values.code,
               name: values.name,
+              symbol: values.symbol || undefined,
+              isBaseCurrency: values.isBaseCurrency ? 1 : 0,
             });
           }
           return true;
@@ -146,6 +154,21 @@ export default function CurrencyFormPage() {
             { required: true, message: '请输入币种名称' },
             { max: 50, message: '币种名称最多 50 个字符' },
           ]}
+        />
+        <ProFormText
+          name="symbol"
+          label="币种符号"
+          placeholder="如：$、¥、€（可选，最多 10 个字符）"
+          rules={[{ max: 10, message: '币种符号最多 10 个字符' }]}
+        />
+        <ProFormSwitch
+          name="isBaseCurrency"
+          label="是否本位币"
+          tooltip="同一时间只能有一种本位币，开启后将自动取消其他币种的本位币状态"
+          fieldProps={{
+            checkedChildren: '是',
+            unCheckedChildren: '否',
+          }}
         />
         {isEdit ? (
           <ProFormSelect

--- a/apps/web/src/pages/master-data/currencies/index.tsx
+++ b/apps/web/src/pages/master-data/currencies/index.tsx
@@ -101,6 +101,15 @@ export default function CurrenciesListPage() {
         ellipsis: true,
       },
       {
+        title: '本位币',
+        dataIndex: 'isBaseCurrency',
+        width: 100,
+        render: (_, record) =>
+          record.isBaseCurrency === 1 ? (
+            <Tag color="processing">本位币</Tag>
+          ) : null,
+      },
+      {
         title: '状态',
         dataIndex: 'status',
         width: 120,


### PR DESCRIPTION
## Summary

- 补全币种模块缺失的 `symbol`（币种符号）和 `isBaseCurrency`（是否本位币）两个字段
- 后端 Entity / Migration / DTO 追加字段，Repository 新增 `clearBaseCurrency()`
- Service `create()`/`update()` 加入本位币互斥逻辑：设置新本位币前先清除所有其他记录（仅限非软删除行）
- 前端表单追加 ProFormText + ProFormSwitch 控件，列表新增"本位币"Tag 列，详情页追加展示项
- 补充 3 个本位币互斥逻辑单元测试

## Test plan

- [x] `pnpm --filter api build` 编译零报错
- [x] `pnpm --filter web build` 编译零报错
- [x] `jest --testRegex="currencies.*spec"` 13/13 通过（含 3 个新测试用例）
- [x] Code review 完成，1 个 patch 已修复（`clearBaseCurrency` 过滤软删除记录）
- [x] 手动验证：新建币种时可填写 symbol，切换本位币开关后其他币种本位币状态自动清除
- [x] 手动验证：列表页"本位币"Tag 正确展示，详情页字段完整显示

## QA Notes (2026-04-21)

- 使用独立测试库 `infitek_erp_pr29_test` + 你提供的 RDS 连接完成 API 与前端联调验证。
- 发现并已登记 issue：<https://github.com/friday-ckp/infitek_erp/issues/32>
  - TypeORM CLI 在空库场景下提示 `No migrations are pending`
  - 默认 Bun wrapper 作为 `node` 时，Jest 定向测试会异常失败（切换 Node.js 后通过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
