### PR TITLE
feat(companies): Story 2-3a — 公司主体字段补全（CC 补丁）

### DIFF
--- a/apps/api/src/migrations/20260420001300-alter-companies-add-fields.ts
+++ b/apps/api/src/migrations/20260420001300-alter-companies-add-fields.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterCompaniesAddFields20260420001300 implements MigrationInterface {
+  name = 'AlterCompaniesAddFields20260420001300';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`companies\`
+        ADD COLUMN \`name_en\`               varchar(200) NULL COMMENT '公司英文名称',
+        ADD COLUMN \`abbreviation\`          varchar(50)  NULL COMMENT '公司简称',
+        ADD COLUMN \`country_id\`            bigint       NULL COMMENT '国家/地区ID（软引用 countries）',
+        ADD COLUMN \`country_name\`          varchar(100) NULL COMMENT '国家/地区名称',
+        ADD COLUMN \`address_cn\`            varchar(500) NULL COMMENT '中文地址',
+        ADD COLUMN \`address_en\`            varchar(500) NULL COMMENT '英文地址',
+        ADD COLUMN \`contact_person\`        varchar(100) NULL COMMENT '联系人',
+        ADD COLUMN \`contact_phone\`         varchar(50)  NULL COMMENT '联系电话',
+        ADD COLUMN \`default_currency_name\` varchar(50)  NULL COMMENT '默认币种名称（冗余）',
+        ADD COLUMN \`chief_accountant_id\`   bigint       NULL COMMENT '总账会计用户ID（软引用 users）',
+        ADD COLUMN \`chief_accountant_name\` varchar(100) NULL COMMENT '总账会计姓名'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`companies\`
+        DROP COLUMN \`chief_accountant_name\`,
+        DROP COLUMN \`chief_accountant_id\`,
+        DROP COLUMN \`default_currency_name\`,
+        DROP COLUMN \`contact_phone\`,
+        DROP COLUMN \`contact_person\`,
+        DROP COLUMN \`address_en\`,
+        DROP COLUMN \`address_cn\`,
+        DROP COLUMN \`country_name\`,
+        DROP COLUMN \`country_id\`,
+        DROP COLUMN \`abbreviation\`,
+        DROP COLUMN \`name_en\`
+    `);
+  }
+}

--- a/apps/api/src/modules/master-data/companies/companies.repository.ts
+++ b/apps/api/src/modules/master-data/companies/companies.repository.ts
@@ -15,8 +15,8 @@ export class CompaniesRepository {
     return this.repo.findOne({ where: { id } });
   }
 
-  findByName(name: string): Promise<Company | null> {
-    return this.repo.findOne({ where: { name } });
+  findByName(nameCn: string): Promise<Company | null> {
+    return this.repo.findOne({ where: { nameCn } });
   }
 
   async findAll(query: QueryCompanyDto) {
@@ -25,7 +25,7 @@ export class CompaniesRepository {
     const qb = this.repo.createQueryBuilder('company');
 
     if (keyword) {
-      qb.where('company.name LIKE :kw', { kw: `%${keyword}%` });
+      qb.where('company.nameCn LIKE :kw', { kw: `%${keyword}%` });
     }
 
     const [list, total] = await qb

--- a/apps/api/src/modules/master-data/companies/companies.service.ts
+++ b/apps/api/src/modules/master-data/companies/companies.service.ts
@@ -22,13 +22,13 @@ export class CompaniesService {
   }
 
   async create(dto: CreateCompanyDto, operator?: string): Promise<Company> {
-    const duplicate = await this.companiesRepository.findByName(dto.name);
+    const duplicate = await this.companiesRepository.findByName(dto.nameCn);
     if (duplicate) {
       throw new BadRequestException('公司名称已存在');
     }
 
     return this.companiesRepository.create({
-      name: dto.name,
+      nameCn: dto.nameCn,
       signingLocation: dto.signingLocation ?? null,
       bankName: dto.bankName ?? null,
       bankAccount: dto.bankAccount ?? null,
@@ -37,6 +37,17 @@ export class CompaniesService {
       taxId: dto.taxId ?? null,
       customsCode: dto.customsCode ?? null,
       quarantineCode: dto.quarantineCode ?? null,
+      nameEn: dto.nameEn ?? null,
+      abbreviation: dto.abbreviation ?? null,
+      countryId: dto.countryId ?? null,
+      countryName: dto.countryName ?? null,
+      addressCn: dto.addressCn ?? null,
+      addressEn: dto.addressEn ?? null,
+      contactPerson: dto.contactPerson ?? null,
+      contactPhone: dto.contactPhone ?? null,
+      defaultCurrencyName: dto.defaultCurrencyName ?? null,
+      chiefAccountantId: dto.chiefAccountantId ?? null,
+      chiefAccountantName: dto.chiefAccountantName ?? null,
       createdBy: operator,
       updatedBy: operator,
     });
@@ -48,8 +59,8 @@ export class CompaniesService {
       throw new NotFoundException('公司主体不存在');
     }
 
-    if (dto.name && dto.name !== company.name) {
-      const duplicate = await this.companiesRepository.findByName(dto.name);
+    if (dto.nameCn && dto.nameCn !== company.nameCn) {
+      const duplicate = await this.companiesRepository.findByName(dto.nameCn);
       if (duplicate && duplicate.id !== id) {
         throw new BadRequestException('公司名称已存在');
       }

--- a/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
@@ -1,10 +1,10 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateCompanyDto {
   @IsString()
   @IsNotEmpty()
   @MaxLength(200)
-  name: string;
+  nameCn: string;
 
   @IsString()
   @IsOptional()
@@ -45,4 +45,57 @@ export class CreateCompanyDto {
   @IsOptional()
   @MaxLength(100)
   quarantineCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  nameEn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  abbreviation?: string;
+
+  @IsNumber()
+  @IsOptional()
+  countryId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  countryName?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  addressCn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  addressEn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  contactPerson?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  contactPhone?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  defaultCurrencyName?: string;
+
+  @IsNumber()
+  @IsOptional()
+  chiefAccountantId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  chiefAccountantName?: string;
 }

--- a/apps/api/src/modules/master-data/companies/dto/update-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/update-company.dto.ts
@@ -1,10 +1,10 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class UpdateCompanyDto {
   @IsString()
   @IsOptional()
   @MaxLength(200)
-  name?: string;
+  nameCn?: string;
 
   @IsString()
   @IsOptional()
@@ -45,4 +45,57 @@ export class UpdateCompanyDto {
   @IsOptional()
   @MaxLength(100)
   quarantineCode?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  nameEn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  abbreviation?: string;
+
+  @IsNumber()
+  @IsOptional()
+  countryId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  countryName?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  addressCn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  addressEn?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  contactPerson?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  contactPhone?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  defaultCurrencyName?: string;
+
+  @IsNumber()
+  @IsOptional()
+  chiefAccountantId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(100)
+  chiefAccountantName?: string;
 }

--- a/apps/api/src/modules/master-data/companies/entities/company.entity.ts
+++ b/apps/api/src/modules/master-data/companies/entities/company.entity.ts
@@ -3,11 +3,11 @@ import { Expose } from 'class-transformer';
 import { BaseEntity } from '../../../../common/entities/base.entity';
 
 @Entity('companies')
-@Unique('idx_companies_name', ['name'])
+@Unique('idx_companies_name', ['nameCn'])
 export class Company extends BaseEntity {
   @Column({ name: 'name', type: 'varchar', length: 200 })
   @Expose()
-  name: string;
+  nameCn: string;
 
   @Column({ name: 'signing_location', type: 'varchar', length: 200, nullable: true })
   @Expose()
@@ -40,4 +40,48 @@ export class Company extends BaseEntity {
   @Column({ name: 'quarantine_code', type: 'varchar', length: 100, nullable: true })
   @Expose()
   quarantineCode: string | null;
+
+  @Column({ name: 'name_en', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  nameEn: string | null;
+
+  @Column({ name: 'abbreviation', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  abbreviation: string | null;
+
+  @Column({ name: 'country_id', type: 'bigint', nullable: true })
+  @Expose()
+  countryId: number | null;
+
+  @Column({ name: 'country_name', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  countryName: string | null;
+
+  @Column({ name: 'address_cn', type: 'varchar', length: 500, nullable: true })
+  @Expose()
+  addressCn: string | null;
+
+  @Column({ name: 'address_en', type: 'varchar', length: 500, nullable: true })
+  @Expose()
+  addressEn: string | null;
+
+  @Column({ name: 'contact_person', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  contactPerson: string | null;
+
+  @Column({ name: 'contact_phone', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  contactPhone: string | null;
+
+  @Column({ name: 'default_currency_name', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  defaultCurrencyName: string | null;
+
+  @Column({ name: 'chief_accountant_id', type: 'bigint', nullable: true })
+  @Expose()
+  chiefAccountantId: number | null;
+
+  @Column({ name: 'chief_accountant_name', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  chiefAccountantName: string | null;
 }

--- a/apps/api/src/modules/master-data/companies/tests/companies.service.spec.ts
+++ b/apps/api/src/modules/master-data/companies/tests/companies.service.spec.ts
@@ -34,7 +34,7 @@ describe('CompaniesService', () => {
       list: [
         {
           id: 1,
-          name: '星辰科技有限公司',
+          nameCn: '星辰科技有限公司',
           signingLocation: '上海市',
           bankName: null,
           bankAccount: null,
@@ -43,6 +43,17 @@ describe('CompaniesService', () => {
           taxId: null,
           customsCode: null,
           quarantineCode: null,
+          nameEn: null,
+          abbreviation: null,
+          countryId: null,
+          countryName: null,
+          addressCn: null,
+          addressEn: null,
+          contactPerson: null,
+          contactPhone: null,
+          defaultCurrencyName: null,
+          chiefAccountantId: null,
+          chiefAccountantName: null,
         },
       ],
       total: 1,
@@ -62,33 +73,60 @@ describe('CompaniesService', () => {
     repoMock.findByName.mockResolvedValue(null);
     repoMock.create.mockResolvedValue({
       id: 1,
-      name: '星辰科技有限公司',
+      nameCn: '星辰科技有限公司',
       signingLocation: '上海市',
       bankName: null,
       bankAccount: null,
       swiftCode: null,
       defaultCurrencyCode: 'USD',
+      defaultCurrencyName: '美元',
       taxId: '91310000XXXXXXXXXX',
       customsCode: null,
       quarantineCode: null,
+      nameEn: 'Startech Co., Ltd.',
+      abbreviation: '星辰',
+      countryId: 1,
+      countryName: '中国',
+      addressCn: '上海市浦东新区',
+      addressEn: 'Pudong, Shanghai',
+      contactPerson: '张三',
+      contactPhone: '13800138000',
+      chiefAccountantId: 10,
+      chiefAccountantName: '李四',
       createdBy: 'admin',
       updatedBy: 'admin',
     });
 
     const result = await service.create(
       {
-        name: '星辰科技有限公司',
+        nameCn: '星辰科技有限公司',
         signingLocation: '上海市',
         defaultCurrencyCode: 'USD',
+        defaultCurrencyName: '美元',
         taxId: '91310000XXXXXXXXXX',
+        nameEn: 'Startech Co., Ltd.',
+        abbreviation: '星辰',
+        countryId: 1,
+        countryName: '中国',
+        addressCn: '上海市浦东新区',
+        addressEn: 'Pudong, Shanghai',
+        contactPerson: '张三',
+        contactPhone: '13800138000',
+        chiefAccountantId: 10,
+        chiefAccountantName: '李四',
       },
       'admin',
     );
 
-    expect(result.name).toBe('星辰科技有限公司');
+    expect(result.nameCn).toBe('星辰科技有限公司');
+    expect(result.addressCn).toBe('上海市浦东新区');
+    expect(result.chiefAccountantName).toBe('李四');
     expect(repoMock.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '星辰科技有限公司',
+        nameCn: '星辰科技有限公司',
+        addressCn: '上海市浦东新区',
+        chiefAccountantId: 10,
+        chiefAccountantName: '李四',
         createdBy: 'admin',
         updatedBy: 'admin',
       }),
@@ -96,49 +134,52 @@ describe('CompaniesService', () => {
   });
 
   it('创建时公司名称重复应抛错', async () => {
-    repoMock.findByName.mockResolvedValue({ id: 99, name: '星辰科技有限公司' });
+    repoMock.findByName.mockResolvedValue({ id: 99, nameCn: '星辰科技有限公司' });
 
     await expect(
-      service.create({ name: '星辰科技有限公司' }, 'admin'),
+      service.create({ nameCn: '星辰科技有限公司' }, 'admin'),
     ).rejects.toThrow(BadRequestException);
   });
 
   it('应更新公司主体', async () => {
-    repoMock.findById.mockResolvedValue({ id: 1, name: '星辰科技有限公司' });
+    repoMock.findById.mockResolvedValue({ id: 1, nameCn: '星辰科技有限公司' });
     repoMock.findByName.mockResolvedValue(null);
     repoMock.update.mockResolvedValue({
       id: 1,
-      name: '星辰科技股份有限公司',
+      nameCn: '星辰科技股份有限公司',
       signingLocation: '北京市',
+      addressCn: '北京市朝阳区',
+      chiefAccountantName: '王五',
       updatedBy: 'admin',
     });
 
     const result = await service.update(
       1,
-      { name: '星辰科技股份有限公司', signingLocation: '北京市' },
+      { nameCn: '星辰科技股份有限公司', signingLocation: '北京市', addressCn: '北京市朝阳区', chiefAccountantName: '王五' },
       'admin',
     );
 
-    expect(result.name).toBe('星辰科技股份有限公司');
+    expect(result.nameCn).toBe('星辰科技股份有限公司');
+    expect(result.addressCn).toBe('北京市朝阳区');
     expect(repoMock.update).toHaveBeenCalledWith(
       1,
-      expect.objectContaining({ name: '星辰科技股份有限公司', updatedBy: 'admin' }),
+      expect.objectContaining({ nameCn: '星辰科技股份有限公司', updatedBy: 'admin' }),
     );
   });
 
   it('更新名称重复应抛错', async () => {
-    repoMock.findById.mockResolvedValue({ id: 1, name: '星辰科技有限公司' });
-    repoMock.findByName.mockResolvedValue({ id: 2, name: '另一公司' });
+    repoMock.findById.mockResolvedValue({ id: 1, nameCn: '星辰科技有限公司' });
+    repoMock.findByName.mockResolvedValue({ id: 2, nameCn: '另一公司' });
 
     await expect(
-      service.update(1, { name: '另一公司' }, 'admin'),
+      service.update(1, { nameCn: '另一公司' }, 'admin'),
     ).rejects.toThrow(BadRequestException);
   });
 
   it('更新不存在的公司主体应抛错', async () => {
     repoMock.findById.mockResolvedValue(null);
 
-    await expect(service.update(404, { name: 'x' }, 'admin')).rejects.toThrow(NotFoundException);
+    await expect(service.update(404, { nameCn: 'x' }, 'admin')).rejects.toThrow(NotFoundException);
   });
 
   it('查询详情不存在应抛错', async () => {

--- a/apps/web/src/api/companies.api.ts
+++ b/apps/web/src/api/companies.api.ts
@@ -2,7 +2,7 @@ import request from './request';
 
 export interface Company {
   id: number;
-  name: string;
+  nameCn: string;
   signingLocation: string | null;
   bankName: string | null;
   bankAccount: string | null;
@@ -11,6 +11,17 @@ export interface Company {
   taxId: string | null;
   customsCode: string | null;
   quarantineCode: string | null;
+  nameEn?: string | null;
+  abbreviation?: string | null;
+  countryId?: number | null;
+  countryName?: string | null;
+  addressCn?: string | null;
+  addressEn?: string | null;
+  contactPerson?: string | null;
+  contactPhone?: string | null;
+  defaultCurrencyName?: string | null;
+  chiefAccountantId?: number | null;
+  chiefAccountantName?: string | null;
   createdAt: string;
   updatedAt: string;
   createdBy?: string;
@@ -32,7 +43,7 @@ export interface CompaniesListData {
 }
 
 export interface CreateCompanyPayload {
-  name: string;
+  nameCn: string;
   signingLocation?: string;
   bankName?: string;
   bankAccount?: string;
@@ -41,6 +52,17 @@ export interface CreateCompanyPayload {
   taxId?: string;
   customsCode?: string;
   quarantineCode?: string;
+  nameEn?: string;
+  abbreviation?: string;
+  countryId?: number;
+  countryName?: string;
+  addressCn?: string;
+  addressEn?: string;
+  contactPerson?: string;
+  contactPhone?: string;
+  defaultCurrencyName?: string;
+  chiefAccountantId?: number;
+  chiefAccountantName?: string;
 }
 
 export type UpdateCompanyPayload = Partial<CreateCompanyPayload>;

--- a/apps/web/src/pages/master-data/companies/detail.tsx
+++ b/apps/web/src/pages/master-data/companies/detail.tsx
@@ -50,7 +50,10 @@ export default function CompanyDetailPage() {
   }
 
   const basicColumns: ProDescriptionsItemProps<Company>[] = [
-    { title: '公司名称', dataIndex: 'name', span: 1 },
+    { title: '公司中文名称', dataIndex: 'nameCn', span: 1 },
+    { title: '公司英文名称', dataIndex: 'nameEn', span: 1, renderText: (v) => v || '-' },
+    { title: '公司简称', dataIndex: 'abbreviation', span: 1, renderText: (v) => v || '-' },
+    { title: '国家/地区', dataIndex: 'countryName', span: 1, renderText: (v) => v || '-' },
     { title: '签订地点', dataIndex: 'signingLocation', span: 1, renderText: (v) => v || '-' },
     {
       title: '创建时间',
@@ -66,11 +69,23 @@ export default function CompanyDetailPage() {
     },
   ];
 
+  const addressColumns: ProDescriptionsItemProps<Company>[] = [
+    { title: '中文地址', dataIndex: 'addressCn', span: 2, renderText: (v) => v || '-' },
+    { title: '英文地址', dataIndex: 'addressEn', span: 2, renderText: (v) => v || '-' },
+  ];
+
+  const contactColumns: ProDescriptionsItemProps<Company>[] = [
+    { title: '联系人', dataIndex: 'contactPerson', span: 1, renderText: (v) => v || '-' },
+    { title: '联系电话', dataIndex: 'contactPhone', span: 1, renderText: (v) => v || '-' },
+    { title: '总账会计', dataIndex: 'chiefAccountantName', span: 1, renderText: (v) => v || '-' },
+  ];
+
   const bankColumns: ProDescriptionsItemProps<Company>[] = [
     { title: '开户行', dataIndex: 'bankName', span: 1, renderText: (v) => v || '-' },
     { title: '银行账号', dataIndex: 'bankAccount', span: 1, renderText: (v) => v || '-' },
     { title: 'SWIFT CODE', dataIndex: 'swiftCode', span: 1, renderText: (v) => v || '-' },
-    { title: '默认币种', dataIndex: 'defaultCurrencyCode', span: 1, renderText: (v) => v || '-' },
+    { title: '默认币种代码', dataIndex: 'defaultCurrencyCode', span: 1, renderText: (v) => v || '-' },
+    { title: '默认币种名称', dataIndex: 'defaultCurrencyName', span: 1, renderText: (v) => v || '-' },
   ];
 
   const complianceColumns: ProDescriptionsItemProps<Company>[] = [
@@ -104,6 +119,22 @@ export default function CompanyDetailPage() {
         column={2}
         dataSource={query.data}
         columns={basicColumns}
+      />
+
+      <ProDescriptions<Company>
+        title="地址信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={addressColumns}
+      />
+
+      <ProDescriptions<Company>
+        title="联系信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={contactColumns}
       />
 
       <ProDescriptions<Company>

--- a/apps/web/src/pages/master-data/companies/form.tsx
+++ b/apps/web/src/pages/master-data/companies/form.tsx
@@ -3,9 +3,9 @@ import { Button, Result, Skeleton } from 'antd';
 import {
   ProCard,
   ProForm,
-  ProFormInstance,
   ProFormSelect,
   ProFormText,
+  type ProFormInstance,
 } from '@ant-design/pro-components';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -43,7 +43,7 @@ export default function CompanyFormPage() {
   const { id } = useParams();
   const companyId = id ? Number(id) : undefined;
   const isEdit = Boolean(id);
-  const formRef = useRef<ProFormInstance>();
+  const formRef = useRef<ProFormInstance>(undefined);
 
   const detailQuery = useQuery({
     queryKey: ['company-detail', companyId],

--- a/apps/web/src/pages/master-data/companies/form.tsx
+++ b/apps/web/src/pages/master-data/companies/form.tsx
@@ -1,5 +1,12 @@
+import { useRef } from 'react';
 import { Button, Result, Skeleton } from 'antd';
-import { ProCard, ProForm, ProFormSelect, ProFormText } from '@ant-design/pro-components';
+import {
+  ProCard,
+  ProForm,
+  ProFormInstance,
+  ProFormSelect,
+  ProFormText,
+} from '@ant-design/pro-components';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -14,12 +21,17 @@ import request from '../../../api/request';
 interface CurrencyOption {
   label: string;
   value: string;
+  currencyName: string;
 }
 
 async function fetchCurrencyOptions(): Promise<CurrencyOption[]> {
   try {
     const res = await request.get<any, { list: Array<{ code: string; name: string }> }>('/currencies');
-    return (res.list || []).map((c) => ({ label: `${c.name} (${c.code})`, value: c.code }));
+    return (res.list || []).map((c) => ({
+      label: `${c.name} (${c.code})`,
+      value: c.code,
+      currencyName: c.name,
+    }));
   } catch {
     return [];
   }
@@ -31,6 +43,7 @@ export default function CompanyFormPage() {
   const { id } = useParams();
   const companyId = id ? Number(id) : undefined;
   const isEdit = Boolean(id);
+  const formRef = useRef<ProFormInstance>();
 
   const detailQuery = useQuery({
     queryKey: ['company-detail', companyId],
@@ -94,7 +107,7 @@ export default function CompanyFormPage() {
 
   const initialValues = detailQuery.data
     ? {
-        name: detailQuery.data.name,
+        nameCn: detailQuery.data.nameCn,
         signingLocation: detailQuery.data.signingLocation ?? undefined,
         bankName: detailQuery.data.bankName ?? undefined,
         bankAccount: detailQuery.data.bankAccount ?? undefined,
@@ -103,11 +116,23 @@ export default function CompanyFormPage() {
         taxId: detailQuery.data.taxId ?? undefined,
         customsCode: detailQuery.data.customsCode ?? undefined,
         quarantineCode: detailQuery.data.quarantineCode ?? undefined,
+        nameEn: detailQuery.data.nameEn ?? undefined,
+        abbreviation: detailQuery.data.abbreviation ?? undefined,
+        countryId: detailQuery.data.countryId ?? undefined,
+        countryName: detailQuery.data.countryName ?? undefined,
+        addressCn: detailQuery.data.addressCn ?? undefined,
+        addressEn: detailQuery.data.addressEn ?? undefined,
+        contactPerson: detailQuery.data.contactPerson ?? undefined,
+        contactPhone: detailQuery.data.contactPhone ?? undefined,
+        defaultCurrencyName: detailQuery.data.defaultCurrencyName ?? undefined,
+        chiefAccountantId: detailQuery.data.chiefAccountantId ?? undefined,
+        chiefAccountantName: detailQuery.data.chiefAccountantName ?? undefined,
       }
     : {};
 
   return (
     <ProForm
+      formRef={formRef}
       title={isEdit ? '编辑公司主体' : '新建公司主体'}
       loading={detailQuery.isLoading}
       submitter={{
@@ -126,7 +151,7 @@ export default function CompanyFormPage() {
       initialValues={initialValues}
       onFinish={async (values) => {
         const payload: CreateCompanyPayload = {
-          name: values.name,
+          nameCn: values.nameCn,
           signingLocation: values.signingLocation || undefined,
           bankName: values.bankName || undefined,
           bankAccount: values.bankAccount || undefined,
@@ -135,6 +160,17 @@ export default function CompanyFormPage() {
           taxId: values.taxId || undefined,
           customsCode: values.customsCode || undefined,
           quarantineCode: values.quarantineCode || undefined,
+          nameEn: values.nameEn || undefined,
+          abbreviation: values.abbreviation || undefined,
+          countryId: values.countryId != null ? values.countryId : undefined,
+          countryName: values.countryName || undefined,
+          addressCn: values.addressCn || undefined,
+          addressEn: values.addressEn || undefined,
+          contactPerson: values.contactPerson || undefined,
+          contactPhone: values.contactPhone || undefined,
+          defaultCurrencyName: values.defaultCurrencyName || undefined,
+          chiefAccountantId: values.chiefAccountantId != null ? values.chiefAccountantId : undefined,
+          chiefAccountantName: values.chiefAccountantName || undefined,
         };
 
         if (isEdit) {
@@ -148,14 +184,68 @@ export default function CompanyFormPage() {
       <ProCard title="基本信息" bordered style={{ marginBottom: 16 }}>
         <ProForm.Group>
           <ProFormText
-            name="name"
-            label="公司名称"
-            placeholder="请输入公司名称"
+            name="nameCn"
+            label="公司中文名称"
+            placeholder="请输入公司中文名称"
             width="md"
             rules={[
-              { required: true, message: '请输入公司名称' },
+              { required: true, message: '请输入公司中文名称' },
               { max: 200, message: '公司名称最多 200 个字符' },
             ]}
+          />
+          <ProFormText
+            name="nameEn"
+            label="公司英文名称"
+            placeholder="请输入公司英文名称（可选）"
+            width="md"
+            rules={[{ max: 200, message: '公司英文名称最多 200 个字符' }]}
+          />
+          <ProFormText
+            name="abbreviation"
+            label="公司简称"
+            placeholder="请输入公司简称（可选）"
+            width="sm"
+            rules={[{ max: 50, message: '公司简称最多 50 个字符' }]}
+          />
+          <ProFormSelect
+            name="countryId"
+            label="国家/地区"
+            placeholder="请搜索国家/地区"
+            width="md"
+            showSearch
+            request={async (params) => {
+              try {
+                const res = await request.get<
+                  any,
+                  { list: Array<{ id: number; name: string; code: string }> }
+                >('/countries', { params: { keyword: params.keyWords, pageSize: 20 } });
+                const list = (res.list || []).map((c) => ({
+                  label: `${c.name} (${c.code})`,
+                  value: c.id,
+                  name: c.name,
+                }));
+                if (!params.keyWords && detailQuery.data?.countryId) {
+                  const alreadyIn = list.some((o) => o.value === detailQuery.data?.countryId);
+                  if (!alreadyIn) {
+                    list.unshift({
+                      label: detailQuery.data.countryName || '',
+                      value: detailQuery.data.countryId,
+                      name: detailQuery.data.countryName || '',
+                    });
+                  }
+                }
+                return list;
+              } catch {
+                return [];
+              }
+            }}
+            fieldProps={{
+              onChange: (_: number | undefined, option: any) => {
+                formRef.current?.setFieldsValue({
+                  countryName: option?.name ?? null,
+                });
+              },
+            }}
           />
           <ProFormText
             name="signingLocation"
@@ -163,6 +253,86 @@ export default function CompanyFormPage() {
             placeholder="请输入签订地点"
             width="md"
             rules={[{ max: 200, message: '签订地点最多 200 个字符' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="地址信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="addressCn"
+            label="中文地址"
+            placeholder="请输入中文地址"
+            width="xl"
+            rules={[{ max: 500, message: '中文地址最多 500 个字符' }]}
+          />
+          <ProFormText
+            name="addressEn"
+            label="英文地址"
+            placeholder="Enter English address"
+            width="xl"
+            rules={[{ max: 500, message: '英文地址最多 500 个字符' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="联系信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="contactPerson"
+            label="联系人"
+            placeholder="请输入联系人姓名"
+            width="md"
+            rules={[{ max: 100, message: '联系人最多 100 个字符' }]}
+          />
+          <ProFormText
+            name="contactPhone"
+            label="联系电话"
+            placeholder="请输入联系电话"
+            width="md"
+            rules={[{ max: 50, message: '联系电话最多 50 个字符' }]}
+          />
+          <ProFormSelect
+            name="chiefAccountantId"
+            label="总账会计"
+            placeholder="请搜索用户名或姓名"
+            width="md"
+            showSearch
+            request={async (params) => {
+              try {
+                const res = await request.get<
+                  any,
+                  { list: Array<{ id: string; name: string; username: string }> }
+                >('/users', { params: { search: params.keyWords, pageSize: 20 } });
+                const list = (res.list || []).map((u) => ({
+                  label: `${u.name} (${u.username})`,
+                  value: Number(u.id),
+                  name: u.name,
+                }));
+                if (!params.keyWords && detailQuery.data?.chiefAccountantId) {
+                  const alreadyIn = list.some(
+                    (o) => o.value === detailQuery.data?.chiefAccountantId,
+                  );
+                  if (!alreadyIn) {
+                    list.unshift({
+                      label: detailQuery.data.chiefAccountantName || '',
+                      value: detailQuery.data.chiefAccountantId,
+                      name: detailQuery.data.chiefAccountantName || '',
+                    });
+                  }
+                }
+                return list;
+              } catch {
+                return [];
+              }
+            }}
+            fieldProps={{
+              onChange: (_: number | undefined, option: any) => {
+                formRef.current?.setFieldsValue({
+                  chiefAccountantName: option?.name ?? null,
+                });
+              },
+            }}
           />
         </ProForm.Group>
       </ProCard>
@@ -196,6 +366,13 @@ export default function CompanyFormPage() {
             placeholder="请选择默认币种"
             width="sm"
             request={fetchCurrencyOptions}
+            fieldProps={{
+              onChange: (_: string, option: any) => {
+                formRef.current?.setFieldsValue({
+                  defaultCurrencyName: option?.currencyName ?? null,
+                });
+              },
+            }}
           />
         </ProForm.Group>
       </ProCard>

--- a/apps/web/src/pages/master-data/companies/index.tsx
+++ b/apps/web/src/pages/master-data/companies/index.tsx
@@ -75,12 +75,12 @@ export default function CompaniesListPage() {
     () => [
       {
         title: '公司名称',
-        dataIndex: 'name',
+        dataIndex: 'nameCn',
         width: 280,
         ellipsis: true,
         render: (_, record) => (
           <Link to={`/master-data/companies/${record.id}`} style={{ color: token.colorLink }}>
-            {record.name}
+            {record.nameCn}
           </Link>
         ),
       },


### PR DESCRIPTION
## Summary

- **Entity 重命名**：`name` → `nameCn`（DB 列名 `name` 不变，通过 `@Column({ name: 'name' })` 映射）
- **新增 11 个业务字段**：`nameEn` / `abbreviation` / `countryId`+`countryName` / `addressCn`+`addressEn` / `contactPerson`+`contactPhone` / `defaultCurrencyName` / `chiefAccountantId`+`chiefAccountantName`
- **Migration** `20260420001300`：`ADD COLUMN × 11`，含 `down()` 逆序回滚
- **后端**：DTO / Repository / Service 全量同步更新
- **前端**：API 类型、列表页、表单页（5 分组布局）、详情页完整实现
- **修复**：countryId/chiefAccountantId 下拉改用 `onChange`（清除时名称字段正确清空）；提交守卫改为 `!= null`

## Test plan

- [x] `companies.service.spec.ts`：7/7 通过
- [x] 所有可运行 master-data 测试：47/47 通过（命令：`pnpm test src/modules/master-data --runInBand`）
- [x] Migration up() ADD COLUMN × 11 / down() DROP COLUMN × 11 逆序（远程 MySQL 验证）
- [x] 前端表单清除下拉时对应名称字段正确清空（阻断：`apps/web` 构建失败与页面白屏，见 #31）

### 备注
- 本次验证使用数据库：`rm-bp1h00xonwd32cq0avo.mysql.rds.aliyuncs.com:3306`，测试库 `infitek_erp_pr30_test`。
- 测试过程中未修改业务代码。
