### PR TITLE
fix(story-3-1a): 前端 Bug 批量修复 — 全局 UI 规范 + 产品分类

### DIFF
--- a/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
+++ b/apps/api/src/modules/master-data/companies/dto/create-company.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateCompanyDto {
@@ -56,6 +57,7 @@ export class CreateCompanyDto {
   @MaxLength(50)
   abbreviation?: string;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   countryId?: number;
@@ -90,6 +92,7 @@ export class CreateCompanyDto {
   @MaxLength(50)
   defaultCurrencyName?: string;
 
+  @Type(() => Number)
   @IsNumber()
   @IsOptional()
   chiefAccountantId?: number;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,11 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ConfigProvider, message } from 'antd';
+import { App as AntdApp, ConfigProvider } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
 import React, { type ReactNode } from 'react';
 import LoginPage from './pages/login/index';
 import AppLayout from './components/layout/AppLayout';
+import { AntdInitializer } from './components/AntdInitializer';
 import UsersList from './pages/settings/users/index';
 import UserDetail from './pages/settings/users/detail';
 import UserForm from './pages/settings/users/form';
@@ -37,13 +38,6 @@ queryClient.setDefaultOptions({
   queries: {
     retry: 1,
     staleTime: 30_000,
-  },
-  mutations: {
-    onError: (error: unknown) => {
-      const err = error as { response?: { data?: { message?: string } } };
-      const msg = err?.response?.data?.message ?? '操作失败，请重试';
-      message.error(msg);
-    },
   },
 });
 
@@ -86,7 +80,9 @@ function App() {
             },
           }}
         >
-          <BrowserRouter>
+          <AntdApp>
+            <AntdInitializer />
+            <BrowserRouter>
             <Routes>
               {/* 公开路由 */}
               <Route path="/login" element={<LoginPage />} />
@@ -128,6 +124,7 @@ function App() {
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </BrowserRouter>
+          </AntdApp>
         </ConfigProvider>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/apps/web/src/api/request.ts
+++ b/apps/web/src/api/request.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { message } from 'antd';
+import antdStatic from '../utils/antdStatic';
 
 const request = axios.create({
   baseURL: '/api',
@@ -31,7 +31,7 @@ request.interceptors.response.use(
     } else {
       const rawMsg = error.response?.data?.message;
       const msg = Array.isArray(rawMsg) ? rawMsg.join('；') : (rawMsg ?? '操作失败');
-      message.error(msg);
+      antdStatic.message?.error(msg);
     }
     return Promise.reject(error.response?.data);
   },

--- a/apps/web/src/api/request.ts
+++ b/apps/web/src/api/request.ts
@@ -29,7 +29,9 @@ request.interceptors.response.use(
       localStorage.removeItem('token');
       window.location.href = '/login';
     } else {
-      message.error(error.response?.data?.message ?? '操作失败');
+      const rawMsg = error.response?.data?.message;
+      const msg = Array.isArray(rawMsg) ? rawMsg.join('；') : (rawMsg ?? '操作失败');
+      message.error(msg);
     }
     return Promise.reject(error.response?.data);
   },

--- a/apps/web/src/components/AntdInitializer.tsx
+++ b/apps/web/src/components/AntdInitializer.tsx
@@ -1,0 +1,18 @@
+import { App } from 'antd';
+import { useEffect } from 'react';
+import { initAntdStatic } from '../utils/antdStatic';
+
+/**
+ * Must be rendered inside <App> (from antd).
+ * Captures the message/modal instances provided by App.useApp() and
+ * stores them in antdStatic so non-component code can use them.
+ */
+export function AntdInitializer() {
+  const { message, modal } = App.useApp();
+
+  useEffect(() => {
+    initAntdStatic(message, modal);
+  }, [message, modal]);
+
+  return null;
+}

--- a/apps/web/src/components/common/SearchForm.tsx
+++ b/apps/web/src/components/common/SearchForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, Flex, Input, Space, Tag, theme } from 'antd';
+import { SearchOutlined, ReloadOutlined } from '@ant-design/icons';
 
 export interface ActiveTag {
   /** 唯一标识，用作 React key */
@@ -17,21 +18,26 @@ export interface SearchFormProps {
   onSearchChange: (value: string) => void;
   /** 搜索框占位文字 */
   placeholder?: string;
-  /** 高级筛选区内容（由调用方渲染，SearchForm 仅负责折叠/展开） */
+  /** 高级筛选区内容（直接全部展示，不折叠） */
   advancedContent?: React.ReactNode;
   /** 已选筛选条件，有内容时显示 Tag 列表和"清除全部"按钮 */
   activeTags?: ActiveTag[];
   /** 点击"清除全部"按钮的回调 */
   onClearAll?: () => void;
+  /** 点击"查询"按钮的回调 */
+  onQuery?: () => void;
+  /** 点击"重置"按钮的回调 */
+  onReset?: () => void;
 }
 
 /**
- * 通用搜索表单组件，封装列表页搜索/高级筛选/筛选 Tag 三段式交互。
+ * 通用搜索表单组件，封装列表页搜索/筛选/Tag 三段式交互。
  *
  * 职责边界：
  * - 只负责 UI 展示和用户交互事件上报
  * - 不持有业务状态，不发起 API 请求
  * - 防抖逻辑由调用方使用 useDebouncedValue hook 处理
+ * - 所有筛选项直接展示，不折叠
  */
 export function SearchForm({
   searchValue,
@@ -40,14 +46,17 @@ export function SearchForm({
   advancedContent,
   activeTags = [],
   onClearAll,
+  onQuery,
+  onReset,
 }: SearchFormProps) {
   const { token } = theme.useToken();
-  const [showAdvanced, setShowAdvanced] = React.useState(false);
+
+  const hasActions = onQuery != null || onReset != null;
 
   return (
     <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
-      {/* 搜索框行 */}
-      <Flex gap={token.marginSM} wrap>
+      {/* 搜索框行 + 高级筛选项（全部直接展示）+ 操作按钮 */}
+      <Flex gap={token.marginSM} wrap align="center">
         <Input
           placeholder={placeholder}
           style={{ width: 320 }}
@@ -55,19 +64,22 @@ export function SearchForm({
           onChange={(e) => onSearchChange(e.target.value)}
           allowClear
         />
-        {advancedContent != null && (
-          <Button type="link" onClick={() => setShowAdvanced((prev) => !prev)}>
-            {showAdvanced ? '收起高级筛选' : '展开高级筛选'}
-          </Button>
+        {advancedContent}
+        {hasActions && (
+          <>
+            {onQuery && (
+              <Button type="primary" icon={<SearchOutlined />} onClick={onQuery}>
+                查询
+              </Button>
+            )}
+            {onReset && (
+              <Button icon={<ReloadOutlined />} onClick={onReset}>
+                重置
+              </Button>
+            )}
+          </>
         )}
       </Flex>
-
-      {/* 高级筛选区（可折叠） */}
-      {advancedContent != null && showAdvanced && (
-        <Flex gap={token.marginSM} wrap>
-          {advancedContent}
-        </Flex>
-      )}
 
       {/* 已选筛选条件 Tag 列表 */}
       {activeTags.length > 0 && (

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -12,6 +12,15 @@ const BREADCRUMB_MAP: Record<string, { label: string; parent?: string; parentLab
   '/settings/users/create': { label: '新建用户', parent: '/settings/users', parentLabel: '用户管理' },
   '/master-data/units': { label: '单位管理', parent: '/master-data', parentLabel: '基础数据' },
   '/master-data/units/create': { label: '新建单位', parent: '/master-data/units', parentLabel: '单位管理' },
+  '/master-data/companies': { label: '公司主体管理', parent: '/master-data', parentLabel: '基础数据' },
+  '/master-data/companies/create': { label: '新建公司主体', parent: '/master-data/companies', parentLabel: '公司主体管理' },
+  '/master-data/countries': { label: '国家/地区管理', parent: '/master-data', parentLabel: '基础数据' },
+  '/master-data/countries/create': { label: '新建国家/地区', parent: '/master-data/countries', parentLabel: '国家/地区管理' },
+  '/master-data/currencies': { label: '币种管理', parent: '/master-data', parentLabel: '基础数据' },
+  '/master-data/currencies/create': { label: '新建币种', parent: '/master-data/currencies', parentLabel: '币种管理' },
+  '/master-data/warehouses': { label: '仓库管理', parent: '/master-data', parentLabel: '基础数据' },
+  '/master-data/warehouses/create': { label: '新建仓库', parent: '/master-data/warehouses', parentLabel: '仓库管理' },
+  '/master-data/product-categories': { label: '产品分类管理', parent: '/master-data', parentLabel: '基础数据' },
 };
 
 function isValidToken(token: string | null): boolean {
@@ -54,6 +63,66 @@ function getBreadcrumbItems(pathname: string): { title: string; path: string }[]
     { title: '基础数据', path: '/master-data' },
     { title: '单位管理', path: '/master-data/units' },
     { title: '单位详情', path: pathname },
+  ];
+  const companyEditMatch = pathname.match(/^\/master-data\/companies\/([a-zA-Z0-9\-_]+)\/edit$/);
+  if (companyEditMatch && companyEditMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '公司主体管理', path: '/master-data/companies' },
+    { title: '编辑公司主体', path: pathname },
+  ];
+  const companyDetailMatch = pathname.match(/^\/master-data\/companies\/([a-zA-Z0-9\-_]+)$/);
+  if (companyDetailMatch && companyDetailMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '公司主体管理', path: '/master-data/companies' },
+    { title: '公司主体详情', path: pathname },
+  ];
+  const countryEditMatch = pathname.match(/^\/master-data\/countries\/([a-zA-Z0-9\-_]+)\/edit$/);
+  if (countryEditMatch && countryEditMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '国家/地区管理', path: '/master-data/countries' },
+    { title: '编辑国家/地区', path: pathname },
+  ];
+  const countryDetailMatch = pathname.match(/^\/master-data\/countries\/([a-zA-Z0-9\-_]+)$/);
+  if (countryDetailMatch && countryDetailMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '国家/地区管理', path: '/master-data/countries' },
+    { title: '国家/地区详情', path: pathname },
+  ];
+  const currencyEditMatch = pathname.match(/^\/master-data\/currencies\/([a-zA-Z0-9\-_]+)\/edit$/);
+  if (currencyEditMatch && currencyEditMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '币种管理', path: '/master-data/currencies' },
+    { title: '编辑币种', path: pathname },
+  ];
+  const currencyDetailMatch = pathname.match(/^\/master-data\/currencies\/([a-zA-Z0-9\-_]+)$/);
+  if (currencyDetailMatch && currencyDetailMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '币种管理', path: '/master-data/currencies' },
+    { title: '币种详情', path: pathname },
+  ];
+  const warehouseEditMatch = pathname.match(/^\/master-data\/warehouses\/([a-zA-Z0-9\-_]+)\/edit$/);
+  if (warehouseEditMatch && warehouseEditMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '仓库管理', path: '/master-data/warehouses' },
+    { title: '编辑仓库', path: pathname },
+  ];
+  const warehouseDetailMatch = pathname.match(/^\/master-data\/warehouses\/([a-zA-Z0-9\-_]+)$/);
+  if (warehouseDetailMatch && warehouseDetailMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '仓库管理', path: '/master-data/warehouses' },
+    { title: '仓库详情', path: pathname },
+  ];
+  const productCategoryEditMatch = pathname.match(/^\/master-data\/product-categories\/([a-zA-Z0-9\-_]+)\/edit$/);
+  if (productCategoryEditMatch && productCategoryEditMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '产品分类管理', path: '/master-data/product-categories' },
+    { title: '编辑产品分类', path: pathname },
+  ];
+  const productCategoryDetailMatch = pathname.match(/^\/master-data\/product-categories\/([a-zA-Z0-9\-_]+)$/);
+  if (productCategoryDetailMatch && productCategoryDetailMatch[1]) return [
+    { title: '基础数据', path: '/master-data' },
+    { title: '产品分类管理', path: '/master-data/product-categories' },
+    { title: '产品分类详情', path: pathname },
   ];
   return [];
 }

--- a/apps/web/src/pages/master-data/companies/index.tsx
+++ b/apps/web/src/pages/master-data/companies/index.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Empty,
   Flex,
-  Input,
   Result,
   Skeleton,
   Space,
@@ -18,17 +17,9 @@ import type { ProColumns } from '@ant-design/pro-components';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { getCompanies, type Company } from '../../../api/companies.api';
-
-function useDebouncedValue(input: string, delay = 300) {
-  const [value, setValue] = useState(input);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setValue(input), delay);
-    return () => window.clearTimeout(timer);
-  }, [input, delay]);
-
-  return value;
-}
+import { SearchForm } from '../../../components/common/SearchForm';
+import type { ActiveTag } from '../../../components/common/SearchForm';
+import { useDebouncedValue } from '../../../hooks/useDebounce';
 
 export default function CompaniesListPage() {
   const navigate = useNavigate();
@@ -172,7 +163,7 @@ export default function CompaniesListPage() {
     </Empty>
   );
 
-  const tags = [
+  const activeTags: ActiveTag[] = [
     keyword
       ? {
           key: 'keyword',
@@ -183,7 +174,7 @@ export default function CompaniesListPage() {
           },
         }
       : null,
-  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+  ].filter(Boolean) as ActiveTag[];
 
   return (
     <div>
@@ -196,37 +187,15 @@ export default function CompaniesListPage() {
         </Button>
       </Flex>
 
-      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
-        <Input
-          placeholder="快捷搜索公司名称"
-          style={{ width: 320 }}
-          value={keywordInput}
-          onChange={(e) => {
-            setKeywordInput(e.target.value);
-            setPage(1);
-          }}
-          allowClear
-        />
-
-        {tags.length > 0 ? (
-          <Space wrap>
-            {tags.map((item) => (
-              <Tag closable key={item.key} onClose={item.onClose}>
-                {item.label}
-              </Tag>
-            ))}
-            <Button
-              type="link"
-              onClick={() => {
-                setKeywordInput('');
-                setPage(1);
-              }}
-            >
-              清除全部
-            </Button>
-          </Space>
-        ) : null}
-      </Space>
+      <SearchForm
+        searchValue={keywordInput}
+        onSearchChange={(v) => { setKeywordInput(v); setPage(1); }}
+        placeholder="快捷搜索公司名称"
+        activeTags={activeTags}
+        onClearAll={() => { setKeywordInput(''); setPage(1); }}
+        onQuery={() => { setPage(1); query.refetch(); }}
+        onReset={() => { setKeywordInput(''); setPage(1); }}
+      />
 
       <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
         <ProTable<Company>

--- a/apps/web/src/pages/master-data/countries/index.tsx
+++ b/apps/web/src/pages/master-data/countries/index.tsx
@@ -4,11 +4,9 @@ import {
   Button,
   Empty,
   Flex,
-  Input,
   Result,
   Skeleton,
   Space,
-  Tag,
   Typography,
   theme,
 } from 'antd';
@@ -17,17 +15,9 @@ import type { ProColumns } from '@ant-design/pro-components';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { getCountries, type Country } from '../../../api/countries.api';
-
-function useDebouncedValue(input: string, delay = 300) {
-  const [value, setValue] = useState(input);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setValue(input), delay);
-    return () => window.clearTimeout(timer);
-  }, [input, delay]);
-
-  return value;
-}
+import { SearchForm } from '../../../components/common/SearchForm';
+import type { ActiveTag } from '../../../components/common/SearchForm';
+import { useDebouncedValue } from '../../../hooks/useDebounce';
 
 export default function CountriesListPage() {
   const navigate = useNavigate();
@@ -39,6 +29,10 @@ export default function CountriesListPage() {
 
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword]);
 
   const query = useQuery({
     queryKey: ['countries', keyword, page, pageSize],
@@ -146,7 +140,7 @@ export default function CountriesListPage() {
     </Empty>
   );
 
-  const tags = [
+  const activeTags: ActiveTag[] = [
     keyword
       ? {
           key: 'keyword',
@@ -157,7 +151,7 @@ export default function CountriesListPage() {
           },
         }
       : null,
-  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+  ].filter(Boolean) as ActiveTag[];
 
   return (
     <div>
@@ -170,39 +164,15 @@ export default function CountriesListPage() {
         </Button>
       </Flex>
 
-      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
-        <Flex gap={token.marginSM} wrap>
-          <Input
-            placeholder="快捷搜索国家/地区代码/名称"
-            style={{ width: 320 }}
-            value={keywordInput}
-            onChange={(e) => {
-              setKeywordInput(e.target.value);
-              setPage(1);
-            }}
-            allowClear
-          />
-        </Flex>
-
-        {tags.length > 0 ? (
-          <Space wrap>
-            {tags.map((item) => (
-              <Tag closable key={item.key} onClose={item.onClose}>
-                {item.label}
-              </Tag>
-            ))}
-            <Button
-              type="link"
-              onClick={() => {
-                setKeywordInput('');
-                setPage(1);
-              }}
-            >
-              清除全部
-            </Button>
-          </Space>
-        ) : null}
-      </Space>
+      <SearchForm
+        searchValue={keywordInput}
+        onSearchChange={(v) => { setKeywordInput(v); setPage(1); }}
+        placeholder="快捷搜索国家/地区代码/名称"
+        activeTags={activeTags}
+        onClearAll={() => { setKeywordInput(''); setPage(1); }}
+        onQuery={() => { setPage(1); query.refetch(); }}
+        onReset={() => { setKeywordInput(''); setPage(1); }}
+      />
 
       <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
         <ProTable<Country>

--- a/apps/web/src/pages/master-data/currencies/index.tsx
+++ b/apps/web/src/pages/master-data/currencies/index.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Empty,
   Flex,
-  Input,
   Popconfirm,
   Result,
   Select,
@@ -22,6 +21,9 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import type { CurrencyStatus } from '@infitek/shared';
 import { getCurrencies, updateCurrency, type Currency } from '../../../api/currencies.api';
+import { SearchForm } from '../../../components/common/SearchForm';
+import type { ActiveTag } from '../../../components/common/SearchForm';
+import { useDebouncedValue } from '../../../hooks/useDebounce';
 
 const CURRENCY_STATUS_ACTIVE = 'active' as CurrencyStatus;
 const CURRENCY_STATUS_INACTIVE = 'inactive' as CurrencyStatus;
@@ -36,17 +38,6 @@ const statusTagMap = {
   inactive: { status: 'default', text: '禁用' },
 } satisfies Record<CurrencyStatus, { status: 'success' | 'default'; text: string }>;
 
-function useDebouncedValue(input: string, delay = 300) {
-  const [value, setValue] = useState(input);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setValue(input), delay);
-    return () => window.clearTimeout(timer);
-  }, [input, delay]);
-
-  return value;
-}
-
 export default function CurrenciesListPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -54,12 +45,15 @@ export default function CurrenciesListPage() {
 
   const [keywordInput, setKeywordInput] = useState('');
   const [status, setStatus] = useState<CurrencyStatus | undefined>();
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword || status);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword, status]);
 
   const query = useQuery({
     queryKey: ['currencies', keyword, status, page, pageSize],
@@ -205,7 +199,7 @@ export default function CurrenciesListPage() {
     </Empty>
   );
 
-  const tags = [
+  const activeTags: ActiveTag[] = [
     keyword
       ? {
           key: 'keyword',
@@ -226,7 +220,7 @@ export default function CurrenciesListPage() {
           },
         }
       : null,
-  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+  ].filter(Boolean) as ActiveTag[];
 
   return (
     <div>
@@ -239,59 +233,28 @@ export default function CurrenciesListPage() {
         </Button>
       </Flex>
 
-      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
-        <Flex gap={token.marginSM} wrap>
-          <Input
-            placeholder="快捷搜索币种代码/名称"
-            style={{ width: 320 }}
-            value={keywordInput}
-            onChange={(e) => {
-              setKeywordInput(e.target.value);
+      <SearchForm
+        searchValue={keywordInput}
+        onSearchChange={(v) => { setKeywordInput(v); setPage(1); }}
+        placeholder="快捷搜索币种代码/名称"
+        activeTags={activeTags}
+        onClearAll={() => { setKeywordInput(''); setStatus(undefined); setPage(1); }}
+        onQuery={() => { setPage(1); query.refetch(); }}
+        onReset={() => { setKeywordInput(''); setStatus(undefined); setPage(1); }}
+        advancedContent={
+          <Select<CurrencyStatus>
+            allowClear
+            placeholder="按状态筛选"
+            options={statusOptions}
+            value={status}
+            onChange={(value) => {
+              setStatus(value);
               setPage(1);
             }}
-            allowClear
+            style={{ width: 200 }}
           />
-          <Button type="link" onClick={() => setShowAdvanced((prev) => !prev)}>
-            {showAdvanced ? '收起高级筛选' : '展开高级筛选'}
-          </Button>
-        </Flex>
-
-        {showAdvanced ? (
-          <Flex gap={token.marginSM} wrap>
-            <Select<CurrencyStatus>
-              allowClear
-              placeholder="按状态筛选"
-              options={statusOptions}
-              value={status}
-              onChange={(value) => {
-                setStatus(value);
-                setPage(1);
-              }}
-              style={{ width: 200 }}
-            />
-          </Flex>
-        ) : null}
-
-        {tags.length > 0 ? (
-          <Space wrap>
-            {tags.map((item) => (
-              <Tag closable key={item.key} onClose={item.onClose}>
-                {item.label}
-              </Tag>
-            ))}
-            <Button
-              type="link"
-              onClick={() => {
-                setKeywordInput('');
-                setStatus(undefined);
-                setPage(1);
-              }}
-            >
-              清除全部
-            </Button>
-          </Space>
-        ) : null}
-      </Space>
+        }
+      />
 
       <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
         <ProTable<Currency>

--- a/apps/web/src/pages/master-data/product-categories/form.tsx
+++ b/apps/web/src/pages/master-data/product-categories/form.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Form, Input, message, Skeleton, TreeSelect } from 'antd';
+import { Form, Input, message, Select, Skeleton, TreeSelect } from 'antd';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createProductCategory,
@@ -9,6 +9,7 @@ import {
   updateProductCategory,
   type ProductCategoryNode,
 } from '../../../api/product-categories.api';
+import { getUsers } from '../../../api/users.api';
 
 interface TreeSelectNode {
   title: string;
@@ -95,6 +96,13 @@ export default function ProductCategoryFormPage() {
     },
   });
 
+  const usersQuery = useQuery({
+    queryKey: ['users', 'all'],
+    queryFn: () => getUsers(1, 200),
+    staleTime: 5 * 60 * 1000,
+  });
+  const userOptions = (usersQuery.data?.list ?? []).map((u) => ({ label: u.name, value: u.name }));
+
   const loading = isEdit && detailQuery.isLoading;
   const submitting = createMutation.isPending || updateMutation.isPending;
   const treeSelectData = buildTreeSelectData(treeQuery.data ?? []);
@@ -113,7 +121,7 @@ export default function ProductCategoryFormPage() {
       createMutation.mutate({
         name: values.name,
         nameEn: values.nameEn,
-        parentId: values.parentId,
+        parentId: values.parentId ?? (parentIdFromQuery ? Number(parentIdFromQuery) : undefined),
         purchaseOwner: values.purchaseOwner,
         productOwner: values.productOwner,
       });
@@ -194,7 +202,19 @@ export default function ProductCategoryFormPage() {
               </Form.Item>
             </div>
 
-            {/* 新建一级分类时可选父级；新建子分类时父级已由 URL 参数确定，不显示 */}
+            {/* 新建子分类时展示只读父级；新建一级分类时可选父级 */}
+            {!isEdit && parentIdFromQuery && (
+              <Form.Item
+                label={<span style={{ fontSize: 13, color: '#374151', fontWeight: 500 }}>父级分类</span>}
+                style={{ marginBottom: 16 }}
+              >
+                <Input
+                  value={parentNode ? parentNode.name : `分类 #${parentIdFromQuery}`}
+                  disabled
+                  size="middle"
+                />
+              </Form.Item>
+            )}
             {!isEdit && !parentIdFromQuery && (
               <Form.Item
                 label={<span style={{ fontSize: 13, color: '#374151', fontWeight: 500 }}>父级分类</span>}
@@ -216,19 +236,39 @@ export default function ProductCategoryFormPage() {
               <Form.Item
                 label={<span style={{ fontSize: 13, color: '#374151', fontWeight: 500 }}>采购负责人</span>}
                 name="purchaseOwner"
-                rules={[{ max: 100, message: '不能超过100个字符' }]}
                 style={{ marginBottom: 24 }}
               >
-                <Input placeholder="可选" size="middle" />
+                <Select
+                  placeholder="请选择用户"
+                  allowClear
+                  showSearch
+                  options={userOptions}
+                  loading={usersQuery.isLoading}
+                  size="middle"
+                  style={{ width: '100%' }}
+                  filterOption={(input, option) =>
+                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                  }
+                />
               </Form.Item>
 
               <Form.Item
                 label={<span style={{ fontSize: 13, color: '#374151', fontWeight: 500 }}>产品负责人</span>}
                 name="productOwner"
-                rules={[{ max: 100, message: '不能超过100个字符' }]}
                 style={{ marginBottom: 24 }}
               >
-                <Input placeholder="可选" size="middle" />
+                <Select
+                  placeholder="请选择用户"
+                  allowClear
+                  showSearch
+                  options={userOptions}
+                  loading={usersQuery.isLoading}
+                  size="middle"
+                  style={{ width: '100%' }}
+                  filterOption={(input, option) =>
+                    (option?.label ?? '').toLowerCase().includes(input.toLowerCase())
+                  }
+                />
               </Form.Item>
             </div>
 

--- a/apps/web/src/pages/master-data/product-categories/index.tsx
+++ b/apps/web/src/pages/master-data/product-categories/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Modal, Result, Skeleton, message } from 'antd';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { App, Button, Result, Skeleton } from 'antd';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteProductCategory, getProductCategoryTree, type ProductCategoryNode } from '../../../api/product-categories.api';
 
 // ─── helpers ───────────────────────────────────────────────────────────────
@@ -157,6 +157,7 @@ function TreeNode({
 export default function ProductCategoriesPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { message, modal } = App.useApp();
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
   const [searchText, setSearchText] = useState('');
@@ -346,7 +347,7 @@ export default function ProductCategoriesPage() {
                 onEdit={() => navigate(`/master-data/product-categories/${selectedNode.id}/edit`)}
                 onCreateChild={() => navigate(`/master-data/product-categories/create?parentId=${selectedNode.id}`)}
                 onDelete={() => {
-                  Modal.confirm({
+                  modal.confirm({
                     title: `删除「${selectedNode.name}」？`,
                     content: selectedNode.children.length > 0
                       ? '该分类下有子分类，请先删除子分类后再操作。'

--- a/apps/web/src/pages/master-data/product-categories/index.tsx
+++ b/apps/web/src/pages/master-data/product-categories/index.tsx
@@ -236,7 +236,7 @@ export default function ProductCategoriesPage() {
           onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#4338CA'; }}
           onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = '#4F46E5'; }}
         >
-          + 新建一级分类
+          + 新建分类
         </button>
       </div>
 
@@ -302,7 +302,7 @@ export default function ProductCategoriesPage() {
                         onClick={() => navigate('/master-data/product-categories/create')}
                         style={{ padding: '6px 14px', borderRadius: 7, fontSize: 12, background: '#4F46E5', color: '#fff', border: 'none', cursor: 'pointer' }}
                       >
-                        新建一级分类
+                        新建分类
                       </button>
                     </>
                   ) : '无匹配结果'}
@@ -355,10 +355,14 @@ export default function ProductCategoriesPage() {
                     okButtonProps: { danger: true, disabled: selectedNode.children.length > 0 },
                     cancelText: '取消',
                     onOk: async () => {
-                      await deleteProductCategory(selectedNode.id);
-                      message.success('删除成功');
-                      queryClient.invalidateQueries({ queryKey: ['product-categories', 'tree'] });
-                      setSelectedId(null);
+                      try {
+                        await deleteProductCategory(selectedNode.id);
+                        message.success('删除成功');
+                        queryClient.invalidateQueries({ queryKey: ['product-categories', 'tree'] });
+                        setSelectedId(null);
+                      } catch {
+                        // 错误由 request.ts 统一处理
+                      }
                     },
                   });
                 }}

--- a/apps/web/src/pages/master-data/units/index.tsx
+++ b/apps/web/src/pages/master-data/units/index.tsx
@@ -216,6 +216,15 @@ export default function UnitsListPage() {
           setStatus(undefined);
           setPage(1);
         }}
+        onQuery={() => {
+          setPage(1);
+          query.refetch();
+        }}
+        onReset={() => {
+          setKeywordInput('');
+          setStatus(undefined);
+          setPage(1);
+        }}
         advancedContent={
           <Select<UnitStatus>
             allowClear

--- a/apps/web/src/pages/master-data/warehouses/index.tsx
+++ b/apps/web/src/pages/master-data/warehouses/index.tsx
@@ -5,13 +5,11 @@ import {
   Button,
   Empty,
   Flex,
-  Input,
   Popconfirm,
   Result,
   Select,
   Skeleton,
   Space,
-  Tag,
   Tooltip,
   Typography,
   message,
@@ -23,6 +21,9 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import type { WarehouseStatus } from '@infitek/shared';
 import { getWarehouses, updateWarehouse, type Warehouse } from '../../../api/warehouses.api';
+import { SearchForm } from '../../../components/common/SearchForm';
+import type { ActiveTag } from '../../../components/common/SearchForm';
+import { useDebouncedValue } from '../../../hooks/useDebounce';
 
 const WAREHOUSE_STATUS_ACTIVE = 'active' as WarehouseStatus;
 const WAREHOUSE_STATUS_INACTIVE = 'inactive' as WarehouseStatus;
@@ -37,17 +38,6 @@ const statusTagMap = {
   inactive: { status: 'default', text: '禁用' },
 } satisfies Record<WarehouseStatus, { status: 'success' | 'default'; text: string }>;
 
-function useDebouncedValue(input: string, delay = 300) {
-  const [value, setValue] = useState(input);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => setValue(input), delay);
-    return () => window.clearTimeout(timer);
-  }, [input, delay]);
-
-  return value;
-}
-
 export default function WarehousesListPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -55,12 +45,15 @@ export default function WarehousesListPage() {
 
   const [keywordInput, setKeywordInput] = useState('');
   const [status, setStatus] = useState<WarehouseStatus | undefined>();
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
   const keyword = useDebouncedValue(keywordInput, 300).trim();
   const hasFilters = Boolean(keyword || status);
+
+  useEffect(() => {
+    setPage(1);
+  }, [keyword, status]);
 
   const query = useQuery({
     queryKey: ['warehouses', keyword, status, page, pageSize],
@@ -207,7 +200,7 @@ export default function WarehousesListPage() {
     </Empty>
   );
 
-  const tags = [
+  const activeTags: ActiveTag[] = [
     keyword
       ? {
           key: 'keyword',
@@ -228,7 +221,7 @@ export default function WarehousesListPage() {
           },
         }
       : null,
-  ].filter(Boolean) as Array<{ key: string; label: string; onClose: () => void }>;
+  ].filter(Boolean) as ActiveTag[];
 
   return (
     <div>
@@ -241,59 +234,28 @@ export default function WarehousesListPage() {
         </Button>
       </Flex>
 
-      <Space direction="vertical" size={token.marginSM} style={{ width: '100%' }}>
-        <Flex gap={token.marginSM} wrap>
-          <Input
-            placeholder="快捷搜索仓库名称/地址"
-            style={{ width: 320 }}
-            value={keywordInput}
-            onChange={(e) => {
-              setKeywordInput(e.target.value);
+      <SearchForm
+        searchValue={keywordInput}
+        onSearchChange={(v) => { setKeywordInput(v); setPage(1); }}
+        placeholder="快捷搜索仓库名称/地址"
+        activeTags={activeTags}
+        onClearAll={() => { setKeywordInput(''); setStatus(undefined); setPage(1); }}
+        onQuery={() => { setPage(1); query.refetch(); }}
+        onReset={() => { setKeywordInput(''); setStatus(undefined); setPage(1); }}
+        advancedContent={
+          <Select<WarehouseStatus>
+            allowClear
+            placeholder="按状态筛选"
+            options={statusOptions}
+            value={status}
+            onChange={(value) => {
+              setStatus(value);
               setPage(1);
             }}
-            allowClear
+            style={{ width: 200 }}
           />
-          <Button type="link" onClick={() => setShowAdvanced((prev) => !prev)}>
-            {showAdvanced ? '收起高级筛选' : '展开高级筛选'}
-          </Button>
-        </Flex>
-
-        {showAdvanced ? (
-          <Flex gap={token.marginSM} wrap>
-            <Select<WarehouseStatus>
-              allowClear
-              placeholder="按状态筛选"
-              options={statusOptions}
-              value={status}
-              onChange={(value) => {
-                setStatus(value);
-                setPage(1);
-              }}
-              style={{ width: 200 }}
-            />
-          </Flex>
-        ) : null}
-
-        {tags.length > 0 ? (
-          <Space wrap>
-            {tags.map((item) => (
-              <Tag closable key={item.key} onClose={item.onClose}>
-                {item.label}
-              </Tag>
-            ))}
-            <Button
-              type="link"
-              onClick={() => {
-                setKeywordInput('');
-                setStatus(undefined);
-                setPage(1);
-              }}
-            >
-              清除全部
-            </Button>
-          </Space>
-        ) : null}
-      </Space>
+        }
+      />
 
       <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
         <ProTable<Warehouse>

--- a/apps/web/src/pages/settings/users/index.tsx
+++ b/apps/web/src/pages/settings/users/index.tsx
@@ -31,12 +31,12 @@ export default function UsersList() {
   const [searchInput, setSearchInput] = useState('');
   const [statusInput, setStatusInput] = useState('');
 
-  const fetchUsers = async (page: number = 1, search: string = '', status: string = '') => {
+  const fetchUsers = async (page: number = 1, search: string = '', status: string = '', pageSize?: number) => {
     setState((prev) => ({ ...prev, loading: true }));
     try {
       const data = await getUsers(
         page,
-        state.pageSize,
+        pageSize ?? state.pageSize,
         search || undefined,
         (status as 'ACTIVE' | 'INACTIVE') || undefined,
       );
@@ -175,10 +175,13 @@ export default function UsersList() {
             current: state.page,
             pageSize: state.pageSize,
             total: state.total,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
             showTotal: (total) => `共 ${total} 条`,
-            onChange: (page) => {
-              setState((prev) => ({ ...prev, page }));
-              fetchUsers(page, state.search, state.statusFilter);
+            onChange: (page, pageSize) => {
+              const newPage = pageSize !== state.pageSize ? 1 : page;
+              setState((prev) => ({ ...prev, page: newPage, pageSize }));
+              fetchUsers(newPage, state.search, state.statusFilter, pageSize);
             },
           }}
         />

--- a/apps/web/src/utils/antdStatic.ts
+++ b/apps/web/src/utils/antdStatic.ts
@@ -1,0 +1,25 @@
+/**
+ * antdStatic — stores App.useApp() instances so non-component code
+ * (axios interceptors, queryClient callbacks) can call message/modal
+ * without the "Static function can not consume context" warning.
+ *
+ * Usage:
+ *   import antdStatic from '../utils/antdStatic';
+ *   antdStatic.message.error('...');
+ */
+import type { MessageInstance } from 'antd/es/message/interface';
+import type { ModalStaticFunctions } from 'antd/es/modal/confirm';
+
+type ModalInstance = Omit<ModalStaticFunctions, 'warn'>;
+
+const antdStatic: { message: MessageInstance; modal: ModalInstance } = {
+  message: undefined as unknown as MessageInstance,
+  modal: undefined as unknown as ModalInstance,
+};
+
+export function initAntdStatic(message: MessageInstance, modal: ModalInstance) {
+  antdStatic.message = message;
+  antdStatic.modal = modal;
+}
+
+export default antdStatic;


### PR DESCRIPTION
## Summary

- **Bug1**: 修复 `CreateCompanyDto` 中 `countryId`/`chiefAccountantId` 字符串→数字类型转换失败（添加 `@Type(() => Number)`）
- **Bug2**: 移除所有列表页「展开高级筛选」折叠按钮，改为所有筛选项直接展示；`SearchForm` 组件新增「查询」「重置」操作按钮
- **Bug3**: 补全 `AppLayout` 面包屑，覆盖 companies/countries/currencies/warehouses/product-categories 各级页面
- **Bug4**: 用户管理分页添加页大小选择器（`showSizeChanger`），修复 `fetchUsers` 的 pageSize 闭包问题
- **Bug5**: 修复 API 错误 toast 不显示问题（NestJS class-validator 返回数组 `message`，改为 join 后传给 `message.error`）
- **Bug6**: 产品分类多项修复（按钮文案、删除确认/反馈、子分类 parentId 丢失、负责人改为用户选择器 Select）
- **Follow-up Fix**: 修复 React 19 场景下 Antd 静态 `message/Modal` 显示问题，并清理 `useMutation` 未使用导致的构建报错

## Test plan

- [x] 创建公司主体，填写国家 ID，验证不再报 400 类型错误
- [x] 进入各列表页（单位、公司、国家/地区、币种、仓库），确认筛选栏无折叠按钮，「查询」「重置」按钮均可见
- [x] 进入公司/国家/地区/币种/仓库详情与编辑页，确认面包屑正确显示层级
- [x] 用户管理列表页确认分页区有页大小选项（10/20/50）
- [x] 触发表单验证错误，确认 toast 显示具体的校验信息而非乱码
- [x] 产品分类页：「新建分类」按钮文案正确；删除操作有成功/失败反馈；新建子分类时父级只读展示且数据保存正确；负责人字段为下拉选择器

## 本地验证补充

- 按 BMAD TEA 的 PR 阶段思路执行关键 API + E2E 验证（P0/关键路径）
- 2026-04-21 基于最新提交复测通过：
  - #35 已复测通过并关闭
  - #36 已复测通过并关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)
