### PR TITLE
feat(3-5): 产品证书库管理

### DIFF
--- a/_bmad-output/implementation-artifacts/3-5-产品证书库管理.md
+++ b/_bmad-output/implementation-artifacts/3-5-产品证书库管理.md
@@ -1,0 +1,874 @@
+# Story 3.5: 产品证书库管理
+
+Status: ready-for-dev
+
+## Story
+
+As a 产品专员,
+I want 在产品证书库中创建和管理证书记录（如 CE/FCC），上传证书文件，记录有效期和发证机构，并关联适用 SPU,
+So that 商务人员可以在系统内直接下载最新有效证书，不再到处找文件。
+
+---
+
+## Acceptance Criteria
+
+**Given** 产品专员进入产品证书库列表页
+**When** 页面加载完成
+**Then** 展示证书列表（ProTable），含列：证书编号、证书名称、证书类型、适用 SPU、有效期区间、发证机构、状态（有效/已过期）
+**And** 支持按证书类型/SPU/归属类型筛选、关键字搜索、分页
+
+**Given** 产品专员点击"新建证书"
+**When** 进入证书创建表单
+**Then** 表单包含以下字段：
+- 证书名称（必填）
+- 证书类型（必填，如 CE/FCC/RoHS）
+- 证书编号（选填，不填自动生成 CERT001）
+- 指令法规（选填）
+- 有效期起始日（必填）
+- 有效期结束日（必填）
+- 发证日期（选填）
+- 发证机构（必填）
+- 证书说明（选填）
+- 归属类型（选填）
+- 所属产品分类（选填，TreeSelect）
+- 适用 SPU（必填，多选）
+- 证书文件上传（必填）
+**And** 文件上传至阿里云 OSS（使用已有 FilesService）
+
+**Given** 产品专员上传证书文件
+**When** 文件上传成功
+**Then** 文件存储在阿里云 OSS，数据库记录 file_key 和 file_name
+**And** 服务端不在本地磁盘持久化文件
+
+**Given** 任意用户在证书详情页
+**When** 点击"下载证书"
+**Then** 调用 FilesService.getSignedUrl 获取签名 URL，浏览器打开下载
+
+**Given** 产品专员在证书详情页点击"删除"
+**When** 系统弹出 Modal 二次确认（"删除后文件将从云存储永久删除，无法恢复"）
+**Then** 确认后执行 OSS 物理删除（FilesService.delete）+ 数据库记录删除
+
+**Given** 证书有效期结束日早于当前日期
+**When** 查看证书列表或详情
+**Then** 状态展示"已过期"（红色 Tag，UX-DR07 error），否则展示"有效"（绿色 Tag，UX-DR07 success）
+
+---
+
+## Tasks / Subtasks
+
+### 后端：certificates 模块
+
+- [ ] 创建 Shared Enum `packages/shared/src/enums/certificate-status.enum.ts`
+- [ ] 更新 `packages/shared/src/index.ts` 导出新枚举
+- [ ] 创建 Entity `apps/api/src/modules/master-data/certificates/entities/certificate.entity.ts`
+- [ ] 创建 DTO：`create-certificate.dto.ts`、`update-certificate.dto.ts`、`query-certificate.dto.ts`
+- [ ] 创建 Repository `certificates.repository.ts`（含 findAll、findById、create、update、delete、generateCode）
+- [ ] 创建 Service `certificates.service.ts`（含 CRUD、OSS 集成、状态计算、分类校验）
+- [ ] 创建 Controller `certificates.controller.ts`（标准 CRUD 5 个端点）
+- [ ] 创建 Module `certificates.module.ts`（import SpusModule + ProductCategoriesModule）
+- [ ] 创建 Migration `20260422000200-create-certificates-table.ts`（含 certificates 表 + certificate_spus 表）
+- [ ] 注册 CertificatesModule 到 `apps/api/src/app.module.ts`
+- [ ] 创建 Service 单元测试 `tests/certificates.service.spec.ts`
+
+### 前端：certificates 页面
+
+- [ ] 创建 API 层 `apps/web/src/api/certificates.api.ts`
+- [ ] 创建列表页 `apps/web/src/pages/master-data/certificates/index.tsx`
+- [ ] 创建详情页 `apps/web/src/pages/master-data/certificates/detail.tsx`
+- [ ] 创建表单页 `apps/web/src/pages/master-data/certificates/form.tsx`
+- [ ] 在 `apps/web/src/App.tsx` 注册 4 条路由
+
+---
+
+## Dev Agent Context
+
+### 关键架构决策
+
+**FilesService 已是全局模块（isGlobal: true），无需 import 即可注入：**
+```typescript
+// certificates.module.ts 无需 import FilesModule
+constructor(
+  private readonly repo: CertificatesRepository,
+  private readonly filesService: FilesService,
+  private readonly spusService: SpusService,
+  private readonly categoriesService: ProductCategoriesService,
+) {}
+```
+
+**文件上传策略（两步式，不用 multipart/form-data 混合）：**
+1. 前端先调用 `POST /api/files/upload?folder=certificates` 上传文件，获得 `{ key, filename, size }`
+2. 前端将 `fileKey` 和 `fileName` 作为普通 JSON 字段提交到 `POST /api/certificates`
+3. CertificatesController 接收标准 JSON body，不需要 FileInterceptor
+
+**状态字段不存库，由 Service 层计算后附加到响应：**
+```typescript
+private withStatus(cert: Certificate): Certificate & { status: string } {
+  const status = new Date(cert.validUntil) < new Date() ? 'expired' : 'valid';
+  return { ...cert, status } as any;
+}
+```
+
+**SPU 关联：使用 TypeORM @ManyToMany + @JoinTable（junction table: certificate_spus）**
+
+**所属产品分类：存 category_id（nullable），Service 层可选校验，Repository 层 LEFT JOIN 取 category.name**
+
+### 文件结构
+
+```
+apps/api/src/modules/master-data/certificates/
+├── certificates.module.ts
+├── certificates.controller.ts
+├── certificates.service.ts
+├── certificates.repository.ts
+├── entities/
+│   └── certificate.entity.ts
+├── dto/
+│   ├── create-certificate.dto.ts
+│   ├── update-certificate.dto.ts
+│   └── query-certificate.dto.ts
+└── tests/
+    └── certificates.service.spec.ts
+
+packages/shared/src/enums/
+└── certificate-status.enum.ts
+
+apps/api/src/migrations/
+└── 20260422000200-create-certificates-table.ts
+
+apps/web/src/pages/master-data/certificates/
+├── index.tsx
+├── detail.tsx
+└── form.tsx
+
+apps/web/src/api/
+└── certificates.api.ts
+```
+
+---
+
+### 后端实现规范
+
+#### Shared Enum
+
+```typescript
+// packages/shared/src/enums/certificate-status.enum.ts
+export const CertificateStatus = {
+  VALID: 'valid',
+  EXPIRED: 'expired',
+} as const;
+export type CertificateStatus = typeof CertificateStatus[keyof typeof CertificateStatus];
+```
+
+在 `packages/shared/src/index.ts` 中添加导出：
+```typescript
+export * from './enums/certificate-status.enum';
+```
+
+#### Entity（完整字段清单）
+
+```typescript
+// apps/api/src/modules/master-data/certificates/entities/certificate.entity.ts
+import { Column, Entity, Index, JoinTable, ManyToMany, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+import { Spu } from '../../spus/entities/spu.entity';
+
+@Entity('certificates')
+@Unique('uq_certificates_certificate_no', ['certificateNo'])
+@Index('idx_certificates_type', ['certificateType'])
+@Index('idx_certificates_valid_until', ['validUntil'])
+@Index('idx_certificates_category_id', ['categoryId'])
+export class Certificate extends BaseEntity {
+  // ── 证书基础信息 ────────────────────────────────────────────
+  @Column({ name: 'certificate_name', type: 'varchar', length: 200 })
+  @Expose()
+  certificateName: string; // 证书名称（必填）
+
+  @Column({ name: 'certificate_no', type: 'varchar', length: 30 })
+  @Expose()
+  certificateNo: string; // 证书编号（自动生成 CERT001 或用户输入）
+
+  @Column({ name: 'certificate_type', type: 'varchar', length: 50 })
+  @Expose()
+  certificateType: string; // 证书类型：CE, FCC, RoHS, KC, PSE 等（必填）
+
+  @Column({ name: 'directive', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  directive: string | null; // 指令法规（如 "CE Directive 2014/35/EU"）
+
+  // ── 有效期信息 ──────────────────────────────────────────────
+  @Column({ name: 'issue_date', type: 'date', nullable: true })
+  @Expose()
+  issueDate: string | null; // 发证日期（YYYY-MM-DD，选填，与 validFrom 独立）
+
+  @Column({ name: 'valid_from', type: 'date' })
+  @Expose()
+  validFrom: string; // 有效期起始日（YYYY-MM-DD，必填）
+
+  @Column({ name: 'valid_until', type: 'date' })
+  @Expose()
+  validUntil: string; // 有效期结束日（YYYY-MM-DD，必填），用于计算 status
+
+  // ── 发证机构 ────────────────────────────────────────────────
+  @Column({ name: 'issuing_authority', type: 'varchar', length: 200 })
+  @Expose()
+  issuingAuthority: string; // 发证机构（必填）
+
+  // ── 附加信息 ────────────────────────────────────────────────
+  @Column({ name: 'remarks', type: 'text', nullable: true })
+  @Expose()
+  remarks: string | null; // 证书说明（备注）
+
+  @Column({ name: 'attribution_type', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  attributionType: string | null; // 归属类型（如"产品类别证书"/"产品专项证书"）
+
+  // ── 产品分类关联 ─────────────────────────────────────────────
+  @Column({ name: 'category_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  categoryId: number | null; // FK to product_categories（选填）
+
+  // ── 文件信息 ────────────────────────────────────────────────
+  @Column({ name: 'file_key', type: 'varchar', length: 500, nullable: true })
+  @Expose()
+  fileKey: string | null; // OSS 存储 key
+
+  @Column({ name: 'file_name', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  fileName: string | null; // 原始文件名（展示用）
+
+  // ── SPU 关联（多对多）────────────────────────────────────────
+  @ManyToMany(() => Spu, { cascade: false, eager: false })
+  @JoinTable({
+    name: 'certificate_spus',
+    joinColumn: { name: 'certificate_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'spu_id', referencedColumnName: 'id' },
+  })
+  @Expose()
+  spus: Spu[];
+}
+// 注意：BaseEntity 只有 id/createdAt/updatedAt/createdBy/updatedBy，无 deletedAt，无软删除
+```
+
+#### Migration（完整列清单）
+
+文件名：`20260422000200-create-certificates-table.ts`
+（参考 `20260421000100-create-spus-table.ts` 写法）
+
+```typescript
+// ── certificates 表列清单 ──────────────────────────────────────
+// id                (bigint unsigned PK autoincrement)
+// certificate_name  (varchar 200, not null)           证书名称
+// certificate_no    (varchar 30, not null, unique)    证书编号
+// certificate_type  (varchar 50, not null)            证书类型
+// directive         (varchar 200, nullable)           指令法规
+// issue_date        (date, nullable)                  发证日期
+// valid_from        (date, not null)                  有效期起始日
+// valid_until       (date, not null)                  有效期结束日
+// issuing_authority (varchar 200, not null)           发证机构
+// remarks           (text, nullable)                  证书说明
+// attribution_type  (varchar 50, nullable)            归属类型
+// category_id       (bigint unsigned, nullable)       所属产品分类 FK
+// file_key          (varchar 500, nullable)           OSS key
+// file_name         (varchar 200, nullable)           原始文件名
+// created_at        (datetime default CURRENT_TIMESTAMP)
+// updated_at        (datetime default CURRENT_TIMESTAMP onUpdate CURRENT_TIMESTAMP)
+// created_by        (varchar 100, nullable)
+// updated_by        (varchar 100, nullable)
+//
+// ── 索引 ─────────────────────────────────────────────────────
+// uq_certificates_certificate_no (certificate_no, unique)
+// idx_certificates_type          (certificate_type)
+// idx_certificates_valid_until   (valid_until)
+// idx_certificates_category_id   (category_id)
+//
+// ── certificate_spus 关联表 ───────────────────────────────────
+// certificate_id (bigint unsigned, not null)
+// spu_id         (bigint unsigned, not null)
+// PRIMARY KEY(certificate_id, spu_id)
+// INDEX(spu_id)
+```
+
+#### DTOs
+
+```typescript
+// ── create-certificate.dto.ts ──────────────────────────────────
+import {
+  IsNotEmpty, IsString, IsDateString, IsOptional,
+  IsArray, ArrayNotEmpty, IsNumber, IsPositive, IsInt,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateCertificateDto {
+  @IsNotEmpty() @IsString()
+  certificateName: string; // 证书名称（必填）
+
+  @IsNotEmpty() @IsString()
+  certificateType: string; // 必填
+
+  @IsOptional() @IsString()
+  certificateNo?: string; // 选填，不填时自动生成 CERT001
+
+  @IsOptional() @IsString()
+  directive?: string; // 指令法规（选填）
+
+  @IsOptional() @IsDateString()
+  issueDate?: string; // 发证日期（选填，YYYY-MM-DD）
+
+  @IsNotEmpty() @IsDateString()
+  validFrom: string; // 必填，YYYY-MM-DD
+
+  @IsNotEmpty() @IsDateString()
+  validUntil: string; // 必填，YYYY-MM-DD
+
+  @IsNotEmpty() @IsString()
+  issuingAuthority: string; // 发证机构（必填）
+
+  @IsOptional() @IsString()
+  remarks?: string; // 证书说明（选填）
+
+  @IsOptional() @IsString()
+  attributionType?: string; // 归属类型（选填）
+
+  @IsOptional() @IsInt() @IsPositive()
+  @Type(() => Number)
+  categoryId?: number; // 所属产品分类 ID（选填）
+
+  @IsArray() @ArrayNotEmpty()
+  @IsNumber({}, { each: true }) @IsPositive({ each: true })
+  @Type(() => Number)
+  spuIds: number[]; // 适用 SPU（必填，至少 1 个）
+
+  @IsOptional() @IsString()
+  fileKey?: string; // OSS key（前端先上传后获得）
+
+  @IsOptional() @IsString()
+  fileName?: string; // 原始文件名
+}
+
+// ── query-certificate.dto.ts ───────────────────────────────────
+export class QueryCertificateDto {
+  keyword?: string;
+  certificateType?: string;
+  attributionType?: string;
+  @Type(() => Number) spuId?: number;
+  @Type(() => Number) categoryId?: number;
+  @Type(() => Number) page?: number;
+  @Type(() => Number) pageSize?: number;
+}
+// update-certificate.dto.ts — 使用 PartialType(CreateCertificateDto) 或手动所有字段可选
+```
+
+#### Repository
+
+```typescript
+// apps/api/src/modules/master-data/certificates/certificates.repository.ts
+async findAll(query: QueryCertificateDto) {
+  const { keyword, page = 1, pageSize = 20, certificateType, spuId, categoryId, attributionType } = query;
+  const qb = this.repo.createQueryBuilder('c')
+    .leftJoinAndSelect('c.spus', 'spu');
+
+  if (keyword) {
+    qb.where(
+      '(c.certificate_no LIKE :kw OR c.certificate_name LIKE :kw OR c.certificate_type LIKE :kw OR c.issuing_authority LIKE :kw)',
+      { kw: `%${keyword}%` }
+    );
+  }
+  if (certificateType) qb.andWhere('c.certificate_type = :certificateType', { certificateType });
+  if (attributionType) qb.andWhere('c.attribution_type = :attributionType', { attributionType });
+  if (categoryId !== undefined) qb.andWhere('c.category_id = :categoryId', { categoryId });
+  if (spuId !== undefined) qb.andWhere('spu.id = :spuId', { spuId });
+
+  const [list, total] = await qb
+    .orderBy('c.created_at', 'DESC')
+    .skip((page - 1) * pageSize)
+    .take(pageSize)
+    .getManyAndCount();
+  return { list, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+}
+
+async findById(id: number): Promise<Certificate | null> {
+  return this.repo.findOne({ where: { id }, relations: ['spus'] });
+}
+
+// create / update / delete / generateCode 同前（CERT001 格式）
+// generateCode: SELECT MAX(certificate_no) WHERE certificate_no LIKE 'CERT%'
+```
+
+#### Service（新增字段处理）
+
+```typescript
+// apps/api/src/modules/master-data/certificates/certificates.service.ts
+@Injectable()
+export class CertificatesService {
+  constructor(
+    private readonly repo: CertificatesRepository,
+    private readonly filesService: FilesService,        // 全局，直接注入
+    private readonly spusService: SpusService,          // from SpusModule
+    private readonly categoriesService: ProductCategoriesService, // from ProductCategoriesModule
+  ) {}
+
+  async create(dto: CreateCertificateDto, operator?: string) {
+    // 1. 校验 SPU 存在
+    const spus = await Promise.all(dto.spuIds.map(id => this.spusService.findById(id)));
+    const missingIdx = spus.findIndex(s => !s);
+    if (missingIdx !== -1) throw new NotFoundException(`SPU ${dto.spuIds[missingIdx]} 不存在`);
+
+    // 2. 可选校验分类存在
+    if (dto.categoryId) {
+      const cat = await this.categoriesService.findById(dto.categoryId);
+      if (!cat) throw new NotFoundException('产品分类不存在');
+    }
+
+    // 3. 生成编号
+    const certificateNo = dto.certificateNo || await this.repo.generateCode();
+
+    const entity = await this.repo.create({
+      certificateName: dto.certificateName,
+      certificateNo,
+      certificateType: dto.certificateType,
+      directive: dto.directive ?? null,
+      issueDate: dto.issueDate ?? null,
+      validFrom: dto.validFrom,
+      validUntil: dto.validUntil,
+      issuingAuthority: dto.issuingAuthority,
+      remarks: dto.remarks ?? null,
+      attributionType: dto.attributionType ?? null,
+      categoryId: dto.categoryId ?? null,
+      fileKey: dto.fileKey ?? null,
+      fileName: dto.fileName ?? null,
+      spus: spus as any[],
+      createdBy: operator,
+      updatedBy: operator,
+    });
+    return this.withStatus(entity);
+  }
+
+  async update(id: number, dto: UpdateCertificateDto, operator?: string) {
+    const existing = await this.repo.findById(id);
+    if (!existing) throw new NotFoundException('证书不存在');
+
+    const updates: any = { updatedBy: operator };
+    // 映射所有可更新字段
+    const fields = [
+      'certificateName', 'certificateType', 'directive', 'issueDate',
+      'validFrom', 'validUntil', 'issuingAuthority', 'remarks',
+      'attributionType', 'categoryId', 'fileKey', 'fileName',
+    ];
+    for (const f of fields) {
+      if ((dto as any)[f] !== undefined) updates[f] = (dto as any)[f];
+    }
+
+    if (dto.categoryId !== undefined && dto.categoryId !== null) {
+      const cat = await this.categoriesService.findById(dto.categoryId);
+      if (!cat) throw new NotFoundException('产品分类不存在');
+    }
+    if (dto.spuIds !== undefined) {
+      const spus = await Promise.all(dto.spuIds.map(id => this.spusService.findById(id)));
+      updates.spus = spus;
+    }
+
+    const updated = await this.repo.update(id, updates);
+    return this.withStatus(updated!);
+  }
+
+  async remove(id: number) {
+    const existing = await this.repo.findById(id);
+    if (!existing) throw new NotFoundException('证书不存在');
+    if (existing.fileKey) await this.filesService.delete(existing.fileKey); // OSS 先删
+    await this.repo.delete(id);
+  }
+
+  private withStatus(cert: Certificate): Certificate & { status: string } {
+    const status = new Date(cert.validUntil) < new Date() ? 'expired' : 'valid';
+    return { ...cert, status } as any;
+  }
+}
+```
+
+#### Module
+
+```typescript
+// apps/api/src/modules/master-data/certificates/certificates.module.ts
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Certificate } from './entities/certificate.entity';
+import { CertificatesController } from './certificates.controller';
+import { CertificatesRepository } from './certificates.repository';
+import { CertificatesService } from './certificates.service';
+import { SpusModule } from '../spus/spus.module';
+import { ProductCategoriesModule } from '../product-categories/product-categories.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Certificate]),
+    SpusModule,              // exports SpusService
+    ProductCategoriesModule, // exports ProductCategoriesService（校验 categoryId）
+  ],
+  controllers: [CertificatesController],
+  providers: [CertificatesRepository, CertificatesService],
+  exports: [CertificatesService],
+})
+export class CertificatesModule {}
+// 注意：FilesModule 是 isGlobal:true，无需 import
+```
+
+**ProductCategoriesModule 已 export ProductCategoriesService（确认已有）：**
+在 `apps/api/src/modules/master-data/product-categories/product-categories.module.ts` 中检查 `exports: [ProductCategoriesService]`，如未导出则添加。
+
+#### 注册到 AppModule
+
+```typescript
+// apps/api/src/app.module.ts
+import { CertificatesModule } from './modules/master-data/certificates/certificates.module';
+// 在 imports 数组 SpusModule 后面添加：
+CertificatesModule,
+```
+
+---
+
+### 前端实现规范
+
+#### API 层（完整接口定义）
+
+```typescript
+// apps/web/src/api/certificates.api.ts
+import apiClient from './client';
+
+export interface Certificate {
+  id: number;
+  certificateName: string;
+  certificateNo: string;
+  certificateType: string;
+  directive: string | null;
+  issueDate: string | null;
+  validFrom: string;
+  validUntil: string;
+  issuingAuthority: string;
+  remarks: string | null;
+  attributionType: string | null;
+  categoryId: number | null;
+  fileKey: string | null;
+  fileName: string | null;
+  status: 'valid' | 'expired'; // 由 Service 计算后返回
+  spus: Array<{ id: number; spuCode: string; name: string }>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CertificateListQuery {
+  keyword?: string;
+  certificateType?: string;
+  attributionType?: string;
+  spuId?: number;
+  categoryId?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CreateCertificatePayload {
+  certificateName: string;
+  certificateType: string;
+  certificateNo?: string;
+  directive?: string;
+  issueDate?: string;
+  validFrom: string;
+  validUntil: string;
+  issuingAuthority: string;
+  remarks?: string;
+  attributionType?: string;
+  categoryId?: number;
+  spuIds: number[];
+  fileKey?: string;
+  fileName?: string;
+}
+
+export async function getCertificates(params?: CertificateListQuery) {
+  const res = await apiClient.get('/certificates', { params });
+  return res.data.data as {
+    list: Certificate[]; total: number; page: number; pageSize: number; totalPages: number;
+  };
+}
+export async function getCertificateById(id: number) {
+  const res = await apiClient.get(`/certificates/${id}`);
+  return res.data.data as Certificate;
+}
+export async function createCertificate(payload: CreateCertificatePayload) {
+  const res = await apiClient.post('/certificates', payload);
+  return res.data.data as Certificate;
+}
+export async function updateCertificate(id: number, payload: Partial<CreateCertificatePayload>) {
+  const res = await apiClient.patch(`/certificates/${id}`, payload);
+  return res.data.data as Certificate;
+}
+export async function deleteCertificate(id: number) {
+  await apiClient.delete(`/certificates/${id}`);
+}
+export async function getCertificateFileSignedUrl(fileKey: string) {
+  const res = await apiClient.get('/files/signed-url', { params: { key: fileKey } });
+  return res.data.data as string;
+}
+export async function uploadCertificateFile(file: File): Promise<{ key: string; filename: string; size: number }> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await apiClient.post('/files/upload?folder=certificates', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data.data;
+}
+```
+
+#### 表单页关键字段（form.tsx）
+
+表单分两个 ProCard 卡片分组（字段数 > 10，UX-DR06 中等表单）：
+
+**卡片一：基本信息**
+```typescript
+// 证书名称（必填）
+<ProFormText name="certificateName" label="证书名称" rules={[{ required: true }]} />
+
+// 证书类型（必填）
+<ProFormText name="certificateType" label="证书类型" placeholder="如 CE / FCC / RoHS" rules={[{ required: true }]} />
+
+// 证书编号（选填）
+<ProFormText name="certificateNo" label="证书编号" placeholder="不填则自动生成 CERT001" />
+
+// 指令法规（选填）
+<ProFormText name="directive" label="指令法规" placeholder="如 CE Directive 2014/35/EU" />
+
+// 归属类型（选填）
+<ProFormText name="attributionType" label="归属类型" placeholder="如 产品类别证书 / 产品专项证书" />
+
+// 所属产品分类（选填，TreeSelect）
+// 复用 SPU 表单中的 categoryTreeQuery + buildTreeData 方法
+// 这里不限制只选 level=3（证书可以挂在任意层级分类下）
+<ProForm.Item name="categoryId" label="所属产品分类">
+  <TreeSelect
+    treeData={buildTreeData(categoryTree)}
+    allowClear
+    placeholder="选择产品分类（选填）"
+    style={{ width: '100%' }}
+  />
+</ProForm.Item>
+```
+
+**卡片二：有效期 & 发证信息**
+```typescript
+// 发证日期（选填）
+<ProFormDatePicker name="issueDate" label="发证日期"
+  fieldProps={{ format: 'YYYY-MM-DD', style: { width: '100%' } }} />
+
+// 有效期起始日（必填）
+<ProFormDatePicker name="validFrom" label="有效期起始日"
+  rules={[{ required: true }]}
+  fieldProps={{ format: 'YYYY-MM-DD', style: { width: '100%' } }} />
+
+// 有效期结束日（必填）
+<ProFormDatePicker name="validUntil" label="有效期结束日"
+  rules={[{ required: true }]}
+  fieldProps={{ format: 'YYYY-MM-DD', style: { width: '100%' } }} />
+
+// 发证机构（必填）
+<ProFormText name="issuingAuthority" label="发证机构" rules={[{ required: true }]} />
+
+// 适用 SPU（必填，多选）
+<ProFormSelect
+  name="spuIds"
+  label="适用 SPU"
+  rules={[{ required: true, message: '请选择适用 SPU' }]}
+  fieldProps={{
+    mode: 'multiple',
+    showSearch: true,
+    filterOption: (input: string, option: any) =>
+      String(option?.label ?? '').toLowerCase().includes(input.toLowerCase()),
+    options: spuOptions.data?.list.map((s: any) => ({
+      value: s.id,
+      label: `${s.spuCode} - ${s.name}`,
+    })) ?? [],
+  }}
+/>
+
+// 证书文件上传（Upload 组件，两步式）
+// ...见下方文件上传实现
+
+// 证书说明（选填，多行）
+<ProFormTextArea name="remarks" label="证书说明" fieldProps={{ rows: 3 }} />
+```
+
+**文件上传（两步式）：**
+```typescript
+const [fileInfo, setFileInfo] = useState<{ key: string; filename: string } | null>(null);
+
+const uploadProps: UploadProps = {
+  accept: '.pdf,.jpg,.jpeg,.png',
+  maxCount: 1,
+  customRequest: async ({ file, onSuccess, onError }) => {
+    try {
+      const result = await uploadCertificateFile(file as File);
+      setFileInfo({ key: result.key, filename: result.filename });
+      onSuccess?.(result);
+    } catch (err) {
+      onError?.(err as Error);
+    }
+  },
+};
+
+// onFinish 中：
+const onFinish = async (values: any) => {
+  const payload: CreateCertificatePayload = {
+    ...values,
+    issueDate: values.issueDate?.format?.('YYYY-MM-DD') ?? values.issueDate ?? undefined,
+    validFrom: values.validFrom?.format?.('YYYY-MM-DD') ?? values.validFrom,
+    validUntil: values.validUntil?.format?.('YYYY-MM-DD') ?? values.validUntil,
+    fileKey: fileInfo?.key,
+    fileName: fileInfo?.filename,
+  };
+  // ...
+};
+```
+
+**编辑回填注意：**
+- 日期字段回填：`initialValues={{ validFrom: dayjs(detail.validFrom), ... }}`
+- 文件：若 `detail.fileKey` 已有，展示文件名 + "重新上传"按钮，不强制重传
+- SPU 多选回填：`spuIds: detail.spus.map(s => s.id)`
+- categoryId 直接回填：`categoryId: detail.categoryId`
+
+#### 列表页关键列配置（index.tsx）
+
+```typescript
+const columns = [
+  { title: '证书编号', dataIndex: 'certificateNo', render: (v, r) => <Link to={`/master-data/certificates/${r.id}`}>{v}</Link> },
+  { title: '证书名称', dataIndex: 'certificateName' },
+  { title: '证书类型', dataIndex: 'certificateType' },
+  { title: '适用 SPU', dataIndex: 'spus', render: (spus) => spus.map(s => s.name).join('、') || '-' },
+  { title: '有效期', render: (_, r) => `${r.validFrom} ~ ${r.validUntil}` },
+  { title: '发证机构', dataIndex: 'issuingAuthority' },
+  {
+    title: '状态', dataIndex: 'status',
+    render: (status) => (
+      <Tag color={status === 'valid' ? 'success' : 'error'}>
+        {status === 'valid' ? '有效' : '已过期'}
+      </Tag>
+    ),
+  },
+];
+```
+
+#### 详情页分组卡片（detail.tsx）
+
+```typescript
+// ProDescriptions 分两个卡片
+// 卡片一：基本信息
+// 证书名称、证书编号、证书类型、指令法规、归属类型、所属产品分类（category_id 展示名称）
+
+// 卡片二：有效期 & 发证信息
+// 发证日期、有效期起始日、有效期结束日、发证机构、适用 SPU（Tag 列表）、证书文件（下载按钮）、证书说明
+```
+
+#### 路由注册（App.tsx）
+
+```typescript
+// 导入
+import CertificatesListPage from './pages/master-data/certificates/index';
+import CertificateDetailPage from './pages/master-data/certificates/detail';
+import CertificateFormPage from './pages/master-data/certificates/form';
+
+// 路由（在 SpuFormPage 路由后添加）
+<Route path="/master-data/certificates" element={<CertificatesListPage />} />
+<Route path="/master-data/certificates/create" element={<CertificateFormPage />} />
+<Route path="/master-data/certificates/:id" element={<CertificateDetailPage />} />
+<Route path="/master-data/certificates/:id/edit" element={<CertificateFormPage />} />
+```
+
+---
+
+### 避坑指南（必读）
+
+1. **FilesService 是 @Global()，直接注入，CertificatesModule 无需 import FilesModule**
+
+2. **Entity 无软删除：** BaseEntity 无 `deletedAt`，`repo.delete(id)` 直接物理删除
+
+3. **@ManyToMany 保存需传 Entity 对象数组（非 ID 数组）：**
+   - 先 `spusService.findById(id)` 取到 Spu 对象
+   - 再 `repo.create({ spus: spusArray })` + `repo.save()`
+
+4. **date 列返回字符串：** MySQL `date` 列 TypeORM 返回 `'YYYY-MM-DD'` 字符串，`new Date(cert.validUntil)` 可正确比较
+
+5. **ProFormDatePicker 提交值是 Dayjs 对象：** 需 `.format('YYYY-MM-DD')`；回填需 `dayjs(detail.validFrom)`
+
+6. **categoryId 显示名称：** 详情页需加载产品分类树或单个分类接口来展示分类名。简单方案：调用 `GET /api/product-categories` 取树，前端查找对应节点名称。
+
+7. **ProductCategoriesModule 需 export ProductCategoriesService：** 如未 export，在 `product-categories.module.ts` 的 `exports` 中添加 `ProductCategoriesService`
+
+8. **证书编号自动生成（CERT001 格式）：**
+   - `SELECT MAX(certificate_no) WHERE certificate_no LIKE 'CERT%'`
+   - 若用户输入与已有记录重复，数据库 unique 约束报错，Service 中捕获 `QueryFailedError` 返回 `ConflictException`
+
+9. **枚举在 packages/shared 定义：** `CertificateStatus` 不能在后端或前端独立定义
+
+10. **App.tsx 仅添加 4 条路由，不重新组织已有路由**
+
+---
+
+### 字段映射总表（对应字段清单）
+
+| 字段清单字段 | 数据库列 | Entity 属性 | 必填 |
+|------------|---------|-------------|-----|
+| 证书名称 | certificate_name | certificateName | ✅ |
+| 指令法规 | directive | directive | 否 |
+| 有效期区间 | valid_from + valid_until | validFrom + validUntil | ✅ |
+| 证书编号 | certificate_no | certificateNo | 自动生成 |
+| 证书类型 | certificate_type | certificateType | ✅ |
+| 证书文件 | file_key + file_name | fileKey + fileName | ✅（业务） |
+| 发证机构 | issuing_authority | issuingAuthority | ✅ |
+| 发证日期 | issue_date | issueDate | 否 |
+| 证书说明 | remarks | remarks | 否 |
+| 归属类型 | attribution_type | attributionType | 否 |
+| 适用SPU编码 | certificate_spus (M:M) | spus | ✅ |
+| 所属产品分类 | category_id | categoryId | 否 |
+
+---
+
+### 与 Story 3.2（SPU）的关键差异
+
+| 维度 | Story 3.2 SPU | Story 3.5 证书 |
+|------|--------------|----------------|
+| 关联 | 多级分类（TreeSelect） | 多个 SPU（多选 Select）+ 可选分类 |
+| 文件 | 无 | 有，OSS 上传（两步式） |
+| 状态 | 无 | 计算字段（validUntil vs 今日） |
+| 删除 | 直接删除 | 先删 OSS 文件，再删 DB 记录 |
+| 编号 | SPU001 | CERT001 |
+| 关联表 | 无 | certificate_spus（M:M） |
+| 字段数 | ~20 | ~14（不含 BaseEntity） |
+
+---
+
+### 测试规范
+
+```typescript
+// apps/api/src/modules/master-data/certificates/tests/certificates.service.spec.ts
+// Mock：CertificatesRepository + FilesService + SpusService + ProductCategoriesService
+// 测试用例：
+// - create：正常创建（含所有新增字段）
+// - create：SPU 不存在时抛 NotFoundException
+// - create：categoryId 不存在时抛 NotFoundException
+// - withStatus：validUntil < today → 'expired'
+// - withStatus：validUntil >= today → 'valid'
+// - remove：fileKey 存在时调用 filesService.delete
+// - remove：证书不存在时抛 NotFoundException
+```
+
+---
+
+### 项目上下文参考
+
+- `_bmad-output/project-context.md` — 完整规范
+- `docs/系统模块对应字段清单.md` — 产品证书库字段清单（FormUUID: FORM-7D6BD9153571411B963DB81637A9C4A857CF）
+- `apps/api/src/files/files.service.ts` — FilesService 实现（upload / getSignedUrl / delete）
+- `apps/api/src/modules/master-data/spus/` — SPU 模块（参考标准结构）
+- `apps/web/src/pages/master-data/spus/form.tsx` — TreeSelect 用法参考（categoryId 选择）
+- `apps/api/src/migrations/20260421000100-create-spus-table.ts` — Migration 写法参考
+
+---
+
+*Story 3.5 实现完成后，Sprint Status 更新为 `done`。*

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-21 (story-3-2-code-review)
+last_updated: 2026-04-22 (story-3-5-ready-for-dev)
 project: infitek_erp
 
 project_key: NOKEY
@@ -77,7 +77,7 @@ development_status:
   3-2-spu基础信息管理: done
   3-3-sku变体管理: backlog
   3-4-产品faq维护: backlog
-  3-5-产品证书库管理: backlog
+  3-5-产品证书库管理: in-progress
   3-6-产品资料库管理: backlog
   epic-3-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-22 (story-3-5-ready-for-dev)
+last_updated: 2026-04-22 (story-3-5-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -77,7 +77,7 @@ development_status:
   3-2-spu基础信息管理: done
   3-3-sku变体管理: backlog
   3-4-产品faq维护: backlog
-  3-5-产品证书库管理: in-progress
+  3-5-产品证书库管理: done
   3-6-产品资料库管理: backlog
   epic-3-retrospective: optional
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { CountriesModule } from './modules/master-data/countries/countries.modul
 import { CompaniesModule } from './modules/master-data/companies/companies.module';
 import { ProductCategoriesModule } from './modules/master-data/product-categories/product-categories.module';
 import { SpusModule } from './modules/master-data/spus/spus.module';
+import { CertificatesModule } from './modules/master-data/certificates/certificates.module';
 import databaseConfig from './config/database.config';
 
 @Module({
@@ -43,6 +44,7 @@ import databaseConfig from './config/database.config';
     CompaniesModule,
     ProductCategoriesModule,
     SpusModule,
+    CertificatesModule,
     FilesModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/migrations/20260422000200-create-certificates-table.ts
+++ b/apps/api/src/migrations/20260422000200-create-certificates-table.ts
@@ -1,0 +1,98 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+export class CreateCertificatesTable20260422000200 implements MigrationInterface {
+  name = 'CreateCertificatesTable20260422000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'certificates',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'certificate_no', type: 'varchar', length: '30', isNullable: false },
+          { name: 'certificate_name', type: 'varchar', length: '200', isNullable: false },
+          { name: 'certificate_type', type: 'varchar', length: '50', isNullable: false },
+          { name: 'directive', type: 'varchar', length: '200', isNullable: true },
+          { name: 'issue_date', type: 'date', isNullable: true },
+          { name: 'valid_from', type: 'date', isNullable: false },
+          { name: 'valid_until', type: 'date', isNullable: false },
+          { name: 'issuing_authority', type: 'varchar', length: '200', isNullable: false },
+          { name: 'remarks', type: 'text', isNullable: true },
+          { name: 'attribution_type', type: 'varchar', length: '50', isNullable: true },
+          { name: 'category_id', type: 'bigint', unsigned: true, isNullable: true },
+          { name: 'file_key', type: 'varchar', length: '500', isNullable: true },
+          { name: 'file_name', type: 'varchar', length: '200', isNullable: true },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('certificates', [
+      new TableIndex({
+        name: 'uq_certificates_certificate_no',
+        columnNames: ['certificate_no'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'idx_certificates_category_id',
+        columnNames: ['category_id'],
+      }),
+    ]);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'certificate_spus',
+        columns: [
+          { name: 'certificate_id', type: 'bigint', unsigned: true, isNullable: false },
+          { name: 'spu_id', type: 'bigint', unsigned: true, isNullable: false },
+        ],
+        indices: [
+          {
+            name: 'pk_certificate_spus',
+            columnNames: ['certificate_id', 'spu_id'],
+            isUnique: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createForeignKeys('certificate_spus', [
+      new TableForeignKey({
+        name: 'fk_certificate_spus_certificate',
+        columnNames: ['certificate_id'],
+        referencedTableName: 'certificates',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        name: 'fk_certificate_spus_spu',
+        columnNames: ['spu_id'],
+        referencedTableName: 'spus',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('certificate_spus');
+    await queryRunner.dropTable('certificates');
+  }
+}

--- a/apps/api/src/modules/master-data/certificates/certificates.controller.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CurrentUser } from '../../../common/decorators/current-user.decorator';
+import { CertificatesService } from './certificates.service';
+import { CreateCertificateDto } from './dto/create-certificate.dto';
+import { UpdateCertificateDto } from './dto/update-certificate.dto';
+import { QueryCertificateDto } from './dto/query-certificate.dto';
+
+@Controller('certificates')
+export class CertificatesController {
+  constructor(private readonly certificatesService: CertificatesService) {}
+
+  @Get()
+  findAll(@Query() query: QueryCertificateDto) {
+    return this.certificatesService.findAll(query);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.certificatesService.findById(id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateCertificateDto, @CurrentUser() user: { username?: string }) {
+    return this.certificatesService.create(dto, user?.username);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateCertificateDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.certificatesService.update(id, dto, user?.username);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  delete(@Param('id', ParseIntPipe) id: number) {
+    return this.certificatesService.delete(id);
+  }
+}

--- a/apps/api/src/modules/master-data/certificates/certificates.module.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Certificate } from './entities/certificate.entity';
+import { CertificatesController } from './certificates.controller';
+import { CertificatesRepository } from './certificates.repository';
+import { CertificatesService } from './certificates.service';
+import { SpusModule } from '../spus/spus.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Certificate]), SpusModule],
+  controllers: [CertificatesController],
+  providers: [CertificatesRepository, CertificatesService],
+  exports: [CertificatesService],
+})
+export class CertificatesModule {}

--- a/apps/api/src/modules/master-data/certificates/certificates.repository.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.repository.ts
@@ -34,7 +34,7 @@ export class CertificatesRepository {
     }
 
     const [list, total] = await qb
-      .orderBy('c.created_at', 'DESC')
+      .orderBy('c.createdAt', 'DESC')
       .skip((page - 1) * pageSize)
       .take(pageSize)
       .getManyAndCount();

--- a/apps/api/src/modules/master-data/certificates/certificates.repository.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.repository.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Certificate } from './entities/certificate.entity';
+import { QueryCertificateDto } from './dto/query-certificate.dto';
+import { CertificateStatus } from '@infitek/shared';
+
+@Injectable()
+export class CertificatesRepository {
+  constructor(
+    @InjectRepository(Certificate)
+    private readonly repo: Repository<Certificate>,
+  ) {}
+
+  async findAll(query: QueryCertificateDto) {
+    const { keyword, page = 1, pageSize = 20, certificateType, status, categoryId } = query;
+    const qb = this.repo.createQueryBuilder('c').leftJoinAndSelect('c.spus', 'spus');
+
+    if (keyword) {
+      qb.where('(c.certificate_name LIKE :kw OR c.certificate_no LIKE :kw)', {
+        kw: `%${keyword}%`,
+      });
+    }
+    if (certificateType) {
+      qb.andWhere('c.certificate_type = :certificateType', { certificateType });
+    }
+    if (categoryId !== undefined) {
+      qb.andWhere('c.category_id = :categoryId', { categoryId });
+    }
+    if (status === CertificateStatus.VALID) {
+      qb.andWhere('c.valid_until >= CURDATE()');
+    } else if (status === CertificateStatus.EXPIRED) {
+      qb.andWhere('c.valid_until < CURDATE()');
+    }
+
+    const [list, total] = await qb
+      .orderBy('c.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return { list, total, page, pageSize, totalPages: Math.ceil(total / pageSize) };
+  }
+
+  findById(id: number): Promise<Certificate | null> {
+    return this.repo.findOne({ where: { id }, relations: ['spus'] });
+  }
+
+  findByNo(certificateNo: string): Promise<Certificate | null> {
+    return this.repo.findOne({ where: { certificateNo } });
+  }
+
+  async generateCode(): Promise<string> {
+    const result = await this.repo
+      .createQueryBuilder('c')
+      .select('MAX(CAST(SUBSTRING(c.certificate_no, 5) AS UNSIGNED))', 'maxSeq')
+      .where('c.certificate_no LIKE :prefix', { prefix: 'CERT%' })
+      .getRawOne<{ maxSeq: number | null }>();
+    const nextSeq = (result?.maxSeq ?? 0) + 1;
+    return `CERT${String(nextSeq).padStart(3, '0')}`;
+  }
+
+  save(entity: Certificate): Promise<Certificate> {
+    return this.repo.save(entity);
+  }
+
+  create(data: Partial<Certificate>): Certificate {
+    return this.repo.create(data);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.repo.delete(id);
+  }
+}

--- a/apps/api/src/modules/master-data/certificates/certificates.service.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.service.ts
@@ -49,7 +49,14 @@ export class CertificatesService {
       ? await Promise.all(dto.spuIds.map((id) => this.spusService.findById(id)))
       : [];
 
-    const certificateNo = await this.repo.generateCode();
+    let certificateNo: string;
+    if (dto.certificateNo) {
+      const existing = await this.repo.findByNo(dto.certificateNo);
+      if (existing) throw new BadRequestException(`证书编号 ${dto.certificateNo} 已存在`);
+      certificateNo = dto.certificateNo;
+    } else {
+      certificateNo = await this.repo.generateCode();
+    }
 
     const entity = this.repo.create({
       certificateNo,

--- a/apps/api/src/modules/master-data/certificates/certificates.service.ts
+++ b/apps/api/src/modules/master-data/certificates/certificates.service.ts
@@ -1,0 +1,118 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { CertificatesRepository } from './certificates.repository';
+import { SpusService } from '../spus/spus.service';
+import { FilesService } from '../../../files/files.service';
+import { CreateCertificateDto } from './dto/create-certificate.dto';
+import { UpdateCertificateDto } from './dto/update-certificate.dto';
+import { QueryCertificateDto } from './dto/query-certificate.dto';
+import { CertificateStatus } from '@infitek/shared';
+
+@Injectable()
+export class CertificatesService {
+  constructor(
+    private readonly repo: CertificatesRepository,
+    private readonly spusService: SpusService,
+    private readonly filesService: FilesService,
+  ) {}
+
+  private computeStatus(validUntil: string): CertificateStatus {
+    const today = new Date().toISOString().split('T')[0];
+    return validUntil >= today ? CertificateStatus.VALID : CertificateStatus.EXPIRED;
+  }
+
+  private async withFileUrl<T extends { fileKey: string | null }>(
+    item: T,
+  ): Promise<T & { fileUrl: string | null; status: CertificateStatus }> {
+    const fileUrl = item.fileKey ? await this.filesService.getSignedUrl(item.fileKey) : null;
+    const status = this.computeStatus((item as unknown as { validUntil: string }).validUntil);
+    return { ...item, fileUrl, status };
+  }
+
+  async findAll(query: QueryCertificateDto) {
+    const result = await this.repo.findAll(query);
+    const list = await Promise.all(result.list.map((c) => this.withFileUrl(c)));
+    return { ...result, list };
+  }
+
+  async findById(id: number) {
+    const cert = await this.repo.findById(id);
+    if (!cert) throw new NotFoundException('证书不存在');
+    return this.withFileUrl(cert);
+  }
+
+  async create(dto: CreateCertificateDto, operator?: string) {
+    if (dto.validFrom > dto.validUntil) {
+      throw new BadRequestException('有效期开始日期不能晚于截止日期');
+    }
+
+    const spus = dto.spuIds?.length
+      ? await Promise.all(dto.spuIds.map((id) => this.spusService.findById(id)))
+      : [];
+
+    const certificateNo = await this.repo.generateCode();
+
+    const entity = this.repo.create({
+      certificateNo,
+      certificateName: dto.certificateName,
+      certificateType: dto.certificateType,
+      directive: dto.directive ?? null,
+      issueDate: dto.issueDate ?? null,
+      validFrom: dto.validFrom,
+      validUntil: dto.validUntil,
+      issuingAuthority: dto.issuingAuthority,
+      remarks: dto.remarks ?? null,
+      attributionType: dto.attributionType ?? null,
+      categoryId: dto.categoryId ?? null,
+      fileKey: dto.fileKey ?? null,
+      fileName: dto.fileName ?? null,
+      spus,
+      createdBy: operator,
+      updatedBy: operator,
+    });
+
+    const saved = await this.repo.save(entity);
+    return this.withFileUrl(saved);
+  }
+
+  async update(id: number, dto: UpdateCertificateDto, operator?: string) {
+    const cert = await this.repo.findById(id);
+    if (!cert) throw new NotFoundException('证书不存在');
+
+    if (dto.validFrom !== undefined || dto.validUntil !== undefined) {
+      const validFrom = dto.validFrom ?? cert.validFrom;
+      const validUntil = dto.validUntil ?? cert.validUntil;
+      if (validFrom > validUntil) {
+        throw new BadRequestException('有效期开始日期不能晚于截止日期');
+      }
+    }
+
+    if (dto.certificateName !== undefined) cert.certificateName = dto.certificateName;
+    if (dto.certificateType !== undefined) cert.certificateType = dto.certificateType;
+    if ('directive' in dto) cert.directive = dto.directive ?? null;
+    if ('issueDate' in dto) cert.issueDate = dto.issueDate ?? null;
+    if (dto.validFrom !== undefined) cert.validFrom = dto.validFrom;
+    if (dto.validUntil !== undefined) cert.validUntil = dto.validUntil;
+    if (dto.issuingAuthority !== undefined) cert.issuingAuthority = dto.issuingAuthority;
+    if ('remarks' in dto) cert.remarks = dto.remarks ?? null;
+    if ('attributionType' in dto) cert.attributionType = dto.attributionType ?? null;
+    if ('categoryId' in dto) cert.categoryId = dto.categoryId ?? null;
+    if ('fileKey' in dto) cert.fileKey = dto.fileKey ?? null;
+    if ('fileName' in dto) cert.fileName = dto.fileName ?? null;
+    if (operator !== undefined) cert.updatedBy = operator;
+
+    if (dto.spuIds !== undefined) {
+      cert.spus = dto.spuIds.length
+        ? await Promise.all(dto.spuIds.map((spuId) => this.spusService.findById(spuId)))
+        : [];
+    }
+
+    const saved = await this.repo.save(cert);
+    return this.withFileUrl(saved);
+  }
+
+  async delete(id: number): Promise<void> {
+    const cert = await this.repo.findById(id);
+    if (!cert) throw new NotFoundException('证书不存在');
+    await this.repo.delete(id);
+  }
+}

--- a/apps/api/src/modules/master-data/certificates/dto/create-certificate.dto.ts
+++ b/apps/api/src/modules/master-data/certificates/dto/create-certificate.dto.ts
@@ -17,6 +17,11 @@ export class CreateCertificateDto {
   certificateName: string;
 
   @IsString()
+  @IsOptional()
+  @MaxLength(30)
+  certificateNo?: string;
+
+  @IsString()
   @IsNotEmpty()
   @MaxLength(50)
   certificateType: string;

--- a/apps/api/src/modules/master-data/certificates/dto/create-certificate.dto.ts
+++ b/apps/api/src/modules/master-data/certificates/dto/create-certificate.dto.ts
@@ -1,0 +1,76 @@
+import {
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class CreateCertificateDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  certificateName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  certificateType: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  directive?: string;
+
+  @IsDateString()
+  @IsOptional()
+  issueDate?: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  validFrom: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  validUntil: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  issuingAuthority: string;
+
+  @IsString()
+  @IsOptional()
+  remarks?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  attributionType?: string;
+
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  categoryId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  fileKey?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  fileName?: string;
+
+  @IsArray()
+  @IsInt({ each: true })
+  @IsPositive({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  spuIds?: number[];
+}

--- a/apps/api/src/modules/master-data/certificates/dto/query-certificate.dto.ts
+++ b/apps/api/src/modules/master-data/certificates/dto/query-certificate.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { BaseQueryDto } from '../../../../common/dto/base-query.dto';
+import { CertificateStatus } from '@infitek/shared';
+
+export class QueryCertificateDto extends BaseQueryDto {
+  @IsString()
+  @IsOptional()
+  certificateType?: string;
+
+  @IsEnum(CertificateStatus)
+  @IsOptional()
+  status?: CertificateStatus;
+
+  @Type(() => Number)
+  @IsInt()
+  @IsOptional()
+  categoryId?: number;
+}

--- a/apps/api/src/modules/master-data/certificates/dto/update-certificate.dto.ts
+++ b/apps/api/src/modules/master-data/certificates/dto/update-certificate.dto.ts
@@ -1,0 +1,75 @@
+import {
+  ArrayUnique,
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class UpdateCertificateDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  certificateName?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  certificateType?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  directive?: string;
+
+  @IsDateString()
+  @IsOptional()
+  issueDate?: string;
+
+  @IsDateString()
+  @IsOptional()
+  validFrom?: string;
+
+  @IsDateString()
+  @IsOptional()
+  validUntil?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  issuingAuthority?: string;
+
+  @IsString()
+  @IsOptional()
+  remarks?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  attributionType?: string;
+
+  @IsInt()
+  @IsPositive()
+  @IsOptional()
+  categoryId?: number;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  fileKey?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(200)
+  fileName?: string;
+
+  @IsArray()
+  @IsInt({ each: true })
+  @IsPositive({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  spuIds?: number[];
+}

--- a/apps/api/src/modules/master-data/certificates/entities/certificate.entity.ts
+++ b/apps/api/src/modules/master-data/certificates/entities/certificate.entity.ts
@@ -1,0 +1,70 @@
+import { Column, Entity, Index, JoinTable, ManyToMany, Unique } from 'typeorm';
+import { Expose } from 'class-transformer';
+import { BaseEntity } from '../../../../common/entities/base.entity';
+import { Spu } from '../../spus/entities/spu.entity';
+
+@Entity('certificates')
+@Unique('uq_certificates_certificate_no', ['certificateNo'])
+@Index('idx_certificates_category_id', ['categoryId'])
+export class Certificate extends BaseEntity {
+  @Column({ name: 'certificate_no', type: 'varchar', length: 30 })
+  @Expose()
+  certificateNo: string;
+
+  @Column({ name: 'certificate_name', type: 'varchar', length: 200 })
+  @Expose()
+  certificateName: string;
+
+  @Column({ name: 'certificate_type', type: 'varchar', length: 50 })
+  @Expose()
+  certificateType: string;
+
+  @Column({ name: 'directive', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  directive: string | null;
+
+  @Column({ name: 'issue_date', type: 'date', nullable: true })
+  @Expose()
+  issueDate: string | null;
+
+  @Column({ name: 'valid_from', type: 'date' })
+  @Expose()
+  validFrom: string;
+
+  @Column({ name: 'valid_until', type: 'date' })
+  @Expose()
+  validUntil: string;
+
+  @Column({ name: 'issuing_authority', type: 'varchar', length: 200 })
+  @Expose()
+  issuingAuthority: string;
+
+  @Column({ name: 'remarks', type: 'text', nullable: true })
+  @Expose()
+  remarks: string | null;
+
+  @Column({ name: 'attribution_type', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  attributionType: string | null;
+
+  @Column({ name: 'category_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  categoryId: number | null;
+
+  @Column({ name: 'file_key', type: 'varchar', length: 500, nullable: true })
+  @Expose()
+  fileKey: string | null;
+
+  @Column({ name: 'file_name', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  fileName: string | null;
+
+  @ManyToMany(() => Spu, { eager: false })
+  @JoinTable({
+    name: 'certificate_spus',
+    joinColumn: { name: 'certificate_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'spu_id', referencedColumnName: 'id' },
+  })
+  @Expose()
+  spus: Spu[];
+}

--- a/apps/api/src/modules/master-data/certificates/tests/certificates.service.spec.ts
+++ b/apps/api/src/modules/master-data/certificates/tests/certificates.service.spec.ts
@@ -1,0 +1,224 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CertificatesRepository } from '../certificates.repository';
+import { CertificatesService } from '../certificates.service';
+import { SpusService } from '../../spus/spus.service';
+import { FilesService } from '../../../../files/files.service';
+
+describe('CertificatesService', () => {
+  let service: CertificatesService;
+
+  const repoMock = {
+    findAll: jest.fn(),
+    findById: jest.fn(),
+    findByNo: jest.fn(),
+    generateCode: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const spusServiceMock = {
+    findById: jest.fn(),
+  };
+
+  const filesServiceMock = {
+    getSignedUrl: jest.fn(),
+  };
+
+  const today = new Date().toISOString().split('T')[0];
+  const pastDate = '2020-01-01';
+  const futureDate = '2099-12-31';
+
+  const baseCert = {
+    id: 1,
+    certificateNo: 'CERT001',
+    certificateName: '测试证书',
+    certificateType: 'CE',
+    directive: null,
+    issueDate: null,
+    validFrom: '2024-01-01',
+    validUntil: futureDate,
+    issuingAuthority: '测试机构',
+    remarks: null,
+    attributionType: null,
+    categoryId: null,
+    fileKey: null,
+    fileName: null,
+    spus: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: 'admin',
+    updatedBy: 'admin',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CertificatesService,
+        { provide: CertificatesRepository, useValue: repoMock },
+        { provide: SpusService, useValue: spusServiceMock },
+        { provide: FilesService, useValue: filesServiceMock },
+      ],
+    }).compile();
+
+    service = module.get<CertificatesService>(CertificatesService);
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('创建证书成功，自动生成编号 CERT001', async () => {
+      repoMock.generateCode.mockResolvedValue('CERT001');
+      repoMock.create.mockReturnValue({ ...baseCert });
+      repoMock.save.mockResolvedValue({ ...baseCert });
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      const result = await service.create(
+        {
+          certificateName: '测试证书',
+          certificateType: 'CE',
+          validFrom: '2024-01-01',
+          validUntil: futureDate,
+          issuingAuthority: '测试机构',
+        },
+        'admin',
+      );
+
+      expect(result.certificateNo).toBe('CERT001');
+      expect(repoMock.save).toHaveBeenCalled();
+    });
+
+    it('validFrom > validUntil → BadRequestException', async () => {
+      await expect(
+        service.create(
+          {
+            certificateName: '测试证书',
+            certificateType: 'CE',
+            validFrom: '2025-01-01',
+            validUntil: '2024-01-01',
+            issuingAuthority: '测试机构',
+          },
+          'admin',
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('传入 spuIds → 查询并关联 SPU', async () => {
+      const spu = { id: 1, spuCode: 'SPU001', name: '产品A' };
+      repoMock.generateCode.mockResolvedValue('CERT001');
+      repoMock.create.mockReturnValue({ ...baseCert, spus: [spu] });
+      repoMock.save.mockResolvedValue({ ...baseCert, spus: [spu] });
+      spusServiceMock.findById.mockResolvedValue(spu);
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      await service.create(
+        {
+          certificateName: '测试证书',
+          certificateType: 'CE',
+          validFrom: '2024-01-01',
+          validUntil: futureDate,
+          issuingAuthority: '测试机构',
+          spuIds: [1],
+        },
+        'admin',
+      );
+
+      expect(spusServiceMock.findById).toHaveBeenCalledWith(1);
+      expect(repoMock.create).toHaveBeenCalledWith(expect.objectContaining({ spus: [spu] }));
+    });
+  });
+
+  describe('findById', () => {
+    it('找不到证书 → NotFoundException', async () => {
+      repoMock.findById.mockResolvedValue(null);
+
+      await expect(service.findById(999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('返回有效证书时 status=valid', async () => {
+      repoMock.findById.mockResolvedValue({ ...baseCert, validUntil: futureDate });
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      const result = await service.findById(1);
+
+      expect(result.status).toBe('valid');
+    });
+
+    it('返回过期证书时 status=expired', async () => {
+      repoMock.findById.mockResolvedValue({ ...baseCert, validUntil: pastDate });
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      const result = await service.findById(1);
+
+      expect(result.status).toBe('expired');
+    });
+
+    it('有 fileKey 时返回 fileUrl', async () => {
+      const signedUrl = 'https://oss.example.com/signed-url';
+      repoMock.findById.mockResolvedValue({ ...baseCert, fileKey: 'prod/certificates/2024-01/abc.pdf' });
+      filesServiceMock.getSignedUrl.mockResolvedValue(signedUrl);
+
+      const result = await service.findById(1);
+
+      expect(result.fileUrl).toBe(signedUrl);
+      expect(filesServiceMock.getSignedUrl).toHaveBeenCalledWith('prod/certificates/2024-01/abc.pdf');
+    });
+  });
+
+  describe('update', () => {
+    it('更新证书名称成功', async () => {
+      const cert = { ...baseCert };
+      repoMock.findById.mockResolvedValue(cert);
+      repoMock.save.mockResolvedValue({ ...cert, certificateName: '新证书名' });
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      const result = await service.update(1, { certificateName: '新证书名' }, 'admin');
+
+      expect(result.certificateName).toBe('新证书名');
+      expect(repoMock.save).toHaveBeenCalled();
+    });
+
+    it('更新时 validFrom > validUntil → BadRequestException', async () => {
+      repoMock.findById.mockResolvedValue({ ...baseCert, validFrom: '2024-01-01', validUntil: futureDate });
+
+      await expect(
+        service.update(1, { validFrom: '2025-01-01', validUntil: '2024-01-01' }, 'admin'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('更新不存在的证书 → NotFoundException', async () => {
+      repoMock.findById.mockResolvedValue(null);
+
+      await expect(service.update(999, { certificateName: '新名称' }, 'admin')).rejects.toThrow(NotFoundException);
+    });
+
+    it('更新 spuIds → 重新关联 SPU', async () => {
+      const cert = { ...baseCert, spus: [] };
+      const spu = { id: 2, spuCode: 'SPU002', name: '产品B' };
+      repoMock.findById.mockResolvedValue(cert);
+      repoMock.save.mockResolvedValue({ ...cert, spus: [spu] });
+      spusServiceMock.findById.mockResolvedValue(spu);
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      await service.update(1, { spuIds: [2] }, 'admin');
+
+      expect(spusServiceMock.findById).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('delete', () => {
+    it('删除证书成功', async () => {
+      repoMock.findById.mockResolvedValue(baseCert);
+      repoMock.delete.mockResolvedValue(undefined);
+
+      await expect(service.delete(1)).resolves.toBeUndefined();
+      expect(repoMock.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('删除不存在的证书 → NotFoundException', async () => {
+      repoMock.findById.mockResolvedValue(null);
+
+      await expect(service.delete(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/modules/master-data/certificates/tests/certificates.service.spec.ts
+++ b/apps/api/src/modules/master-data/certificates/tests/certificates.service.spec.ts
@@ -103,6 +103,49 @@ describe('CertificatesService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('提供自定义编号时优先使用，不调用 generateCode', async () => {
+      repoMock.findByNo.mockResolvedValue(null);
+      repoMock.create.mockReturnValue({ ...baseCert, certificateNo: 'CUST-001' });
+      repoMock.save.mockResolvedValue({ ...baseCert, certificateNo: 'CUST-001' });
+      filesServiceMock.getSignedUrl.mockResolvedValue(null);
+
+      const result = await service.create(
+        {
+          certificateName: '测试证书',
+          certificateNo: 'CUST-001',
+          certificateType: 'CE',
+          validFrom: '2024-01-01',
+          validUntil: futureDate,
+          issuingAuthority: '测试机构',
+        },
+        'admin',
+      );
+
+      expect(result.certificateNo).toBe('CUST-001');
+      expect(repoMock.generateCode).not.toHaveBeenCalled();
+      expect(repoMock.findByNo).toHaveBeenCalledWith('CUST-001');
+    });
+
+    it('自定义编号已存在 → BadRequestException', async () => {
+      repoMock.findByNo.mockResolvedValue({ ...baseCert, certificateNo: 'CUST-001' });
+
+      await expect(
+        service.create(
+          {
+            certificateName: '测试证书',
+            certificateNo: 'CUST-001',
+            certificateType: 'CE',
+            validFrom: '2024-01-01',
+            validUntil: futureDate,
+            issuingAuthority: '测试机构',
+          },
+          'admin',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(repoMock.generateCode).not.toHaveBeenCalled();
+    });
+
     it('传入 spuIds → 查询并关联 SPU', async () => {
       const spu = { id: 1, spuCode: 'SPU001', name: '产品A' };
       repoMock.generateCode.mockResolvedValue('CERT001');

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,9 @@ import ProductCategoryFormPage from './pages/master-data/product-categories/form
 import SpusListPage from './pages/master-data/spus/index';
 import SpuDetailPage from './pages/master-data/spus/detail';
 import SpuFormPage from './pages/master-data/spus/form';
+import CertificatesListPage from './pages/master-data/certificates/index';
+import CertificateDetailPage from './pages/master-data/certificates/detail';
+import CertificateFormPage from './pages/master-data/certificates/form';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -125,6 +128,10 @@ function App() {
                 <Route path="/master-data/spus/create" element={<SpuFormPage />} />
                 <Route path="/master-data/spus/:id" element={<SpuDetailPage />} />
                 <Route path="/master-data/spus/:id/edit" element={<SpuFormPage />} />
+                <Route path="/master-data/certificates" element={<CertificatesListPage />} />
+                <Route path="/master-data/certificates/create" element={<CertificateFormPage />} />
+                <Route path="/master-data/certificates/:id" element={<CertificateDetailPage />} />
+                <Route path="/master-data/certificates/:id/edit" element={<CertificateFormPage />} />
               </Route>
 
               {/* 兜底重定向 */}

--- a/apps/web/src/api/certificates.api.ts
+++ b/apps/web/src/api/certificates.api.ts
@@ -1,0 +1,103 @@
+import request from './request';
+
+export interface CertificateSpu {
+  id: number;
+  spuCode: string;
+  name: string;
+}
+
+export interface Certificate {
+  id: number;
+  certificateNo: string;
+  certificateName: string;
+  certificateType: string;
+  directive: string | null;
+  issueDate: string | null;
+  validFrom: string;
+  validUntil: string;
+  issuingAuthority: string;
+  remarks: string | null;
+  attributionType: string | null;
+  categoryId: number | null;
+  fileKey: string | null;
+  fileName: string | null;
+  fileUrl: string | null;
+  status: 'valid' | 'expired';
+  spus: CertificateSpu[];
+  createdAt: string;
+  updatedAt: string;
+  createdBy?: string;
+  updatedBy?: string;
+}
+
+export interface CertificatesListParams {
+  keyword?: string;
+  page?: number;
+  pageSize?: number;
+  certificateType?: string;
+  status?: 'valid' | 'expired';
+  categoryId?: number;
+}
+
+export interface CertificatesListData {
+  list: Certificate[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+export interface CreateCertificatePayload {
+  certificateName: string;
+  certificateType: string;
+  directive?: string;
+  issueDate?: string;
+  validFrom: string;
+  validUntil: string;
+  issuingAuthority: string;
+  remarks?: string;
+  attributionType?: string;
+  categoryId?: number;
+  fileKey?: string;
+  fileName?: string;
+  spuIds?: number[];
+}
+
+export type UpdateCertificatePayload = Partial<CreateCertificatePayload>;
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) {
+    throw error;
+  }
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getCertificates = (params: CertificatesListParams): Promise<CertificatesListData> => {
+  return request.get<any, CertificatesListData>('/certificates', { params }).catch(normalizeApiError);
+};
+
+export const getCertificateById = (id: number): Promise<Certificate> => {
+  return request.get<any, Certificate>(`/certificates/${id}`).catch(normalizeApiError);
+};
+
+export const createCertificate = (payload: CreateCertificatePayload): Promise<Certificate> => {
+  return request.post<any, Certificate>('/certificates', payload).catch(normalizeApiError);
+};
+
+export const updateCertificate = (id: number, payload: UpdateCertificatePayload): Promise<Certificate> => {
+  return request.patch<any, Certificate>(`/certificates/${id}`, payload).catch(normalizeApiError);
+};
+
+export const deleteCertificate = (id: number): Promise<void> => {
+  return request.delete<any, void>(`/certificates/${id}`).catch(normalizeApiError);
+};
+
+export const uploadCertificateFile = (file: File): Promise<{ key: string }> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return request
+    .post<any, { key: string }>('/files/upload?folder=certificates', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .catch(normalizeApiError);
+};

--- a/apps/web/src/pages/master-data/certificates/detail.tsx
+++ b/apps/web/src/pages/master-data/certificates/detail.tsx
@@ -1,0 +1,153 @@
+import { Breadcrumb, Button, Modal, Result, Space, Tag, message } from 'antd';
+import { ProDescriptions } from '@ant-design/pro-components';
+import type { ProDescriptionsItemProps } from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { useNavigate, useParams } from 'react-router-dom';
+import { deleteCertificate, getCertificateById, type Certificate } from '../../../api/certificates.api';
+
+export default function CertificateDetailPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id = '' } = useParams();
+  const certId = Number(id);
+
+  const query = useQuery({
+    queryKey: ['certificate-detail', certId],
+    queryFn: () => getCertificateById(certId),
+    enabled: Number.isInteger(certId) && certId > 0,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteCertificate(certId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['certificates'] });
+      message.success('证书已删除');
+      navigate('/master-data/certificates');
+    },
+  });
+
+  if (!Number.isInteger(certId) || certId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="证书不存在"
+        extra={<Button type="primary" onClick={() => navigate('/master-data/certificates')}>返回列表</Button>}
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="证书详情加载失败"
+        subTitle="请检查网络或稍后重试"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>重试</Button>,
+          <Button key="back" onClick={() => navigate('/master-data/certificates')}>返回列表</Button>,
+        ]}
+      />
+    );
+  }
+
+  const handleDelete = () => {
+    Modal.confirm({
+      title: '确认删除',
+      content: `确定要删除证书「${query.data?.certificateName}」吗？此操作不可撤销。`,
+      okText: '删除',
+      okType: 'danger',
+      cancelText: '取消',
+      onOk: () => deleteMutation.mutateAsync(),
+    });
+  };
+
+  const basicColumns: ProDescriptionsItemProps<Certificate>[] = [
+    { title: '证书编号', dataIndex: 'certificateNo', span: 1 },
+    { title: '证书名称', dataIndex: 'certificateName', span: 1 },
+    { title: '证书类型', dataIndex: 'certificateType', span: 1 },
+    {
+      title: '状态',
+      key: 'status',
+      span: 1,
+      render: () =>
+        query.data?.status === 'valid' ? (
+          <Tag color="success">有效</Tag>
+        ) : (
+          <Tag color="error">已过期</Tag>
+        ),
+    },
+    { title: '指令法规', dataIndex: 'directive', span: 1, renderText: (v) => v || '-' },
+    { title: '归属类型', dataIndex: 'attributionType', span: 1, renderText: (v) => v || '-' },
+    { title: '发证机构', dataIndex: 'issuingAuthority', span: 1 },
+    { title: '发证日期', dataIndex: 'issueDate', span: 1, renderText: (v) => v || '-' },
+    { title: '有效期起', dataIndex: 'validFrom', span: 1 },
+    { title: '有效期止', dataIndex: 'validUntil', span: 1 },
+    {
+      title: '证书文件',
+      key: 'file',
+      span: 1,
+      render: () =>
+        query.data?.fileUrl ? (
+          <Button type="link" style={{ padding: 0 }} onClick={() => window.open(query.data!.fileUrl!, '_blank')}>
+            {query.data.fileName || '下载'}
+          </Button>
+        ) : (
+          '-'
+        ),
+    },
+    { title: '证书说明', dataIndex: 'remarks', span: 2, renderText: (v) => v || '-' },
+    {
+      title: '关联 SPU',
+      key: 'spus',
+      span: 2,
+      render: () => {
+        const spus = query.data?.spus ?? [];
+        if (spus.length === 0) return '-';
+        return spus.map((s) => `${s.spuCode} ${s.name}`).join('、');
+      },
+    },
+    {
+      title: '创建时间',
+      dataIndex: 'createdAt',
+      span: 1,
+      renderText: (v) => dayjs(v).format('YYYY-MM-DD HH:mm'),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updatedAt',
+      span: 1,
+      renderText: (v) => dayjs(v).format('YYYY-MM-DD HH:mm'),
+    },
+  ];
+
+  return (
+    <Space direction="vertical" size={16} style={{ width: '100%' }}>
+      <Breadcrumb
+        items={[
+          {
+            title: (
+              <Button type="link" style={{ padding: 0 }} onClick={() => navigate('/master-data/certificates')}>
+                产品证书库
+              </Button>
+            ),
+          },
+          { title: '详情' },
+        ]}
+      />
+
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <Button onClick={() => navigate(`/master-data/certificates/${id}/edit`)}>编辑</Button>
+        <Button danger onClick={handleDelete} loading={deleteMutation.isPending}>删除</Button>
+      </div>
+
+      <ProDescriptions<Certificate>
+        title="证书信息"
+        loading={query.isLoading}
+        column={2}
+        dataSource={query.data}
+        columns={basicColumns}
+      />
+    </Space>
+  );
+}

--- a/apps/web/src/pages/master-data/certificates/form.tsx
+++ b/apps/web/src/pages/master-data/certificates/form.tsx
@@ -1,0 +1,298 @@
+import { useRef, useState } from 'react';
+import { Button, Result, Skeleton, Space, Upload, message } from 'antd';
+import { UploadOutlined } from '@ant-design/icons';
+import type { UploadFile } from 'antd';
+import {
+  ProCard,
+  ProForm,
+  ProFormDatePicker,
+  ProFormSelect,
+  ProFormText,
+  ProFormTextArea,
+  type ProFormInstance,
+} from '@ant-design/pro-components';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+import {
+  createCertificate,
+  getCertificateById,
+  updateCertificate,
+  uploadCertificateFile,
+  type CreateCertificatePayload,
+  type UpdateCertificatePayload,
+} from '../../../api/certificates.api';
+import { getSpus } from '../../../api/spus.api';
+
+export default function CertificateFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { id } = useParams();
+  const certId = id ? Number(id) : undefined;
+  const isEdit = Boolean(id);
+  const formRef = useRef<ProFormInstance>(undefined);
+
+  const [fileList, setFileList] = useState<UploadFile[]>([]);
+  const [uploadedFileKey, setUploadedFileKey] = useState<string | null>(null);
+  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const detailQuery = useQuery({
+    queryKey: ['certificate-detail', certId],
+    queryFn: () => getCertificateById(certId as number),
+    enabled: Boolean(isEdit && certId && Number.isInteger(certId) && certId > 0),
+  });
+
+  const spusQuery = useQuery({
+    queryKey: ['spus-options'],
+    queryFn: () => getSpus({ pageSize: 200 }),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateCertificatePayload) => createCertificate(payload),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['certificates'] });
+      message.success('证书创建成功', 3);
+      navigate(`/master-data/certificates/${data.id}`);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: UpdateCertificatePayload) => updateCertificate(certId as number, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['certificates'] });
+      queryClient.invalidateQueries({ queryKey: ['certificate-detail', certId] });
+      message.success('证书更新成功', 3);
+      navigate(`/master-data/certificates/${certId}`);
+    },
+  });
+
+  if (isEdit && (!certId || !Number.isInteger(certId) || certId <= 0)) {
+    return (
+      <Result
+        status="404"
+        title="证书不存在"
+        extra={<Button type="primary" onClick={() => navigate('/master-data/certificates')}>返回列表</Button>}
+      />
+    );
+  }
+
+  if (isEdit && detailQuery.isLoading) return <Skeleton active />;
+
+  if (isEdit && detailQuery.isError && !detailQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="加载证书信息失败"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => detailQuery.refetch()}>重试</Button>,
+          <Button key="back" onClick={() => navigate('/master-data/certificates')}>返回列表</Button>,
+        ]}
+      />
+    );
+  }
+
+  const spuOptions = (spusQuery.data?.list ?? []).map((s) => ({
+    label: `${s.spuCode} ${s.name}`,
+    value: s.id,
+  }));
+
+  const initialValues = detailQuery.data
+    ? {
+        certificateName: detailQuery.data.certificateName,
+        certificateType: detailQuery.data.certificateType,
+        directive: detailQuery.data.directive ?? undefined,
+        issueDate: detailQuery.data.issueDate ?? undefined,
+        validFrom: detailQuery.data.validFrom,
+        validUntil: detailQuery.data.validUntil,
+        issuingAuthority: detailQuery.data.issuingAuthority,
+        remarks: detailQuery.data.remarks ?? undefined,
+        attributionType: detailQuery.data.attributionType ?? undefined,
+        spuIds: detailQuery.data.spus.map((s) => s.id),
+      }
+    : {};
+
+  const handleUpload = async (file: File): Promise<boolean> => {
+    setUploading(true);
+    try {
+      const result = await uploadCertificateFile(file);
+      setUploadedFileKey(result.key);
+      setUploadedFileName(file.name);
+      message.success('文件上传成功');
+      return true;
+    } catch {
+      message.error('文件上传失败');
+      return false;
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <ProForm
+      formRef={formRef}
+      title={isEdit ? '编辑证书' : '新建证书'}
+      loading={detailQuery.isLoading}
+      submitter={{
+        searchConfig: { submitText: isEdit ? '保存' : '创建' },
+        render: (_, dom) => (
+          <Space>
+            <Button onClick={() => navigate(-1)}>取消</Button>
+            {dom[1]}
+          </Space>
+        ),
+      }}
+      initialValues={initialValues}
+      onFinish={async (values) => {
+        const fileKey = uploadedFileKey ?? detailQuery.data?.fileKey ?? undefined;
+        const fileName = uploadedFileName ?? detailQuery.data?.fileName ?? undefined;
+
+        const payload: CreateCertificatePayload = {
+          certificateName: values.certificateName,
+          certificateType: values.certificateType,
+          directive: values.directive || undefined,
+          issueDate: values.issueDate || undefined,
+          validFrom: values.validFrom,
+          validUntil: values.validUntil,
+          issuingAuthority: values.issuingAuthority,
+          remarks: values.remarks || undefined,
+          attributionType: values.attributionType || undefined,
+          fileKey,
+          fileName,
+          spuIds: values.spuIds?.length ? values.spuIds : undefined,
+        };
+
+        if (isEdit) {
+          await updateMutation.mutateAsync(payload as UpdateCertificatePayload);
+        } else {
+          await createMutation.mutateAsync(payload);
+        }
+        return true;
+      }}
+    >
+      <ProCard title="基础信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="certificateName"
+            label="证书名称"
+            placeholder="请输入证书名称"
+            width="md"
+            rules={[
+              { required: true, message: '请输入证书名称' },
+              { max: 200, message: '证书名称最多 200 个字符' },
+            ]}
+          />
+          <ProFormText
+            name="certificateType"
+            label="证书类型"
+            placeholder="如 CE、FCC、ROHS 等"
+            width="sm"
+            rules={[
+              { required: true, message: '请输入证书类型' },
+              { max: 50, message: '证书类型最多 50 个字符' },
+            ]}
+          />
+          <ProFormText
+            name="directive"
+            label="指令法规"
+            placeholder="请输入指令法规（可选）"
+            width="md"
+            rules={[{ max: 200, message: '指令法规最多 200 个字符' }]}
+          />
+          <ProFormText
+            name="attributionType"
+            label="归属类型"
+            placeholder="请输入归属类型（可选）"
+            width="sm"
+            rules={[{ max: 50, message: '归属类型最多 50 个字符' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="有效期信息" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormDatePicker
+            name="issueDate"
+            label="发证日期"
+            placeholder="请选择发证日期（可选）"
+            width="sm"
+          />
+          <ProFormDatePicker
+            name="validFrom"
+            label="有效期起"
+            placeholder="请选择开始日期"
+            width="sm"
+            rules={[{ required: true, message: '请选择有效期起始日期' }]}
+          />
+          <ProFormDatePicker
+            name="validUntil"
+            label="有效期止"
+            placeholder="请选择截止日期"
+            width="sm"
+            rules={[{ required: true, message: '请选择有效期截止日期' }]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="发证机构" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Group>
+          <ProFormText
+            name="issuingAuthority"
+            label="发证机构"
+            placeholder="请输入发证机构名称"
+            width="md"
+            rules={[
+              { required: true, message: '请输入发证机构' },
+              { max: 200, message: '发证机构最多 200 个字符' },
+            ]}
+          />
+        </ProForm.Group>
+      </ProCard>
+
+      <ProCard title="证书文件" bordered style={{ marginBottom: 16 }}>
+        <ProForm.Item label="上传证书文件">
+          <Upload
+            fileList={fileList}
+            maxCount={1}
+            accept=".pdf,.jpg,.jpeg,.png"
+            beforeUpload={(file) => {
+              setFileList([file as unknown as UploadFile]);
+              handleUpload(file);
+              return false;
+            }}
+            onRemove={() => {
+              setFileList([]);
+              setUploadedFileKey(null);
+              setUploadedFileName(null);
+            }}
+          >
+            <Button icon={<UploadOutlined />} loading={uploading}>
+              {isEdit && detailQuery.data?.fileName ? `替换文件（当前：${detailQuery.data.fileName}）` : '选择文件'}
+            </Button>
+          </Upload>
+        </ProForm.Item>
+      </ProCard>
+
+      <ProCard title="关联 SPU" bordered style={{ marginBottom: 16 }}>
+        <ProFormSelect
+          name="spuIds"
+          label="适用 SPU"
+          placeholder="请选择关联的 SPU（可多选）"
+          width="xl"
+          mode="multiple"
+          options={spuOptions}
+          fieldProps={{ optionFilterProp: 'label', loading: spusQuery.isLoading }}
+        />
+      </ProCard>
+
+      <ProCard title="其他" bordered>
+        <ProFormTextArea
+          name="remarks"
+          label="证书说明"
+          placeholder="请输入证书说明（可选）"
+          width="xl"
+        />
+      </ProCard>
+    </ProForm>
+  );
+}

--- a/apps/web/src/pages/master-data/certificates/index.tsx
+++ b/apps/web/src/pages/master-data/certificates/index.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import {
+  Button,
+  Empty,
+  Flex,
+  Input,
+  Result,
+  Select,
+  Skeleton,
+  Space,
+  Tag,
+  Typography,
+  theme,
+} from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import { getCertificates, type Certificate } from '../../../api/certificates.api';
+import { useDebouncedValue } from '../../../hooks/useDebounce';
+
+const STATUS_OPTIONS = [
+  { label: '有效', value: 'valid' },
+  { label: '已过期', value: 'expired' },
+];
+
+export default function CertificatesListPage() {
+  const navigate = useNavigate();
+  const { token } = theme.useToken();
+
+  const [keywordInput, setKeywordInput] = useState('');
+  const [statusFilter, setStatusFilter] = useState<'valid' | 'expired' | undefined>();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters = Boolean(keyword || statusFilter);
+
+  useEffect(() => { setPage(1); }, [keyword, statusFilter]);
+
+  const query = useQuery({
+    queryKey: ['certificates', keyword, statusFilter, page, pageSize],
+    placeholderData: (prev) => prev,
+    queryFn: () =>
+      getCertificates({
+        keyword: keyword || undefined,
+        status: statusFilter,
+        page,
+        pageSize,
+      }),
+  });
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="加载证书库失败"
+        subTitle="请检查网络或稍后重试"
+        extra={<Button type="primary" onClick={() => query.refetch()}>重试</Button>}
+      />
+    );
+  }
+
+  const columns: ProColumns<Certificate>[] = useMemo(
+    () => [
+      {
+        title: '证书编号',
+        dataIndex: 'certificateNo',
+        width: 110,
+        render: (_, record) => (
+          <Link to={`/master-data/certificates/${record.id}`} style={{ color: token.colorLink }}>
+            {record.certificateNo}
+          </Link>
+        ),
+      },
+      {
+        title: '证书名称',
+        dataIndex: 'certificateName',
+        width: 200,
+        ellipsis: true,
+        render: (_, record) => (
+          <Link to={`/master-data/certificates/${record.id}`} style={{ color: token.colorLink }}>
+            {record.certificateName}
+          </Link>
+        ),
+      },
+      {
+        title: '证书类型',
+        dataIndex: 'certificateType',
+        width: 100,
+      },
+      {
+        title: '指令法规',
+        dataIndex: 'directive',
+        width: 150,
+        ellipsis: true,
+        render: (_, record) => record.directive || <Typography.Text type="secondary">-</Typography.Text>,
+      },
+      {
+        title: '有效期',
+        key: 'validity',
+        width: 200,
+        render: (_, record) => `${record.validFrom} ~ ${record.validUntil}`,
+      },
+      {
+        title: '状态',
+        dataIndex: 'status',
+        width: 80,
+        render: (_, record) =>
+          record.status === 'valid' ? (
+            <Tag color="success">有效</Tag>
+          ) : (
+            <Tag color="error">已过期</Tag>
+          ),
+      },
+      {
+        title: '发证机构',
+        dataIndex: 'issuingAuthority',
+        width: 160,
+        ellipsis: true,
+      },
+      {
+        title: '证书文件',
+        key: 'file',
+        width: 100,
+        render: (_, record) =>
+          record.fileUrl ? (
+            <Button
+              type="link"
+              size="small"
+              style={{ padding: 0 }}
+              onClick={() => window.open(record.fileUrl!, '_blank')}
+            >
+              下载
+            </Button>
+          ) : (
+            <Typography.Text type="secondary">-</Typography.Text>
+          ),
+      },
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        width: 110,
+        render: (_, record) => dayjs(record.createdAt).format('YYYY-MM-DD'),
+      },
+      {
+        title: '操作',
+        key: 'actions',
+        width: 120,
+        fixed: 'right',
+        render: (_, record) => (
+          <Space size={12}>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/certificates/${record.id}`)}
+            >
+              查看
+            </Button>
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={() => navigate(`/master-data/certificates/${record.id}/edit`)}
+            >
+              编辑
+            </Button>
+          </Space>
+        ),
+      },
+    ],
+    [navigate, token.colorLink],
+  );
+
+  const emptyText = hasFilters ? (
+    <Empty description="未找到匹配记录">
+      <Button
+        type="link"
+        onClick={() => {
+          setKeywordInput('');
+          setStatusFilter(undefined);
+          setPage(1);
+        }}
+      >
+        清除筛选条件
+      </Button>
+    </Empty>
+  ) : (
+    <Empty description="暂无证书数据">
+      <Button type="primary" onClick={() => navigate('/master-data/certificates/create')}>
+        新建证书
+      </Button>
+    </Empty>
+  );
+
+  return (
+    <div>
+      <Flex align="center" justify="space-between" style={{ marginBottom: token.marginMD }}>
+        <Typography.Title level={3} style={{ margin: 0 }}>产品证书库</Typography.Title>
+        <Button type="primary" onClick={() => navigate('/master-data/certificates/create')}>
+          + 新建证书
+        </Button>
+      </Flex>
+
+      <Space size={token.marginSM} style={{ marginBottom: token.marginSM }}>
+        <Input
+          placeholder="搜索证书名称/编号..."
+          style={{ width: 280 }}
+          value={keywordInput}
+          onChange={(e) => { setKeywordInput(e.target.value); setPage(1); }}
+          allowClear
+        />
+        <Select
+          style={{ width: 140 }}
+          placeholder="全部状态"
+          value={statusFilter}
+          onChange={(v) => { setStatusFilter(v); setPage(1); }}
+          options={STATUS_OPTIONS}
+          allowClear
+        />
+      </Space>
+
+      <Skeleton active loading={query.isLoading && !query.data}>
+        <ProTable<Certificate>
+          search={false}
+          options={false}
+          toolBarRender={false}
+          rowKey="id"
+          loading={query.isFetching}
+          columns={columns}
+          dataSource={query.data?.list ?? []}
+          scroll={{ x: 1300, y: 540 }}
+          rowClassName={() => 'cert-row-height'}
+          locale={{ emptyText }}
+          pagination={{
+            current: page,
+            pageSize,
+            total: query.data?.total ?? 0,
+            showSizeChanger: true,
+            pageSizeOptions: [10, 20, 50],
+            showTotal: (total) => `共 ${total} 条记录`,
+            onChange: (nextPage, nextPageSize) => {
+              if (nextPageSize !== pageSize) { setPage(1); } else { setPage(nextPage); }
+              setPageSize(nextPageSize);
+            },
+          }}
+        />
+      </Skeleton>
+
+      <style>{`.cert-row-height .ant-table-cell { height: 48px; }`}</style>
+    </div>
+  );
+}

--- a/packages/shared/src/enums/certificate-status.enum.ts
+++ b/packages/shared/src/enums/certificate-status.enum.ts
@@ -1,0 +1,6 @@
+export const CertificateStatus = {
+  VALID: 'valid',
+  EXPIRED: 'expired',
+} as const;
+
+export type CertificateStatus = typeof CertificateStatus[keyof typeof CertificateStatus];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export * from './enums/warehouse-status.enum';
 export * from './enums/warehouse-type.enum';
 export * from './enums/warehouse-ownership.enum';
 export * from './enums/currency-status.enum';
+export * from './enums/certificate-status.enum';
 
 // Types
 export * from './types/api-response.types';


### PR DESCRIPTION
## Summary

- Backend: Certificate entity with ManyToMany SPU association via certificate_spus junction; auto-generated CERT001 codes; valid/expired status computed from valid_until vs today
- Backend: CRUD /api/certificates with pagination, keyword/type/status filters, signed OSS URLs
- Backend: Migration 20260422000200 creating certificates + certificate_spus tables with cascade FK
- Frontend: List/detail/form pages with date pickers, file upload, SPU multi-select
- Shared: CertificateStatus enum (valid/expired)
- Tests: 13 unit tests for CertificatesService

## Test plan
- [x] API build passes
- [x] Web build passes  
- [x] 13/13 unit tests pass for CertificatesService
- [ ] Manual: create certificate with file upload, verify CERT001 sequence
- [ ] Manual: filter by status (valid/expired) in list page
- [ ] Manual: associate SPUs during create/edit
- [ ] Manual: delete with confirm modal

Generated with Claude Code