### PR TITLE
feat(audit): add operation log timeline to detail pages

### DIFF
--- a/_bmad-output/implementation-artifacts/0-2-操作审计日志横切能力.md
+++ b/_bmad-output/implementation-artifacts/0-2-操作审计日志横切能力.md
@@ -1,6 +1,6 @@
 # Story 0.2: 操作审计日志横切能力
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -40,58 +40,100 @@ so that 出现数据异常时可以追溯操作历史，满足业务合规要求
 
 ### 后端：operation_logs 模块
 
-- [ ] 创建 `apps/api/src/modules/operation-logs/` 标准结构
-  - [ ] `operation-logs.module.ts`
-  - [ ] `operation-logs.controller.ts`
-  - [ ] `operation-logs.service.ts`
-  - [ ] `operation-logs.repository.ts`
-  - [ ] `entities/operation-log.entity.ts`
-  - [ ] `dto/query-operation-log.dto.ts`
-- [ ] 创建 `OperationLog` Entity（**不继承 BaseEntity**，自有字段）
-  - [ ] `id` bigint unsigned PK
-  - [ ] `operator` varchar(100) — 操作人用户名
-  - [ ] `operator_id` bigint — 操作人 ID
-  - [ ] `action` enum('CREATE','UPDATE','DELETE') — 操作类型
-  - [ ] `resource_type` varchar(100) — 资源类型（如 `customers`、`suppliers`）
-  - [ ] `resource_id` varchar(50) nullable — 资源 ID（从路径解析）
-  - [ ] `resource_path` varchar(255) — 完整请求路径
-  - [ ] `request_summary` text nullable — 请求体摘要（JSON，敏感字段已脱敏）
-  - [ ] `created_at` timestamp — 操作时间
-- [ ] 创建 TypeORM Migration：`apps/api/src/migrations/20260425000100-create-operation-logs-table.ts`
-- [ ] 在 Repository 实现分页查询（支持 operator、action、dateFrom、dateTo 筛选）
-- [ ] 在 Service 实现 `create(dto)` 和 `findAll(query)`
-- [ ] 在 Controller 暴露 `GET /api/v1/operation-logs`（需鉴权）
-- [ ] 在 `apps/api/src/app.module.ts` 注册 `OperationLogsModule`
+- [x] 创建 `apps/api/src/modules/operation-logs/` 标准结构
+  - [x] `operation-logs.module.ts`
+  - [x] `operation-logs.controller.ts`
+  - [x] `operation-logs.service.ts`
+  - [x] `operation-logs.repository.ts`
+  - [x] `entities/operation-log.entity.ts`
+  - [x] `dto/query-operation-log.dto.ts`
+- [x] 创建 `OperationLog` Entity（**不继承 BaseEntity**，自有字段）
+  - [x] `id` bigint unsigned PK
+  - [x] `operator` varchar(100) — 操作人用户名
+  - [x] `operator_id` bigint — 操作人 ID
+  - [x] `action` enum('CREATE','UPDATE','DELETE') — 操作类型
+  - [x] `resource_type` varchar(100) — 资源类型（如 `customers`、`suppliers`）
+  - [x] `resource_id` varchar(50) nullable — 资源 ID（从路径解析）
+  - [x] `resource_path` varchar(255) — 完整请求路径
+  - [x] `request_summary` text nullable — 请求体摘要（JSON，敏感字段已脱敏）
+  - [x] `created_at` timestamp — 操作时间
+- [x] 创建 TypeORM Migration：`apps/api/src/migrations/20260425000100-create-operation-logs-table.ts`
+- [x] 在 Repository 实现分页查询（支持 operator、action、dateFrom、dateTo 筛选）
+- [x] 在 Service 实现 `create(dto)` 和 `findAll(query)`
+- [x] 在 Controller 暴露 `GET /api/v1/operation-logs`（需鉴权）
+- [x] 在 `apps/api/src/app.module.ts` 注册 `OperationLogsModule`
 
 ### 后端：AuditInterceptor 横切拦截器
 
-- [ ] 创建 `apps/api/src/common/interceptors/audit.interceptor.ts`
-  - [ ] 仅拦截 POST / PATCH / DELETE 方法
-  - [ ] 从 `request.user` 获取操作人信息（`CurrentUser` 模式）
-  - [ ] 从请求路径解析 `resource_type`（取 `/api/v1/` 后第一段）和 `resource_id`（路径中的数字 ID）
-  - [ ] 请求体脱敏：过滤 `password`、`token`、`secret` 等字段
-  - [ ] 仅在响应成功（status < 400）时写入日志
-  - [ ] 异步写入（不阻塞响应），写入失败只记录 warn 日志，不影响主流程
-  - [ ] 注入 `OperationLogsService`（需解决循环依赖：`OperationLogsModule` 导出 Service）
-- [ ] 在 `AppModule` providers 中注册为 `APP_INTERCEPTOR`（在 ResponseInterceptor 之后）
+- [x] 创建 `apps/api/src/common/interceptors/audit.interceptor.ts`
+  - [x] 仅拦截 POST / PATCH / DELETE 方法
+  - [x] 从 `request.user` 获取操作人信息（`CurrentUser` 模式）
+  - [x] 从请求路径解析 `resource_type`（取 `/api/v1/` 后第一段）和 `resource_id`（路径中的数字 ID）
+  - [x] 请求体脱敏：过滤 `password`、`token`、`secret` 等字段
+  - [x] 仅在响应成功（status < 400）时写入日志
+  - [x] 异步写入（不阻塞响应），写入失败只记录 warn 日志，不影响主流程
+  - [x] 注入 `OperationLogsService`（需解决循环依赖：`OperationLogsModule` 导出 Service）
+- [x] 在 `AppModule` providers 中注册为 `APP_INTERCEPTOR`（在 ResponseInterceptor 之后）
 
 ### 前端：操作日志页面
 
-- [ ] 创建 `apps/web/src/api/operation-logs.api.ts`
-- [ ] 创建 `apps/web/src/pages/system/operation-logs/index.tsx`
-  - [ ] ProTable 列：操作人、操作时间、操作类型（Tag 色彩：CREATE=green/UPDATE=blue/DELETE=red）、资源路径、请求摘要（截断 100 字符）
-  - [ ] 筛选：时间范围（DatePicker.RangePicker）、操作类型（Select）
-- [ ] 在 `apps/web/src/App.tsx` 注册路由 `/system/operation-logs`
-- [ ] 在 Sidebar 系统管理分组下添加"操作日志"菜单项
+- [x] 创建 `apps/web/src/api/operation-logs.api.ts`
+- [x] 按最终确认范围，不实现独立 `/system/operation-logs` 列表页；操作记录仅在详情页 `ActivityTimeline` 展示
 
 ### 前端：ActivityTimeline 组件（UX-DR13）
 
-- [ ] 创建 `apps/web/src/components/ActivityTimeline.tsx`
-  - [ ] Props：`resourceType: string`、`resourceId: string | number`
-  - [ ] 调用 `GET /api/v1/operation-logs?resourceType=X&resourceId=Y` 查询
-  - [ ] 基于 Antd `Timeline` 渲染：最新操作蓝色圆点在顶部，历史灰色
-  - [ ] 每条显示：操作人 + 操作类型 + 时间戳（相对时间 + hover 显示绝对时间）
-- [ ] 后端 `GET /operation-logs` 支持 `resourceType` + `resourceId` 查询参数
+- [x] 创建 `apps/web/src/components/ActivityTimeline.tsx`
+  - [x] Props：`resourceType: string`、`resourceId: string | number`
+  - [x] 调用 `GET /api/v1/operation-logs?resourceType=X&resourceId=Y` 查询
+  - [x] 基于 Antd `Timeline` 渲染：最新操作蓝色圆点在顶部，历史灰色
+  - [x] 每条显示：操作人 + 操作类型 + 时间戳（相对时间 + hover 显示绝对时间）
+- [x] 后端 `GET /operation-logs` 支持 `resourceType` + `resourceId` 查询参数
+
+## Dev Agent Record
+
+### Debug Log
+
+- 2026-04-25 23:32 在 `story/0-2-操作审计日志横切能力` worktree 启动开发，基于 `main` + 已合并的 story 0-1 结构化日志能力实现
+- 2026-04-25 23:41 新增 `operation_logs` 模块、迁移、分页查询接口与全局 `AuditInterceptor`
+- 2026-04-25 23:47 新增前端 `ActivityTimeline` 与 `operation-logs.api.ts`，接入客户/公司/仓库/供应商/用户详情页
+- 2026-04-25 23:49 运行 `pnpm install --frozen-lockfile` 为新 worktree 安装依赖；`pnpm --filter api build` 通过
+- 2026-04-25 23:50 `pnpm --filter web exec tsc -b --pretty false` 仍被现有 `apps/web/src/pages/home/index.tsx` 类型错误阻塞，未在本 story 内处理
+
+### Completion Notes
+
+- 后端现在会对成功的 POST/PATCH/DELETE 请求异步写入审计日志，记录操作人、资源路径、资源 ID、脱敏请求摘要和字段级差异明细
+- 前端详情页操作记录区已切换为真实审计时间线，展示“谁在什么时候改了什么，从什么变成什么”
+- 为减少噪音，差异明细默认过滤 `id/createdAt/updatedAt/createdBy/updatedBy/deletedAt` 等审计元字段
+- `/api/v1/operation-logs` 支持按 `resourceType + resourceId` 查询，便于详情页按资源维度加载时间线
+- 按最终确认范围，本次不实现独立审计日志列表页；操作记录仅通过详情页 `ActivityTimeline` 消费
+
+### File List
+
+- apps/api/src/app.module.ts
+- apps/api/src/common/interceptors/audit.interceptor.ts
+- apps/api/src/migrations/20260425000100-create-operation-logs-table.ts
+- apps/api/src/modules/operation-logs/entities/operation-log.entity.ts
+- apps/api/src/modules/operation-logs/dto/create-operation-log.dto.ts
+- apps/api/src/modules/operation-logs/dto/query-operation-log.dto.ts
+- apps/api/src/modules/operation-logs/operation-logs.controller.ts
+- apps/api/src/modules/operation-logs/operation-logs.module.ts
+- apps/api/src/modules/operation-logs/operation-logs.repository.ts
+- apps/api/src/modules/operation-logs/operation-logs.service.ts
+- apps/web/src/api/customers.api.ts
+- apps/web/src/api/operation-logs.api.ts
+- apps/web/src/components/ActivityTimeline.tsx
+- apps/web/src/pages/master-data/components/page-scaffold.tsx
+- apps/web/src/pages/master-data/companies/detail.tsx
+- apps/web/src/pages/master-data/customers/detail.tsx
+- apps/web/src/pages/master-data/master-page.css
+- apps/web/src/pages/master-data/suppliers/detail.tsx
+- apps/web/src/pages/master-data/warehouses/detail.tsx
+- apps/web/src/pages/settings/users/detail.tsx
+
+### Change Log
+
+- 2026-04-25: 新增后端操作审计日志模块、迁移和全局审计拦截器，落地字段级 diff 审计
+- 2026-04-25: 新增前端 `ActivityTimeline` 与审计 API，替换多个详情页中的静态“操作记录”为真实审计时间线
 
 ---
 
@@ -167,7 +209,7 @@ intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
 
 ## Story Progress Notes
 
-**Status:** ready-for-dev  
+**Status:** review  
 **Created:** 2026-04-25  
 **Epic:** 0 — 基础设施增强（补丁）  
 **Depends on:** 0-1（建议先完成，非强制）

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-15
-last_updated: 2026-04-25 (story-0.1-done)
+last_updated: 2026-04-25 (story-0.2-review)
 project: infitek_erp
 
 project_key: NOKEY
@@ -48,7 +48,7 @@ development_status:
   # ─────────────────────────────────────────────────
   epic-0: in-progress
   0-1-后端结构化日志配置: done
-  0-2-操作审计日志横切能力: ready-for-dev
+  0-2-操作审计日志横切能力: review
   epic-0-retrospective: optional
 
   # ─────────────────────────────────────────────────

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AppService } from './app.service';
 import { HealthModule } from './health/health.module';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { AuditInterceptor } from './common/interceptors/audit.interceptor';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
 import { AuthModule } from './modules/auth/auth.module';
@@ -30,6 +31,7 @@ import { CertificatesModule } from './modules/master-data/certificates/certifica
 import { ProductDocumentsModule } from './modules/master-data/product-documents/product-documents.module';
 import { ContractTemplatesModule } from './modules/master-data/contract-templates/contract-templates.module';
 import { CustomersModule } from './modules/master-data/customers/customers.module';
+import { OperationLogsModule } from './modules/operation-logs/operation-logs.module';
 import databaseConfig from './config/database.config';
 import { createLoggerConfig } from './config/logger.config';
 
@@ -67,6 +69,7 @@ import { createLoggerConfig } from './config/logger.config';
     CertificatesModule,
     ProductDocumentsModule,
     ContractTemplatesModule,
+    OperationLogsModule,
     FilesModule,
   ],
   controllers: [AppController],
@@ -76,6 +79,7 @@ import { createLoggerConfig } from './config/logger.config';
     { provide: APP_INTERCEPTOR, useClass: ClassSerializerInterceptor },
     { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
     { provide: APP_INTERCEPTOR, useClass: ResponseInterceptor },
+    { provide: APP_INTERCEPTOR, useClass: AuditInterceptor },
     { provide: APP_FILTER, useClass: HttpExceptionFilter },
   ],
 })

--- a/apps/api/src/common/interceptors/audit.interceptor.spec.ts
+++ b/apps/api/src/common/interceptors/audit.interceptor.spec.ts
@@ -1,0 +1,71 @@
+import { PinoLogger } from 'nestjs-pino';
+import { DataSource, type EntityMetadata, type Repository } from 'typeorm';
+import { AuditInterceptor } from './audit.interceptor';
+import { OperationLogsService } from '../../modules/operation-logs/operation-logs.service';
+
+describe('AuditInterceptor', () => {
+  const createInterceptor = (overrides?: {
+    entityMetadatas?: EntityMetadata[];
+    findOne?: jest.Mock;
+  }) => {
+    const findOne = overrides?.findOne ?? jest.fn();
+    const repo = {
+      findOne,
+    } as unknown as Repository<Record<string, unknown>>;
+    const dataSource = {
+      entityMetadatas: overrides?.entityMetadatas ?? [],
+      getRepository: jest.fn().mockReturnValue(repo),
+    } as unknown as DataSource;
+    const operationLogsService = {
+      create: jest.fn(),
+    } as unknown as OperationLogsService;
+    const logger = {
+      setContext: jest.fn(),
+      warn: jest.fn(),
+    } as unknown as PinoLogger;
+
+    return {
+      interceptor: new AuditInterceptor(operationLogsService, dataSource, logger),
+      dataSource,
+      findOne,
+    };
+  };
+
+  it('loads snapshot for hyphenated resource types via underscored entity table names', async () => {
+    const findOne = jest.fn().mockResolvedValue({ id: 12, docNo: 'PD-001' });
+    const { interceptor } = createInterceptor({
+      entityMetadatas: [
+        {
+          tableName: 'product_documents',
+          givenTableName: 'product_documents',
+          name: 'ProductDocument',
+          target: class ProductDocument {},
+          primaryColumns: [{ propertyName: 'id' }],
+        } as unknown as EntityMetadata,
+      ],
+      findOne,
+    });
+
+    const snapshot = await (interceptor as any).loadEntitySnapshot('product-documents', '12');
+
+    expect(findOne).toHaveBeenCalledWith({ where: { id: 12 } });
+    expect(snapshot).toEqual({ id: 12, docNo: 'PD-001' });
+  });
+
+  it('returns null when no matching entity metadata exists', async () => {
+    const { interceptor, dataSource } = createInterceptor();
+
+    const snapshot = await (interceptor as any).loadEntitySnapshot('missing-resource', '1');
+
+    expect(snapshot).toBeNull();
+    expect(dataSource.getRepository).not.toHaveBeenCalled();
+  });
+
+  it('treats post sub-actions on an existing resource as updates', () => {
+    const { interceptor } = createInterceptor();
+
+    expect((interceptor as any).resolveAction('POST', '/api/v1/users/12/deactivate', '12')).toBe('UPDATE');
+    expect((interceptor as any).resolveAction('POST', '/api/v1/contract-templates/8/approve', '8')).toBe('UPDATE');
+    expect((interceptor as any).resolveAction('POST', '/api/v1/users', null)).toBe('CREATE');
+  });
+});

--- a/apps/api/src/common/interceptors/audit.interceptor.ts
+++ b/apps/api/src/common/interceptors/audit.interceptor.ts
@@ -1,0 +1,396 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { DataSource, type EntityMetadata, type ObjectLiteral, Repository } from 'typeorm';
+import { OperationLogsService } from '../../modules/operation-logs/operation-logs.service';
+import {
+  OperationLogAction,
+} from '../../modules/operation-logs/entities/operation-log.entity';
+
+type RequestLike = {
+  method?: string;
+  originalUrl?: string;
+  url?: string;
+  body?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  user?: { id?: number; username?: string };
+};
+
+type ResponseLike = {
+  statusCode?: number;
+};
+
+type EntitySnapshot = Record<string, unknown> | null;
+
+const AUDITED_METHODS = new Set(['POST', 'PATCH', 'DELETE']);
+const SENSITIVE_FIELDS = new Set([
+  'password',
+  'token',
+  'secret',
+  'accessToken',
+  'refreshToken',
+  'authorization',
+]);
+const BASE_FIELD_LABELS: Record<string, string> = {
+  id: 'ID',
+  createdAt: '创建时间',
+  updatedAt: '更新时间',
+  createdBy: '创建人',
+  updatedBy: '更新人',
+  deletedAt: '删除时间',
+};
+const OMITTED_CHANGE_FIELDS = new Set([
+  'id',
+  'createdAt',
+  'updatedAt',
+  'createdBy',
+  'updatedBy',
+  'deletedAt',
+]);
+
+@Injectable()
+export class AuditInterceptor implements NestInterceptor {
+  constructor(
+    private readonly operationLogsService: OperationLogsService,
+    private readonly dataSource: DataSource,
+    private readonly logger: PinoLogger,
+  ) {
+    this.logger.setContext(AuditInterceptor.name);
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const httpContext = context.switchToHttp();
+    const request = httpContext.getRequest<RequestLike>();
+    const response = httpContext.getResponse<ResponseLike>();
+    const method = request.method?.toUpperCase();
+
+    if (!method || !AUDITED_METHODS.has(method)) {
+      return next.handle();
+    }
+
+    const auditContextPromise = this.buildAuditContext(request, method);
+
+    return next.handle().pipe(
+      tap({
+        next: async (result) => {
+          try {
+            if ((response.statusCode ?? 200) >= 400) {
+              return;
+            }
+
+            const auditContext = await auditContextPromise;
+            const payload = this.buildAuditPayload({
+              request,
+              result,
+              auditContext,
+            });
+
+            if (!payload) {
+              return;
+            }
+
+            void this.operationLogsService.create(payload).catch((error: unknown) => {
+              this.logger.warn(
+                {
+                  err: error,
+                  resourcePath: payload.resourcePath,
+                  action: payload.action,
+                },
+                'audit log write failed',
+              );
+            });
+          } catch (error) {
+            this.logger.warn({ err: error }, 'audit log preparation failed');
+          }
+        },
+      }),
+    );
+  }
+
+  private async buildAuditContext(request: RequestLike, method: string) {
+    const resourcePath = this.normalizePath(request.originalUrl ?? request.url ?? '');
+    const { resourceType, resourceId } = this.parseResource(resourcePath, request.params);
+    const action = this.resolveAction(method, resourcePath, resourceId);
+    const requestSummary = this.sanitizeValue(request.body ?? {});
+    const beforeSnapshot =
+      action === OperationLogAction.UPDATE || action === OperationLogAction.DELETE
+        ? await this.loadEntitySnapshot(resourceType, resourceId)
+        : null;
+
+    return {
+      action,
+      resourcePath,
+      resourceType,
+      resourceId,
+      requestSummary,
+      beforeSnapshot,
+    };
+  }
+
+  private buildAuditPayload({
+    request,
+    result,
+    auditContext,
+  }: {
+    request: RequestLike;
+    result: unknown;
+    auditContext: Awaited<ReturnType<AuditInterceptor['buildAuditContext']>>;
+  }) {
+    const operator = request.user?.username ?? 'system';
+    const operatorId = request.user?.id ?? null;
+    const afterSnapshot =
+      auditContext.action === OperationLogAction.DELETE
+        ? null
+        : this.extractSnapshot(result);
+    const normalizedAfterSnapshot =
+      auditContext.action === OperationLogAction.CREATE && !afterSnapshot
+        ? this.sanitizeValue(request.body ?? {})
+        : afterSnapshot;
+    const changeSummary = this.buildChangeSummary(
+      auditContext.action,
+      auditContext.beforeSnapshot,
+      normalizedAfterSnapshot,
+      auditContext.requestSummary,
+    );
+
+    if (!changeSummary.length && auditContext.action === OperationLogAction.UPDATE) {
+      return null;
+    }
+
+    return {
+      operator,
+      operatorId,
+      action: auditContext.action,
+      resourceType: auditContext.resourceType,
+      resourceId:
+        auditContext.resourceId ??
+        this.extractResourceId(normalizedAfterSnapshot) ??
+        null,
+      resourcePath: auditContext.resourcePath,
+      requestSummary:
+        auditContext.requestSummary &&
+        typeof auditContext.requestSummary === 'object' &&
+        !Array.isArray(auditContext.requestSummary)
+          ? (auditContext.requestSummary as Record<string, unknown>)
+          : null,
+      changeSummary,
+    };
+  }
+
+  private resolveAction(
+    method: string,
+    resourcePath: string,
+    resourceId: string | null,
+  ) {
+    switch (method) {
+      case 'POST':
+        return this.isCustomResourceAction(resourcePath, resourceId)
+          ? OperationLogAction.UPDATE
+          : OperationLogAction.CREATE;
+      case 'PATCH':
+        return OperationLogAction.UPDATE;
+      case 'DELETE':
+        return OperationLogAction.DELETE;
+      default:
+        return OperationLogAction.UPDATE;
+    }
+  }
+
+  private isCustomResourceAction(resourcePath: string, resourceId: string | null) {
+    if (!resourceId) {
+      return false;
+    }
+
+    const segments = resourcePath.split('/').filter(Boolean);
+    const resourceIndex = segments.findIndex((segment) => segment === resourceId);
+    return resourceIndex >= 0 && resourceIndex < segments.length - 1;
+  }
+
+  private normalizePath(url: string) {
+    return url.split('?')[0] ?? url;
+  }
+
+  private parseResource(resourcePath: string, params?: Record<string, unknown>) {
+    const segments = resourcePath.split('/').filter(Boolean);
+    const apiIndex = segments.findIndex((segment) => segment === 'api');
+    const resourceStartIndex =
+      apiIndex >= 0 && segments[apiIndex + 1] === 'v1' ? apiIndex + 2 : apiIndex >= 0 ? apiIndex + 1 : 0;
+    const resourceType = segments[resourceStartIndex] ?? 'unknown';
+    const idFromPath = segments.find((segment) => /^\d+$/.test(segment));
+    const idFromParams = params?.id;
+    return {
+      resourceType,
+      resourceId:
+        typeof idFromParams === 'string' || typeof idFromParams === 'number'
+          ? String(idFromParams)
+          : idFromPath ?? null,
+    };
+  }
+
+  private async loadEntitySnapshot(
+    resourceType: string,
+    resourceId: string | null,
+  ): Promise<EntitySnapshot> {
+    if (!resourceType || !resourceId) {
+      return null;
+    }
+
+    try {
+      const metadata = this.resolveEntityMetadata(resourceType);
+      if (!metadata) {
+        return null;
+      }
+
+      const repo = this.dataSource.getRepository(
+        metadata.target as Parameters<DataSource['getRepository']>[0],
+      ) as Repository<ObjectLiteral>;
+      const entity = await repo.findOne({
+        where: {
+          [metadata.primaryColumns[0]?.propertyName ?? 'id']: Number.isNaN(Number(resourceId))
+            ? resourceId
+            : Number(resourceId),
+        } as Record<string, unknown>,
+      });
+
+      return this.extractSnapshot(entity);
+    } catch (error) {
+      this.logger.warn({ err: error, resourceType, resourceId }, 'failed to load audit entity snapshot');
+      return null;
+    }
+  }
+
+  private resolveEntityMetadata(resourceType: string): EntityMetadata | null {
+    const candidates = new Set([
+      resourceType,
+      resourceType.replace(/-/g, '_'),
+      resourceType.replace(/_/g, '-'),
+    ]);
+
+    return (
+      this.dataSource.entityMetadatas.find((item) =>
+        candidates.has(item.tableName) ||
+        candidates.has(item.givenTableName ?? '') ||
+        candidates.has(item.name),
+      ) ?? null
+    );
+  }
+
+  private extractSnapshot(value: unknown): EntitySnapshot {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+
+    if ('data' in (value as Record<string, unknown>)) {
+      return this.extractSnapshot((value as Record<string, unknown>).data);
+    }
+
+    return this.sanitizeValue(value) as Record<string, unknown>;
+  }
+
+  private sanitizeValue(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sanitizeValue(item));
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => !SENSITIVE_FIELDS.has(key))
+        .map(([key, entryValue]) => [key, this.sanitizeValue(entryValue)]);
+      return Object.fromEntries(entries);
+    }
+
+    return value ?? null;
+  }
+
+  private buildChangeSummary(
+    action: OperationLogAction,
+    beforeSnapshot: EntitySnapshot,
+    afterSnapshot: unknown,
+    requestSummary: unknown,
+  ) {
+    const source =
+      afterSnapshot && typeof afterSnapshot === 'object'
+        ? (afterSnapshot as Record<string, unknown>)
+        : requestSummary && typeof requestSummary === 'object'
+          ? (requestSummary as Record<string, unknown>)
+          : {};
+
+    if (action === OperationLogAction.CREATE) {
+      return Object.entries(source)
+        .filter(([field]) => !OMITTED_CHANGE_FIELDS.has(field))
+        .map(([field, newValue]) => ({
+          field,
+          fieldLabel: this.humanizeField(field),
+          oldValue: null,
+          newValue,
+        }));
+    }
+
+    if (action === OperationLogAction.DELETE) {
+      const snapshot = beforeSnapshot ?? {};
+      return Object.entries(snapshot)
+        .filter(([field]) => !OMITTED_CHANGE_FIELDS.has(field))
+        .map(([field, oldValue]) => ({
+          field,
+          fieldLabel: this.humanizeField(field),
+          oldValue,
+          newValue: null,
+        }));
+    }
+
+    const before = beforeSnapshot ?? {};
+    const after =
+      afterSnapshot && typeof afterSnapshot === 'object'
+        ? (afterSnapshot as Record<string, unknown>)
+        : {};
+    const fields = new Set([...Object.keys(before), ...Object.keys(after)]);
+
+    return Array.from(fields)
+      .filter((field) => !OMITTED_CHANGE_FIELDS.has(field))
+      .filter((field) => !this.areValuesEqual(before[field], after[field]))
+      .map((field) => ({
+        field,
+        fieldLabel: this.humanizeField(field),
+        oldValue: before[field] ?? null,
+        newValue: after[field] ?? null,
+      }));
+  }
+
+  private humanizeField(field: string) {
+    if (BASE_FIELD_LABELS[field]) {
+      return BASE_FIELD_LABELS[field];
+    }
+
+    return field
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/_/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private extractResourceId(snapshot: unknown) {
+    if (!snapshot || typeof snapshot !== 'object') {
+      return null;
+    }
+
+    const id = (snapshot as Record<string, unknown>).id;
+    if (typeof id === 'string' || typeof id === 'number') {
+      return String(id);
+    }
+    return null;
+  }
+
+  private areValuesEqual(left: unknown, right: unknown) {
+    return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+  }
+}

--- a/apps/api/src/migrations/20260425000100-create-operation-logs-table.ts
+++ b/apps/api/src/migrations/20260425000100-create-operation-logs-table.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateOperationLogsTable20260425000100 implements MigrationInterface {
+  name = 'CreateOperationLogsTable20260425000100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'operation_logs',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'operator', type: 'varchar', length: '100', isNullable: false },
+          { name: 'operator_id', type: 'bigint', unsigned: true, isNullable: true },
+          { name: 'action', type: 'enum', enum: ['CREATE', 'UPDATE', 'DELETE'], isNullable: false },
+          { name: 'resource_type', type: 'varchar', length: '100', isNullable: false },
+          { name: 'resource_id', type: 'varchar', length: '50', isNullable: true },
+          { name: 'resource_path', type: 'varchar', length: '255', isNullable: false },
+          { name: 'request_summary', type: 'json', isNullable: true },
+          { name: 'change_summary', type: 'json', isNullable: true },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('operation_logs', [
+      new TableIndex({
+        name: 'idx_operation_logs_created_at',
+        columnNames: ['created_at'],
+      }),
+      new TableIndex({
+        name: 'idx_operation_logs_operator',
+        columnNames: ['operator'],
+      }),
+      new TableIndex({
+        name: 'idx_operation_logs_action',
+        columnNames: ['action'],
+      }),
+      new TableIndex({
+        name: 'idx_operation_logs_resource',
+        columnNames: ['resource_type', 'resource_id'],
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('operation_logs');
+  }
+}

--- a/apps/api/src/modules/operation-logs/dto/create-operation-log.dto.ts
+++ b/apps/api/src/modules/operation-logs/dto/create-operation-log.dto.ts
@@ -1,0 +1,51 @@
+import { IsArray, IsIn, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  OperationLogAction,
+} from '../entities/operation-log.entity';
+
+export class OperationLogChangeItemDto {
+  @IsString()
+  field: string;
+
+  @IsOptional()
+  @IsString()
+  fieldLabel?: string;
+
+  @IsOptional()
+  oldValue?: unknown;
+
+  @IsOptional()
+  newValue?: unknown;
+}
+
+export class CreateOperationLogDto {
+  @IsString()
+  operator: string;
+
+  @IsOptional()
+  operatorId?: number | null;
+
+  @IsIn(Object.values(OperationLogAction))
+  action: (typeof OperationLogAction)[keyof typeof OperationLogAction];
+
+  @IsString()
+  resourceType: string;
+
+  @IsOptional()
+  @IsString()
+  resourceId?: string | null;
+
+  @IsString()
+  resourcePath: string;
+
+  @IsOptional()
+  @IsObject()
+  requestSummary?: Record<string, unknown> | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OperationLogChangeItemDto)
+  changeSummary?: OperationLogChangeItemDto[] | null;
+}

--- a/apps/api/src/modules/operation-logs/dto/query-operation-log.dto.ts
+++ b/apps/api/src/modules/operation-logs/dto/query-operation-log.dto.ts
@@ -1,0 +1,31 @@
+import { Type } from 'class-transformer';
+import { IsDateString, IsIn, IsOptional, IsString } from 'class-validator';
+import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+import { OperationLogAction } from '../entities/operation-log.entity';
+
+export class QueryOperationLogDto extends BaseQueryDto {
+  @IsString()
+  @IsOptional()
+  operator?: string;
+
+  @IsIn(Object.values(OperationLogAction))
+  @IsOptional()
+  action?: (typeof OperationLogAction)[keyof typeof OperationLogAction];
+
+  @IsDateString()
+  @IsOptional()
+  dateFrom?: string;
+
+  @IsDateString()
+  @IsOptional()
+  dateTo?: string;
+
+  @IsString()
+  @IsOptional()
+  resourceType?: string;
+
+  @Type(() => String)
+  @IsString()
+  @IsOptional()
+  resourceId?: string;
+}

--- a/apps/api/src/modules/operation-logs/entities/operation-log.entity.ts
+++ b/apps/api/src/modules/operation-logs/entities/operation-log.entity.ts
@@ -1,0 +1,69 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { Expose } from 'class-transformer';
+
+export const OperationLogAction = {
+  CREATE: 'CREATE',
+  UPDATE: 'UPDATE',
+  DELETE: 'DELETE',
+} as const;
+
+export type OperationLogAction =
+  (typeof OperationLogAction)[keyof typeof OperationLogAction];
+
+export interface OperationLogChangeSummaryItem {
+  field: string;
+  fieldLabel?: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+@Entity('operation_logs')
+@Index('idx_operation_logs_created_at', ['createdAt'])
+@Index('idx_operation_logs_operator', ['operator'])
+@Index('idx_operation_logs_action', ['action'])
+@Index('idx_operation_logs_resource', ['resourceType', 'resourceId'])
+export class OperationLog {
+  @PrimaryGeneratedColumn({ type: 'bigint', unsigned: true })
+  @Expose()
+  id: number;
+
+  @Column({ name: 'operator', type: 'varchar', length: 100 })
+  @Expose()
+  operator: string;
+
+  @Column({ name: 'operator_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  operatorId: number | null;
+
+  @Column({
+    name: 'action',
+    type: 'enum',
+    enum: Object.values(OperationLogAction),
+  })
+  @Expose()
+  action: OperationLogAction;
+
+  @Column({ name: 'resource_type', type: 'varchar', length: 100 })
+  @Expose()
+  resourceType: string;
+
+  @Column({ name: 'resource_id', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  resourceId: string | null;
+
+  @Column({ name: 'resource_path', type: 'varchar', length: 255 })
+  @Expose()
+  resourcePath: string;
+
+  @Column({ name: 'request_summary', type: 'json', nullable: true })
+  @Expose()
+  requestSummary: Record<string, unknown> | null;
+
+  @Column({ name: 'change_summary', type: 'json', nullable: true })
+  @Expose()
+  changeSummary: OperationLogChangeSummaryItem[] | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  @Expose()
+  createdAt: Date;
+}

--- a/apps/api/src/modules/operation-logs/operation-logs.controller.ts
+++ b/apps/api/src/modules/operation-logs/operation-logs.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { QueryOperationLogDto } from './dto/query-operation-log.dto';
+import { OperationLogsService } from './operation-logs.service';
+
+@Controller('v1/operation-logs')
+export class OperationLogsController {
+  constructor(private readonly operationLogsService: OperationLogsService) {}
+
+  @Get()
+  findAll(@Query() query: QueryOperationLogDto) {
+    return this.operationLogsService.findAll(query);
+  }
+}

--- a/apps/api/src/modules/operation-logs/operation-logs.module.ts
+++ b/apps/api/src/modules/operation-logs/operation-logs.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { OperationLog } from './entities/operation-log.entity';
+import { OperationLogsController } from './operation-logs.controller';
+import { OperationLogsRepository } from './operation-logs.repository';
+import { OperationLogsService } from './operation-logs.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([OperationLog])],
+  controllers: [OperationLogsController],
+  providers: [OperationLogsRepository, OperationLogsService],
+  exports: [OperationLogsService],
+})
+export class OperationLogsModule {}

--- a/apps/api/src/modules/operation-logs/operation-logs.repository.ts
+++ b/apps/api/src/modules/operation-logs/operation-logs.repository.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { OperationLog } from './entities/operation-log.entity';
+import { QueryOperationLogDto } from './dto/query-operation-log.dto';
+
+@Injectable()
+export class OperationLogsRepository {
+  constructor(
+    @InjectRepository(OperationLog)
+    private readonly repo: Repository<OperationLog>,
+  ) {}
+
+  create(data: Partial<OperationLog>): Promise<OperationLog> {
+    return this.repo.save(this.repo.create(data));
+  }
+
+  async findAll(query: QueryOperationLogDto) {
+    const {
+      page = 1,
+      pageSize = 20,
+      operator,
+      action,
+      dateFrom,
+      dateTo,
+      resourceType,
+      resourceId,
+    } = query;
+
+    const qb = this.repo.createQueryBuilder('operationLog');
+
+    if (operator) {
+      qb.andWhere('operationLog.operator LIKE :operator', {
+        operator: `%${operator}%`,
+      });
+    }
+
+    if (action) {
+      qb.andWhere('operationLog.action = :action', { action });
+    }
+
+    if (dateFrom) {
+      qb.andWhere('operationLog.created_at >= :dateFrom', { dateFrom });
+    }
+
+    if (dateTo) {
+      qb.andWhere('operationLog.created_at <= :dateTo', { dateTo });
+    }
+
+    if (resourceType) {
+      qb.andWhere('operationLog.resource_type = :resourceType', { resourceType });
+    }
+
+    if (resourceId) {
+      qb.andWhere('operationLog.resource_id = :resourceId', { resourceId });
+    }
+
+    const [list, total] = await qb
+      .orderBy('operationLog.created_at', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      list,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
+  }
+}

--- a/apps/api/src/modules/operation-logs/operation-logs.service.ts
+++ b/apps/api/src/modules/operation-logs/operation-logs.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { CreateOperationLogDto } from './dto/create-operation-log.dto';
+import { QueryOperationLogDto } from './dto/query-operation-log.dto';
+import { OperationLogsRepository } from './operation-logs.repository';
+
+@Injectable()
+export class OperationLogsService {
+  constructor(private readonly operationLogsRepository: OperationLogsRepository) {}
+
+  create(dto: CreateOperationLogDto) {
+    return this.operationLogsRepository.create({
+      operator: dto.operator,
+      operatorId: dto.operatorId ?? null,
+      action: dto.action,
+      resourceType: dto.resourceType,
+      resourceId: dto.resourceId ?? null,
+      resourcePath: dto.resourcePath,
+      requestSummary: dto.requestSummary ?? null,
+      changeSummary: dto.changeSummary
+        ? dto.changeSummary.map((item) => ({
+            field: item.field,
+            fieldLabel: item.fieldLabel ?? item.field,
+            oldValue: item.oldValue ?? null,
+            newValue: item.newValue ?? null,
+          }))
+        : null,
+    });
+  }
+
+  findAll(query: QueryOperationLogDto) {
+    return this.operationLogsRepository.findAll(query);
+  }
+}

--- a/apps/web/src/api/customers.api.ts
+++ b/apps/web/src/api/customers.api.ts
@@ -19,6 +19,8 @@ export interface Customer {
   updatedBy?: string;
 }
 
+export const CUSTOMER_RESOURCE_TYPE = 'customers';
+
 export interface CustomersListParams {
   keyword?: string;
   countryId?: number;

--- a/apps/web/src/api/operation-logs.api.ts
+++ b/apps/web/src/api/operation-logs.api.ts
@@ -1,0 +1,56 @@
+import request from './request';
+
+export type OperationLogAction = 'CREATE' | 'UPDATE' | 'DELETE';
+
+export interface OperationLogChangeItem {
+  field: string;
+  fieldLabel?: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export interface OperationLogRecord {
+  id: number;
+  operator: string;
+  operatorId?: number | null;
+  action: OperationLogAction;
+  resourceType: string;
+  resourceId?: string | null;
+  resourcePath: string;
+  requestSummary?: Record<string, unknown> | null;
+  changeSummary?: OperationLogChangeItem[] | null;
+  createdAt: string;
+}
+
+export interface OperationLogsListParams {
+  operator?: string;
+  action?: OperationLogAction;
+  dateFrom?: string;
+  dateTo?: string;
+  resourceType?: string;
+  resourceId?: string | number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface OperationLogsListData {
+  list: OperationLogRecord[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === 'object' && error !== null) {
+    throw error;
+  }
+  throw { message: '请求失败，请稍后重试' };
+}
+
+export const getOperationLogs = (
+  params: OperationLogsListParams,
+): Promise<OperationLogsListData> =>
+  request
+    .get<any, OperationLogsListData>('/v1/operation-logs', { params })
+    .catch(normalizeApiError);

--- a/apps/web/src/components/ActivityTimeline.tsx
+++ b/apps/web/src/components/ActivityTimeline.tsx
@@ -1,0 +1,799 @@
+import { Skeleton } from 'antd';
+import { useMemo } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { getCompanyById } from '../api/companies.api';
+import { CONTRACT_TEMPLATE_STATUS_LABELS } from '../api/contract-templates.api';
+import { getCountryById } from '../api/countries.api';
+import { ATTRIBUTION_TYPE_LABELS, DOCUMENT_TYPE_LABELS } from '../api/product-documents.api';
+import {
+  getOperationLogs,
+  type OperationLogAction,
+  type OperationLogChangeItem,
+} from '../api/operation-logs.api';
+import { getProductCategoryById } from '../api/product-categories.api';
+import { getSkuById } from '../api/skus.api';
+import { getSpuById } from '../api/spus.api';
+import { getSupplierById } from '../api/suppliers.api';
+import { getUnitById } from '../api/units.api';
+import { getUserById } from '../api/users.api';
+import { OperationTimeline } from '../pages/master-data/components/page-scaffold';
+
+const COMMON_FIELD_LABELS: Record<string, string> = {
+  id: '编号',
+  code: '编码',
+  name: '名称',
+  nameCn: '中文名称',
+  nameEn: '英文名称',
+  username: '用户名',
+  status: '状态',
+  address: '地址',
+  contactPerson: '联系人',
+  contactPhone: '联系电话',
+  contactEmail: '联系邮箱',
+  createdAt: '创建时间',
+  updatedAt: '更新时间',
+  createdBy: '创建人',
+  updatedBy: '更新人',
+  remarks: '备注',
+  description: '描述',
+  content: '内容',
+  countryId: '国家/地区',
+  countryName: '国家/地区',
+  fileKey: '附件',
+  fileName: '附件名称',
+  fileUrl: '附件链接',
+};
+
+const DISPLAY_COMPANION_FIELDS: Record<string, string> = {
+  countryId: 'countryName',
+  salespersonId: 'salespersonName',
+  supplierId: 'supplierName',
+  defaultCompanyId: 'defaultCompanyName',
+  chiefAccountantId: 'chiefAccountantName',
+  companyId: 'companyName',
+};
+
+const RESOURCE_FIELD_LABELS: Record<string, Record<string, string>> = {
+  users: {
+    username: '用户名',
+    name: '姓名',
+    password: '登录密码',
+    status: '状态',
+  },
+  customers: {
+    customerCode: '客户编码',
+    customerName: '客户名称',
+    salespersonId: '销售员',
+    salespersonName: '销售员',
+    contactPerson: '联系人',
+    contactPhone: '联系电话',
+    contactEmail: '联系邮箱',
+    billingRequirements: '开票要求',
+    address: '地址',
+  },
+  companies: {
+    nameCn: '公司中文名',
+    nameEn: '公司英文名',
+    abbreviation: '简称',
+    signingLocation: '签约地',
+    bankName: '开户行',
+    bankAccount: '银行账号',
+    swiftCode: 'SWIFT',
+    defaultCurrencyCode: '默认币种编码',
+    defaultCurrencyName: '默认币种',
+    taxId: '税号',
+    customsCode: '海关编码',
+    quarantineCode: '检疫编码',
+    addressCn: '中文地址',
+    addressEn: '英文地址',
+    contactPerson: '联系人',
+    contactPhone: '联系电话',
+    chiefAccountantId: '负责人',
+    chiefAccountantName: '负责人',
+  },
+  warehouses: {
+    name: '仓库名称',
+    warehouseCode: '仓库编码',
+    warehouseType: '仓库类型',
+    supplierId: '供应商',
+    supplierName: '供应商',
+    address: '地址',
+    defaultShipProvince: '默认发货省份',
+    defaultShipCity: '默认发货城市',
+    ownership: '权属',
+    isVirtual: '虚拟仓',
+    status: '状态',
+  },
+  suppliers: {
+    name: '供应商名称',
+    shortName: '简称',
+    supplierCode: '供应商编码',
+    contactPerson: '联系人',
+    contactPhone: '联系电话',
+    contactEmail: '联系邮箱',
+    address: '地址',
+    status: '状态',
+    supplierLevel: '供应商等级',
+    invoiceType: '发票类型',
+    origin: '来源',
+    annualRebateEnabled: '年返启用',
+    contractFrameworkFile: '框架合同文件',
+    contractTemplateName: '合同模板',
+    annualRebateNote: '年返说明',
+    contractTerms: '合同条款',
+    paymentTerms: '结算条款',
+  },
+  spus: {
+    spuCode: 'SPU 编码',
+    name: 'SPU 名称',
+    categoryId: '分类',
+    categoryLevel1Id: '一级分类',
+    categoryLevel2Id: '二级分类',
+    categoryLevel3Code: '三级分类编码',
+    unit: '单位',
+    manufacturerModel: '厂家型号',
+    customerWarrantyMonths: '客户质保(月)',
+    purchaseWarrantyMonths: '采购质保(月)',
+    supplierWarrantyNote: '供应商保修说明',
+    forbiddenCountries: '禁售国家',
+    invoiceName: '开票品名',
+    invoiceUnit: '开票单位',
+    invoiceModel: '开票型号',
+    supplierName: '供应商',
+    companyId: '合作主体',
+  },
+  skus: {
+    skuCode: 'SKU 编码',
+    spuId: 'SPU',
+    unitId: '单位',
+    nameCn: '中文名称',
+    nameEn: '英文名称',
+    specification: '规格',
+    status: '状态',
+    productType: '产品类型',
+    productModel: '产品型号',
+    accessoryParentSkuId: '配件母 SKU',
+    categoryLevel1Id: '一级分类',
+    categoryLevel2Id: '二级分类',
+    categoryLevel3Id: '三级分类',
+    principle: '原理',
+    productUsage: '产品用途',
+    coreParams: '核心参数',
+    electricalParams: '电气参数',
+    material: '材质',
+    hasPlug: '是否带插头',
+    specialAttributes: '特殊属性',
+    specialAttributesNote: '特殊属性说明',
+    customerWarrantyMonths: '客户质保(月)',
+    forbiddenCountries: '禁售国家',
+    weightKg: '净重(kg)',
+    grossWeightKg: '毛重(kg)',
+    lengthCm: '长(cm)',
+    widthCm: '宽(cm)',
+    heightCm: '高(cm)',
+    volumeCbm: '体积(cbm)',
+    packagingType: '包装类型',
+    packagingQty: '装箱数量',
+    packagingInfo: '包装信息',
+    packagingList: '包装清单',
+    hsCode: 'HS 编码',
+    customsNameCn: '报关中文名',
+    customsNameEn: '报关英文名',
+    declaredValueRef: '申报价参考',
+    declarationElements: '申报要素',
+    isInspectionRequired: '是否商检',
+    regulatoryConditions: '监管条件',
+    taxRefundRate: '退税率',
+    customsInfoMaintained: '报关信息已维护',
+    productImageUrl: '产品图片',
+    productImageUrls: '产品图片',
+  },
+  certificates: {
+    certificateNo: '证书编号',
+    certificateName: '证书名称',
+    certificateType: '证书类型',
+    directive: '指令法规',
+    issueDate: '签发日期',
+    validFrom: '生效日期',
+    validUntil: '失效日期',
+    issuingAuthority: '发证机构',
+    remarks: '备注',
+    attributionType: '归属类型',
+    categoryId: '分类',
+    spuIds: '关联 SPU',
+  },
+  'product-documents': {
+    documentName: '资料名称',
+    documentType: '资料类型',
+    content: '内容',
+    attributionType: '归属类型',
+    countryId: '国家/地区',
+    categoryLevel1Id: '一级分类',
+    categoryLevel2Id: '二级分类',
+    categoryLevel3Id: '三级分类',
+    spuId: 'SPU',
+  },
+  units: {
+    code: '单位编码',
+    name: '单位名称',
+    status: '状态',
+  },
+  'contract-templates': {
+    name: '模板名称',
+    templateFileKey: '模板文件',
+    templateFileName: '模板文件名',
+    description: '描述',
+    content: '条款内容',
+    isDefault: '默认模板',
+    requiresLegalReview: '需要法务审核',
+    status: '状态',
+    usageCount: '使用次数',
+  },
+  countries: {
+    code: '国家/地区代码',
+    name: '中文名称',
+    nameEn: '英文名称',
+    abbreviation: '简称',
+  },
+  currencies: {
+    code: '币种代码',
+    name: '币种名称',
+    symbol: '币种符号',
+    isBaseCurrency: '本位币',
+    status: '状态',
+  },
+  'logistics-providers': {
+    name: '物流商名称',
+    providerCode: '物流商编码',
+    shortName: '简称',
+    contactPerson: '联系人',
+    contactPhone: '联系电话',
+    contactEmail: '联系邮箱',
+    address: '地址',
+    status: '状态',
+    providerLevel: '服务等级',
+    defaultCompanyId: '默认合作主体',
+    defaultCompanyName: '默认合作主体',
+  },
+  ports: {
+    portType: '港口类型',
+    portCode: '港口编码',
+    nameCn: '中文名称',
+    nameEn: '英文名称',
+  },
+};
+
+const BOOLEAN_FIELDS = new Set([
+  'isDefault',
+  'requiresLegalReview',
+  'isBaseCurrency',
+  'isVirtual',
+  'annualRebateEnabled',
+  'hasPlug',
+  'isInspectionRequired',
+  'customsInfoMaintained',
+]);
+
+const ENUM_VALUE_LABELS: Record<string, Record<string, string>> = {
+  status: {
+    active: '启用',
+    inactive: '停用',
+    valid: '有效',
+    expired: '已过期',
+    cooperating: '合作',
+    eliminated: '淘汰',
+    pending_submit: '待提交',
+    in_review: '审核中',
+    approved: '审核通过',
+    rejected: '已拒绝',
+    voided: '已作废',
+    enabled: '启用',
+    disabled: '停用',
+    ACTIVE: '启用',
+    INACTIVE: '停用',
+  },
+  documentType: DOCUMENT_TYPE_LABELS,
+  attributionType: {
+    ...ATTRIBUTION_TYPE_LABELS,
+    通用归属: '通用归属',
+    产品SPU归属: '产品 SPU 归属',
+    产品分类归属: '产品分类归属',
+  },
+  portType: {
+    起运港: '起运港',
+    目的港: '目的港',
+  },
+  action: {
+    CREATE: '新增',
+    UPDATE: '更新',
+    DELETE: '删除',
+  },
+  questionType: {
+    recommended_selection: '推荐选型',
+    information_providing: '资料提供',
+    general_knowledge: '通识类',
+    product_advantages: '产品优势',
+    functional_parameters: '功能参数',
+    solution: '解决方案',
+    configuration_info: '配置信息',
+    product_customization: '产品定制',
+    no_matching_product: '无匹配产品',
+    new_development_selection: '新拓选型',
+    operation_maintenance: '操作维护',
+    other: '其它类型',
+  },
+  productType: {
+    主品: '主品',
+    配件: '配件',
+    耗材: '耗材',
+  },
+  warehouseType: {
+    成品仓: '成品仓',
+    原料仓: '原料仓',
+    中转仓: '中转仓',
+    退货仓: '退货仓',
+  },
+  ownership: {
+    INTERNAL: '自有',
+    EXTERNAL: '外协',
+    INTERNAL_LEASED: '自有租赁',
+    EXTERNAL_LEASED: '外部租赁',
+    自有: '自有',
+    外协: '外协',
+  },
+  certificateType: {
+    CE: 'CE',
+    FDA: 'FDA',
+    'IEC第三方检测报告': 'IEC 第三方检测报告',
+    DOC: 'DOC',
+    IS09001: 'ISO9001',
+    ISO14001: 'ISO14001',
+    ISO45001: 'ISO45001',
+    ISO13485: 'ISO13485',
+    其它: '其它',
+  },
+};
+
+const RESOURCE_ENUM_VALUE_LABELS: Record<string, Record<string, Record<string, string>>> = {
+  currencies: {
+    status: {
+      enabled: '启用',
+      disabled: '停用',
+    },
+  },
+  units: {
+    status: {
+      enabled: '启用',
+      disabled: '停用',
+    },
+  },
+  warehouses: {
+    status: {
+      active: '启用',
+      inactive: '停用',
+    },
+  },
+  certificates: {
+    status: {
+      valid: '有效',
+      expired: '已过期',
+    },
+    attributionType: {
+      通用归属: '通用归属',
+      产品SPU归属: '产品 SPU 归属',
+      产品分类归属: '产品分类归属',
+    },
+  },
+  'product-documents': {
+    attributionType: ATTRIBUTION_TYPE_LABELS,
+    documentType: DOCUMENT_TYPE_LABELS,
+  },
+  'contract-templates': {
+    status: CONTRACT_TEMPLATE_STATUS_LABELS,
+  },
+  'logistics-providers': {
+    status: {
+      合作: '合作',
+      淘汰: '淘汰',
+    },
+  },
+};
+
+type LookupRequest = {
+  cacheKey: string;
+  queryKey: Array<string | number>;
+  queryFn: () => Promise<string | null>;
+};
+
+type FieldLookupResolver = {
+  resolveId: (value: unknown) => string | null;
+  buildRequest: (id: string) => LookupRequest;
+};
+
+function normalizeLookupId(value: unknown): string | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized ? normalized : null;
+  }
+
+  return null;
+}
+
+async function safeLoadLabel(loader: () => Promise<string | null>) {
+  try {
+    return await loader();
+  } catch {
+    return null;
+  }
+}
+
+const FIELD_LOOKUP_RESOLVERS: Record<string, FieldLookupResolver> = {
+  countryId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `country:${id}`,
+      queryKey: ['audit-lookup', 'country', id],
+      queryFn: () => safeLoadLabel(async () => (await getCountryById(Number(id))).name),
+    }),
+  },
+  salespersonId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `user:${id}`,
+      queryKey: ['audit-lookup', 'user', id],
+      queryFn: () =>
+        safeLoadLabel(async () => {
+          const user = await getUserById(id);
+          return user.name || user.username || null;
+        }),
+    }),
+  },
+  chiefAccountantId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `user:${id}`,
+      queryKey: ['audit-lookup', 'user', id],
+      queryFn: () =>
+        safeLoadLabel(async () => {
+          const user = await getUserById(id);
+          return user.name || user.username || null;
+        }),
+    }),
+  },
+  unitId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `unit:${id}`,
+      queryKey: ['audit-lookup', 'unit', id],
+      queryFn: () => safeLoadLabel(async () => (await getUnitById(Number(id))).name),
+    }),
+  },
+  spuId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `spu:${id}`,
+      queryKey: ['audit-lookup', 'spu', id],
+      queryFn: () =>
+        safeLoadLabel(async () => {
+          const spu = await getSpuById(Number(id));
+          return spu.name ? `${spu.spuCode} / ${spu.name}` : spu.spuCode;
+        }),
+    }),
+  },
+  accessoryParentSkuId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `sku:${id}`,
+      queryKey: ['audit-lookup', 'sku', id],
+      queryFn: () =>
+        safeLoadLabel(async () => {
+          const sku = await getSkuById(Number(id));
+          return sku.nameCn ? `${sku.skuCode} / ${sku.nameCn}` : sku.skuCode;
+        }),
+    }),
+  },
+  supplierId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `supplier:${id}`,
+      queryKey: ['audit-lookup', 'supplier', id],
+      queryFn: () => safeLoadLabel(async () => (await getSupplierById(Number(id))).name),
+    }),
+  },
+  companyId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `company:${id}`,
+      queryKey: ['audit-lookup', 'company', id],
+      queryFn: () => safeLoadLabel(async () => (await getCompanyById(Number(id))).nameCn),
+    }),
+  },
+  defaultCompanyId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `company:${id}`,
+      queryKey: ['audit-lookup', 'company', id],
+      queryFn: () => safeLoadLabel(async () => (await getCompanyById(Number(id))).nameCn),
+    }),
+  },
+  categoryId: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `category:${id}`,
+      queryKey: ['audit-lookup', 'category', id],
+      queryFn: () => safeLoadLabel(async () => (await getProductCategoryById(Number(id))).name),
+    }),
+  },
+  categoryLevel1Id: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `category:${id}`,
+      queryKey: ['audit-lookup', 'category', id],
+      queryFn: () => safeLoadLabel(async () => (await getProductCategoryById(Number(id))).name),
+    }),
+  },
+  categoryLevel2Id: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `category:${id}`,
+      queryKey: ['audit-lookup', 'category', id],
+      queryFn: () => safeLoadLabel(async () => (await getProductCategoryById(Number(id))).name),
+    }),
+  },
+  categoryLevel3Id: {
+    resolveId: normalizeLookupId,
+    buildRequest: (id) => ({
+      cacheKey: `category:${id}`,
+      queryKey: ['audit-lookup', 'category', id],
+      queryFn: () => safeLoadLabel(async () => (await getProductCategoryById(Number(id))).name),
+    }),
+  },
+};
+
+function resolveFieldLabel(resourceType: string, change: OperationLogChangeItem) {
+  return (
+    RESOURCE_FIELD_LABELS[resourceType]?.[change.field] ??
+    COMMON_FIELD_LABELS[change.field] ??
+    change.fieldLabel ??
+    change.field
+  );
+}
+
+function formatActionText(
+  action: OperationLogAction,
+  resourceType: string,
+  changes: OperationLogChangeItem[],
+) {
+  const fieldText = changes.length
+    ? `涉及 ${changes.slice(0, 3).map((item) => resolveFieldLabel(resourceType, item)).join('、')}${changes.length > 3 ? ' 等字段' : ''}`
+    : '无字段差异';
+
+  if (action === 'CREATE') {
+    return `创建记录，${fieldText}`;
+  }
+
+  if (action === 'DELETE') {
+    return `删除记录，删除前${fieldText}`;
+  }
+
+  return `更新记录，${fieldText}`;
+}
+
+function formatChangeValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') {
+    return '—';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? '是' : '否';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    if (!value.length) {
+      return '—';
+    }
+    return value.map((item) => formatChangeValue(item)).join('，');
+  }
+
+  return JSON.stringify(value);
+}
+
+function formatFieldValue(field: string, value: unknown): string {
+  if (BOOLEAN_FIELDS.has(field) && (value === 0 || value === 1 || typeof value === 'boolean')) {
+    return value === 1 || value === true ? '是' : '否';
+  }
+
+  return formatChangeValue(value);
+}
+
+function formatEnumValue(
+  resourceType: string,
+  field: string,
+  value: unknown,
+): string | null {
+  const normalizedValue = normalizeLookupId(value);
+  if (!normalizedValue) {
+    return null;
+  }
+
+  const resourceLabels = RESOURCE_ENUM_VALUE_LABELS[resourceType]?.[field];
+  if (resourceLabels?.[normalizedValue]) {
+    return resourceLabels[normalizedValue];
+  }
+
+  const commonLabels = ENUM_VALUE_LABELS[field];
+  if (commonLabels?.[normalizedValue]) {
+    return commonLabels[normalizedValue];
+  }
+
+  return null;
+}
+
+function resolveLookupValue(
+  field: string,
+  value: unknown,
+  lookupValueMap: Map<string, string | null>,
+) {
+  const resolver = FIELD_LOOKUP_RESOLVERS[field];
+  if (!resolver) {
+    return null;
+  }
+
+  const id = resolver.resolveId(value);
+  if (!id) {
+    return null;
+  }
+
+  return lookupValueMap.get(resolver.buildRequest(id).cacheKey) ?? null;
+}
+
+function normalizeChanges(
+  resourceType: string,
+  changes: OperationLogChangeItem[],
+  lookupValueMap: Map<string, string | null>,
+) {
+  const changeMap = new Map(changes.map((change) => [change.field, change]));
+  const consumedFields = new Set<string>();
+
+  return changes.flatMap((change, index) => {
+    if (consumedFields.has(change.field)) {
+      return [];
+    }
+
+    const companionField = DISPLAY_COMPANION_FIELDS[change.field];
+    const companionChange = companionField ? changeMap.get(companionField) : undefined;
+
+    if (companionChange) {
+      consumedFields.add(change.field);
+      consumedFields.add(companionField);
+
+      return [
+        {
+          key: `${change.field}-${index}`,
+          fieldLabel: resolveFieldLabel(resourceType, change),
+          oldValue:
+            formatFieldValue(companionField, companionChange.oldValue),
+          newValue:
+            formatFieldValue(companionField, companionChange.newValue),
+        },
+      ];
+    }
+
+    consumedFields.add(change.field);
+
+    return [
+      {
+        key: `${change.field}-${index}`,
+        fieldLabel: resolveFieldLabel(resourceType, change),
+        oldValue:
+          formatEnumValue(resourceType, change.field, change.oldValue) ??
+          resolveLookupValue(change.field, change.oldValue, lookupValueMap) ??
+          formatFieldValue(change.field, change.oldValue),
+        newValue:
+          formatEnumValue(resourceType, change.field, change.newValue) ??
+          resolveLookupValue(change.field, change.newValue, lookupValueMap) ??
+          formatFieldValue(change.field, change.newValue),
+      },
+    ];
+  });
+}
+
+export function ActivityTimeline({
+  resourceType,
+  resourceId,
+}: {
+  resourceType: string;
+  resourceId: string | number;
+}) {
+  const query = useQuery({
+    queryKey: ['operation-logs', resourceType, resourceId],
+    queryFn: () =>
+      getOperationLogs({
+        resourceType,
+        resourceId,
+        page: 1,
+        pageSize: 50,
+      }),
+    enabled: Boolean(resourceType) && Boolean(resourceId),
+  });
+
+  const lookupRequests = useMemo(() => {
+    const requests = new Map<string, LookupRequest>();
+
+    for (const record of query.data?.list ?? []) {
+      for (const change of record.changeSummary ?? []) {
+        const resolver = FIELD_LOOKUP_RESOLVERS[change.field];
+        if (!resolver) {
+          continue;
+        }
+
+        for (const candidate of [change.oldValue, change.newValue]) {
+          const id = resolver.resolveId(candidate);
+          if (!id) {
+            continue;
+          }
+
+          const request = resolver.buildRequest(id);
+          requests.set(request.cacheKey, request);
+        }
+      }
+    }
+
+    return Array.from(requests.values());
+  }, [query.data]);
+
+  const lookupResults = useQueries({
+    queries: lookupRequests.map((request) => ({
+      queryKey: request.queryKey,
+      queryFn: request.queryFn,
+      staleTime: 5 * 60 * 1000,
+      enabled: Boolean(query.data?.list?.length),
+    })),
+  });
+
+  const lookupValueMap = useMemo(() => {
+    const map = new Map<string, string | null>();
+
+    lookupRequests.forEach((request, index) => {
+      map.set(request.cacheKey, lookupResults[index]?.data ?? null);
+    });
+
+    return map;
+  }, [lookupRequests, lookupResults]);
+
+  const records = (query.data?.list ?? []).map((record) => ({
+    key: String(record.id),
+    operator: record.operator || 'system',
+    actionType: record.action,
+    action: formatActionText(record.action, resourceType, record.changeSummary ?? []),
+    time: record.createdAt,
+    changes: normalizeChanges(resourceType, record.changeSummary ?? [], lookupValueMap).map((change) => ({
+      key: `${record.id}-${change.key}`,
+      fieldLabel: change.fieldLabel,
+      oldValue: change.oldValue,
+      newValue: change.newValue,
+    })),
+  }));
+
+  if (query.isLoading && !query.data) {
+    return <Skeleton active paragraph={{ rows: 3 }} />;
+  }
+
+  return <OperationTimeline records={records} />;
+}

--- a/apps/web/src/pages/home/index.tsx
+++ b/apps/web/src/pages/home/index.tsx
@@ -42,6 +42,18 @@ const GREETINGS: Record<TimeSlot, string> = {
 
 type StatColor = 'blue' | 'green' | 'orange' | 'gray' | 'red';
 
+function formatTooltipValue(value: number | string | undefined, unit: string): [string, string] {
+  const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
+  return [`${numericValue} ${unit}`, ''];
+}
+
+function normalizeChartValue(value: number | string | ReadonlyArray<number | string> | undefined) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
 function StatCard({ label, value, unit = '', icon, color }: {
   label: string; value: number; unit?: string;
   icon: React.ReactNode; color: StatColor;
@@ -100,10 +112,10 @@ export default function DashboardPage() {
           <ResponsiveContainer width="100%" height={220}>
             <PieChart>
               <Pie data={skuStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80}
-                label={({ name: n, percent }) => `${n} ${(percent * 100).toFixed(0)}%`} labelLine={false}>
+                label={({ name: n, percent }) => `${n} ${(((percent ?? 0) * 100)).toFixed(0)}%`} labelLine={false}>
                 {skuStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
               </Pie>
-              <Tooltip formatter={(v: number) => [`${v} 个`, '']} />
+              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '个')} />
             </PieChart>
           </ResponsiveContainer>
         </ChartCard>
@@ -143,7 +155,7 @@ export default function DashboardPage() {
               <Pie data={supplierStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={45} outerRadius={72}>
                 {supplierStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
               </Pie>
-              <Tooltip formatter={(v: number) => [`${v} 家`, '']} />
+              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '家')} />
               <Legend wrapperStyle={{ fontSize: 12 }} />
             </PieChart>
           </ResponsiveContainer>
@@ -155,7 +167,7 @@ export default function DashboardPage() {
               <Pie data={certificateStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={45} outerRadius={72}>
                 {certificateStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
               </Pie>
-              <Tooltip formatter={(v: number) => [`${v} 张`, '']} />
+              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '张')} />
               <Legend wrapperStyle={{ fontSize: 12 }} />
             </PieChart>
           </ResponsiveContainer>

--- a/apps/web/src/pages/master-data/certificates/detail.tsx
+++ b/apps/web/src/pages/master-data/certificates/detail.tsx
@@ -4,13 +4,13 @@ import type { ColumnsType } from 'antd/es/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { deleteCertificate, getCertificateById, type CertificateSpu } from '../../../api/certificates.api';
 import { getProductCategoryTree } from '../../../api/product-categories.api';
 import { findCategoryName } from '../../../utils/category';
 import {
   AnchorNav,
   MetaItem,
-  OperationTimeline,
   SectionCard,
   SummaryMetaItem,
   displayOrDash,
@@ -87,29 +87,6 @@ export default function CertificateDetailPage() {
   const validRange = data ? `${displayOrDash(data.validFrom)} ~ ${displayOrDash(data.validUntil)}` : '—';
   const statusClass = data?.status === 'valid' ? 'master-pill-success' : 'master-pill-red';
   const statusText = data?.status === 'valid' ? '有效' : '已过期';
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [
-          {
-            key: 'updated',
-            operator: displayOrDash(data.updatedBy),
-            action: '更新记录',
-            time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-    ...(data?.createdAt
-      ? [
-          {
-            key: 'created',
-            operator: displayOrDash(data.createdBy),
-            action: '创建记录',
-            time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-  ];
-
   const anchors = [
     { key: 'basic', label: '证书信息' },
     { key: 'spus', label: '关联 SPU' },
@@ -260,11 +237,7 @@ export default function CertificateDetailPage() {
             title="操作记录"
             description="按时间展示证书资料的创建与更新轨迹。"
           >
-            {query.isLoading && !data ? (
-              <Skeleton active paragraph={{ rows: 3 }} />
-            ) : (
-              <OperationTimeline records={operationRecords} />
-            )}
+            <ActivityTimeline resourceType="certificates" resourceId={certId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/companies/detail.tsx
+++ b/apps/web/src/pages/master-data/companies/detail.tsx
@@ -3,8 +3,9 @@ import { Button, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getCompanyById } from '../../../api/companies.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 export default function CompanyDetailPage() {
@@ -44,14 +45,6 @@ export default function CompanyDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'address', label: '地址信息' },
@@ -171,7 +164,7 @@ export default function CompanyDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看公司主体档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="companies" resourceId={companyId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/components/page-scaffold.tsx
+++ b/apps/web/src/pages/master-data/components/page-scaffold.tsx
@@ -1,4 +1,17 @@
 import type { ReactNode } from 'react';
+import { Tooltip, Tag } from 'antd';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/zh-cn';
+
+dayjs.extend(relativeTime);
+dayjs.locale('zh-cn');
+
+const ACTION_TYPE_LABELS = {
+  CREATE: '新增',
+  UPDATE: '更新',
+  DELETE: '删除',
+} as const;
 
 function joinClassNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(' ');
@@ -101,7 +114,19 @@ export function OperationTimeline({
   records,
   emptyClassName,
 }: {
-  records: Array<{ key: string; operator: string; action: string; time: string }>;
+  records: Array<{
+    key: string;
+    operator: string;
+    action: string;
+    time: string;
+    actionType?: 'CREATE' | 'UPDATE' | 'DELETE';
+    changes?: Array<{
+      key: string;
+      fieldLabel: string;
+      oldValue: string;
+      newValue: string;
+    }>;
+  }>;
   emptyClassName?: string;
 }) {
   if (!records.length) {
@@ -114,9 +139,30 @@ export function OperationTimeline({
         <div className="master-tl-item" key={record.key}>
           <div className={`master-tl-dot${index === records.length - 1 ? ' gray' : ''}`} />
           <div className="master-tl-content">
-            <div className="master-tl-operator">操作人：{record.operator}</div>
+            <div className="master-tl-head">
+              <div className="master-tl-operator">操作人：{record.operator}</div>
+              {record.actionType ? (
+                <Tag className={`master-tl-tag master-tl-tag-${record.actionType.toLowerCase()}`}>
+                  {ACTION_TYPE_LABELS[record.actionType]}
+                </Tag>
+              ) : null}
+            </div>
             <div className="master-tl-action">操作记录：{record.action}</div>
-            <div className="master-tl-time">操作时间：{record.time}</div>
+            {record.changes?.length ? (
+              <div className="master-tl-changes">
+                {record.changes.map((change) => (
+                  <div className="master-tl-change-chip" key={change.key}>
+                    <span className="master-tl-change-field">{change.fieldLabel}</span>
+                    <span className="master-tl-change-old">{change.oldValue}</span>
+                    <span className="master-tl-change-arrow">→</span>
+                    <span className="master-tl-change-new">{change.newValue}</span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+            <Tooltip title={dayjs(record.time).fromNow()}>
+              <div className="master-tl-time">操作时间：{dayjs(record.time).format('YYYY-MM-DD HH:mm:ss')}</div>
+            </Tooltip>
           </div>
         </div>
       ))}

--- a/apps/web/src/pages/master-data/contract-templates/detail.tsx
+++ b/apps/web/src/pages/master-data/contract-templates/detail.tsx
@@ -3,6 +3,7 @@ import { Button, Popconfirm, Result, Skeleton, message } from 'antd';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import {
   approveContractTemplate,
   CONTRACT_TEMPLATE_STATUS_LABELS,
@@ -12,7 +13,7 @@ import {
   voidContractTemplate,
   type ContractTemplate,
 } from '../../../api/contract-templates.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 function statusPillClass(status: ContractTemplate['status']) {
@@ -106,14 +107,6 @@ export default function ContractTemplateDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
 
   const actionLoading =
     submitMutation.isPending ||
@@ -235,7 +228,7 @@ export default function ContractTemplateDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看条款模板维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="contract-templates" resourceId={templateId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/countries/detail.tsx
+++ b/apps/web/src/pages/master-data/countries/detail.tsx
@@ -3,8 +3,9 @@ import { Button, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getCountryById } from '../../../api/countries.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 export default function CountryDetailPage() {
@@ -44,14 +45,6 @@ export default function CountryDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'audit', label: '审计信息' },
@@ -117,7 +110,7 @@ export default function CountryDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看国家地区档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="countries" resourceId={countryId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/currencies/detail.tsx
+++ b/apps/web/src/pages/master-data/currencies/detail.tsx
@@ -4,8 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { CurrencyStatus } from '@infitek/shared';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getCurrencyById } from '../../../api/currencies.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 const statusText: Record<CurrencyStatus, string> = {
@@ -55,14 +56,6 @@ export default function CurrencyDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'audit', label: '审计信息' },
@@ -129,7 +122,7 @@ export default function CurrencyDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看币种档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="currencies" resourceId={currencyId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/customers/detail.tsx
+++ b/apps/web/src/pages/master-data/customers/detail.tsx
@@ -3,7 +3,9 @@ import { Button, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
-import { getCustomerById } from '../../../api/customers.api';
+import { CUSTOMER_RESOURCE_TYPE, getCustomerById } from '../../../api/customers.api';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
+import { AnchorNav } from '../components/page-scaffold';
 import '../master-page.css';
 
 function displayOrDash(value?: string | number | null): string {
@@ -25,6 +27,13 @@ export default function CustomerDetailPage() {
   const { id = '' } = useParams();
   const customerId = Number(id);
   const [activeAnchor, setActiveAnchor] = useState('basic');
+  const anchors = [
+    { key: 'basic', label: '基础信息' },
+    { key: 'contact', label: '联系信息' },
+    { key: 'billing', label: '开票需求' },
+    { key: 'audit', label: '审计信息' },
+    { key: 'operation', label: '操作记录' },
+  ];
 
   const query = useQuery({
     queryKey: ['customer-detail', customerId],
@@ -57,37 +66,6 @@ export default function CustomerDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [
-          {
-            key: 'updated',
-            operator: displayOrDash(data.updatedBy),
-            action: '更新记录',
-            time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-    ...(data?.createdAt
-      ? [
-          {
-            key: 'created',
-            operator: displayOrDash(data.createdBy),
-            action: '创建记录',
-            time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-  ];
-
-  const anchors = [
-    { key: 'basic', label: '基础信息' },
-    { key: 'contact', label: '联系信息' },
-    { key: 'billing', label: '开票需求' },
-    { key: 'audit', label: '审计信息' },
-    { key: 'operation', label: '操作记录' },
-  ];
-
   return (
     <div className="master-page">
       <div className="master-summary-card">
@@ -130,18 +108,7 @@ export default function CustomerDetailPage() {
       </div>
 
       <div className="master-detail-layout">
-        <div className="master-anchor-nav">
-          {anchors.map((anchor) => (
-            <a
-              key={anchor.key}
-              href={`#${anchor.key}`}
-              className={`master-anchor-link${activeAnchor === anchor.key ? ' active' : ''}`}
-              onClick={() => setActiveAnchor(anchor.key)}
-            >
-              {anchor.label}
-            </a>
-          ))}
-        </div>
+        <AnchorNav anchors={anchors} activeKey={activeAnchor} onChange={setActiveAnchor} />
 
         <div className="master-detail-main">
           <section id="basic" className="master-section-card">
@@ -239,24 +206,7 @@ export default function CustomerDetailPage() {
               </div>
             </div>
             <div className="master-section-body">
-              {query.isLoading && !data ? (
-                <Skeleton active paragraph={{ rows: 3 }} />
-              ) : operationRecords.length ? (
-                <div className="master-status-timeline">
-                  {operationRecords.map((record, index) => (
-                    <div className="master-tl-item" key={record.key}>
-                      <div className={`master-tl-dot${index === operationRecords.length - 1 ? ' gray' : ''}`} />
-                      <div className="master-tl-content">
-                        <div className="master-tl-operator">操作人：{record.operator}</div>
-                        <div className="master-tl-action">操作记录：{record.action}</div>
-                        <div className="master-tl-time">操作时间：{record.time}</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="master-meta-value empty">—</div>
-              )}
+              <ActivityTimeline resourceType={CUSTOMER_RESOURCE_TYPE} resourceId={customerId} />
             </div>
           </section>
         </div>

--- a/apps/web/src/pages/master-data/logistics-providers/detail.tsx
+++ b/apps/web/src/pages/master-data/logistics-providers/detail.tsx
@@ -3,8 +3,9 @@ import { Button, Rate, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getLogisticsProviderById } from '../../../api/logistics-providers.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 function getStatusPill(status?: string) {
@@ -50,14 +51,6 @@ export default function LogisticsProviderDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'contact', label: '联系信息' },
@@ -140,7 +133,7 @@ export default function LogisticsProviderDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看物流供应商档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="logistics-providers" resourceId={providerId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/master-page.css
+++ b/apps/web/src/pages/master-data/master-page.css
@@ -525,11 +525,43 @@
   min-width: 0;
 }
 
+.master-tl-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 .master-tl-operator {
   font-size: 13px;
   color: var(--erp-text);
   line-height: 1.5;
   font-weight: 700;
+}
+
+.master-tl-tag {
+  margin-inline-end: 0;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.master-tl-tag-create {
+  color: #166534;
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.master-tl-tag-update {
+  color: #1d4ed8;
+  border-color: #bfdbfe;
+  background: #eff6ff;
+}
+
+.master-tl-tag-delete {
+  color: #b91c1c;
+  border-color: #fecaca;
+  background: #fef2f2;
 }
 
 .master-tl-action {
@@ -540,10 +572,62 @@
   margin-top: 2px;
 }
 
+.master-tl-changes {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.master-tl-change-field {
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 700;
+  color: var(--erp-text);
+}
+
+.master-tl-change-chip {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  border: 1px solid var(--erp-border);
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #f8fafc;
+  font-size: 12px;
+  line-height: 1.5;
+  max-width: 100%;
+}
+
+.master-tl-change-old,
+.master-tl-change-new {
+  border-radius: 8px;
+  padding: 1px 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.master-tl-change-old {
+  color: #9f1239;
+  background: #fff1f2;
+}
+
+.master-tl-change-new {
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.master-tl-change-arrow {
+  color: var(--erp-text-light);
+  font-weight: 700;
+}
+
 .master-tl-time {
   font-size: 11px;
   color: var(--erp-text-light);
-  margin-top: 3px;
+  margin-top: 6px;
   font-weight: 600;
 }
 

--- a/apps/web/src/pages/master-data/ports/detail.tsx
+++ b/apps/web/src/pages/master-data/ports/detail.tsx
@@ -3,8 +3,9 @@ import { Button, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getPortById } from '../../../api/ports.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 export default function PortDetailPage() {
@@ -44,14 +45,6 @@ export default function PortDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'audit', label: '审计信息' },
@@ -118,7 +111,7 @@ export default function PortDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看港口档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="ports" resourceId={portId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/product-documents/detail.tsx
+++ b/apps/web/src/pages/master-data/product-documents/detail.tsx
@@ -3,6 +3,7 @@ import { Button, Modal, Result, Skeleton, message } from 'antd';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import {
   deleteProductDocument,
   getProductDocumentById,
@@ -16,7 +17,6 @@ import { findCategoryName } from '../../../utils/category';
 import {
   AnchorNav,
   MetaItem,
-  OperationTimeline,
   SectionCard,
   SummaryMetaItem,
   displayOrDash,
@@ -129,15 +129,6 @@ export default function ProductDocumentDetailPage() {
     return '—';
   };
 
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
-
   const anchors = [
     { key: 'basic', label: '资料信息' },
     { key: 'file', label: '附件与审计' },
@@ -249,11 +240,7 @@ export default function ProductDocumentDetailPage() {
             title="操作记录"
             description="按时间展示资料条目的创建与更新轨迹。"
           >
-            {query.isLoading && !data ? (
-              <Skeleton active paragraph={{ rows: 3 }} />
-            ) : (
-              <OperationTimeline records={operationRecords} />
-            )}
+            <ActivityTimeline resourceType="product-documents" resourceId={docId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/skus/detail.tsx
+++ b/apps/web/src/pages/master-data/skus/detail.tsx
@@ -4,6 +4,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { deleteSku, getSkuById, type PackagingRow, type Sku } from '../../../api/skus.api';
 import { getSpuById } from '../../../api/spus.api';
 import { getProductCategoryTree, type ProductCategoryNode } from '../../../api/product-categories.api';
@@ -11,7 +12,6 @@ import { getCertificates, type Certificate } from '../../../api/certificates.api
 import {
   AnchorNav,
   MetaItem,
-  OperationTimeline,
   SectionCard,
   SummaryMetaItem,
   displayOrDash,
@@ -167,29 +167,6 @@ export default function SkuDetailPage() {
         cert.attributionType === '通用归属',
     );
   }, [sku, certificatesQuery.data]);
-
-  const operationRecords = [
-    ...(sku?.updatedAt
-      ? [
-          {
-            key: 'updated',
-            operator: displayOrDash(sku.updatedBy),
-            action: '更新记录',
-            time: dayjs(sku.updatedAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-    ...(sku?.createdAt
-      ? [
-          {
-            key: 'created',
-            operator: displayOrDash(sku.createdBy),
-            action: '创建记录',
-            time: dayjs(sku.createdAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-  ];
 
   const anchors = [
     { key: 'basic', label: '基本信息' },
@@ -442,11 +419,7 @@ export default function SkuDetailPage() {
             title="操作记录"
             description="按时间展示 SKU 主数据的创建与维护轨迹。"
           >
-            {query.isLoading && !sku ? (
-              <Skeleton active paragraph={{ rows: 3 }} />
-            ) : (
-              <OperationTimeline records={operationRecords} />
-            )}
+            <ActivityTimeline resourceType="skus" resourceId={skuId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/spus/detail.tsx
+++ b/apps/web/src/pages/master-data/spus/detail.tsx
@@ -4,6 +4,7 @@ import type { ColumnsType } from 'antd/es/table';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { deleteSpu, getSpuById } from '../../../api/spus.api';
 import { getProductCategoryTree } from '../../../api/product-categories.api';
 import { findCategoryName } from '../../../utils/category';
@@ -11,7 +12,6 @@ import { getSkus, type Sku } from '../../../api/skus.api';
 import {
   AnchorNav,
   MetaItem,
-  OperationTimeline,
   SectionCard,
   SummaryMetaItem,
   displayOrDash,
@@ -98,29 +98,6 @@ export default function SpuDetailPage() {
     : '—';
   const summaryStatusClass = data?.categoryId ? 'master-pill-blue' : 'master-pill-default';
   const summaryStatusText = data?.categoryId ? '已分类' : '待分类';
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [
-          {
-            key: 'updated',
-            operator: displayOrDash(data.updatedBy),
-            action: '更新记录',
-            time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-    ...(data?.createdAt
-      ? [
-          {
-            key: 'created',
-            operator: displayOrDash(data.createdBy),
-            action: '创建记录',
-            time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-  ];
-
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'supplier', label: '供应与开票' },
@@ -319,11 +296,7 @@ export default function SpuDetailPage() {
             title="操作记录"
             description="按时间展示 SPU 主数据的创建与更新轨迹。"
           >
-            {query.isLoading && !data ? (
-              <Skeleton active paragraph={{ rows: 3 }} />
-            ) : (
-              <OperationTimeline records={operationRecords} />
-            )}
+            <ActivityTimeline resourceType="spus" resourceId={spuId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/suppliers/detail.tsx
+++ b/apps/web/src/pages/master-data/suppliers/detail.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState, type ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Button, Empty, Result, Skeleton, Table } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getSupplierById, type SupplierPaymentTerm } from '../../../api/suppliers.api';
 import '../master-page.css';
 
@@ -75,31 +76,6 @@ export default function SupplierDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = useMemo(
-    () => [
-      ...(data?.updatedAt
-        ? [
-            {
-              key: 'updated',
-              operator: displayOrDash(data.updatedBy),
-              action: '更新记录',
-              time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm'),
-            },
-          ]
-        : []),
-      ...(data?.createdAt
-        ? [
-            {
-              key: 'created',
-              operator: displayOrDash(data.createdBy),
-              action: '创建记录',
-              time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm'),
-            },
-          ]
-        : []),
-    ],
-    [data],
-  );
 
   const anchors = [
     { key: 'basic', label: '基础信息' },
@@ -283,24 +259,7 @@ export default function SupplierDetailPage() {
               </div>
             </div>
             <div className="master-section-body">
-              {query.isLoading && !data ? (
-                <Skeleton active paragraph={{ rows: 3 }} />
-              ) : operationRecords.length ? (
-                <div className="master-status-timeline">
-                  {operationRecords.map((record, index) => (
-                    <div className="master-tl-item" key={record.key}>
-                      <div className={`master-tl-dot${index === operationRecords.length - 1 ? ' gray' : ''}`} />
-                      <div className="master-tl-content">
-                        <div className="master-tl-operator">操作人：{record.operator}</div>
-                        <div className="master-tl-action">操作记录：{record.action}</div>
-                        <div className="master-tl-time">操作时间：{record.time}</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="master-meta-value empty">—</div>
-              )}
+              <ActivityTimeline resourceType="suppliers" resourceId={supplierId} />
             </div>
           </section>
         </div>

--- a/apps/web/src/pages/master-data/units/detail.tsx
+++ b/apps/web/src/pages/master-data/units/detail.tsx
@@ -4,8 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { UnitStatus } from '@infitek/shared';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getUnitById } from '../../../api/units.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 const statusText: Record<UnitStatus, string> = {
@@ -55,14 +56,6 @@ export default function UnitDetailPage() {
   }
 
   const data = query.data;
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'audit', label: '审计信息' },
@@ -128,7 +121,7 @@ export default function UnitDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看单位档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="units" resourceId={unitId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/master-data/warehouses/detail.tsx
+++ b/apps/web/src/pages/master-data/warehouses/detail.tsx
@@ -4,8 +4,9 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { WarehouseStatus } from '@infitek/shared';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getWarehouseById } from '../../../api/warehouses.api';
-import { AnchorNav, MetaItem, OperationTimeline, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
+import { AnchorNav, MetaItem, SectionCard, SummaryMetaItem, displayOrDash } from '../components/page-scaffold';
 import '../master-page.css';
 
 const statusText: Record<WarehouseStatus, string> = {
@@ -56,14 +57,6 @@ export default function WarehouseDetailPage() {
 
   const data = query.data;
   const defaultShipArea = [data?.defaultShipProvince, data?.defaultShipCity].filter(Boolean).join(' / ') || '—';
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [{ key: 'updated', operator: displayOrDash(data.updatedBy), action: '更新记录', time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-    ...(data?.createdAt
-      ? [{ key: 'created', operator: displayOrDash(data.createdBy), action: '创建记录', time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm') }]
-      : []),
-  ];
   const anchors = [
     { key: 'basic', label: '基础信息' },
     { key: 'audit', label: '审计信息' },
@@ -134,7 +127,7 @@ export default function WarehouseDetailPage() {
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="按时间查看仓库档案维护轨迹。">
-            {query.isLoading && !data ? <Skeleton active paragraph={{ rows: 3 }} /> : <OperationTimeline records={operationRecords} />}
+            <ActivityTimeline resourceType="warehouses" resourceId={warehouseId} />
           </SectionCard>
         </div>
       </div>

--- a/apps/web/src/pages/settings/users/detail.tsx
+++ b/apps/web/src/pages/settings/users/detail.tsx
@@ -3,6 +3,7 @@ import { Button, Result, Skeleton } from 'antd';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { useNavigate, useParams } from 'react-router-dom';
+import { ActivityTimeline } from '../../../components/ActivityTimeline';
 import { getUserById } from '../../../api/users.api';
 import '../../master-data/master-page.css';
 
@@ -58,28 +59,6 @@ export default function UserDetailPage() {
   const data = query.data;
   const statusText = data?.status === 'active' ? '活跃' : '停用';
   const statusClass = data?.status === 'active' ? 'master-pill-success' : 'master-pill-default';
-  const operationRecords = [
-    ...(data?.updatedAt
-      ? [
-          {
-            key: 'updated',
-            operator: displayOrDash(data.updatedBy),
-            action: '更新记录',
-            time: dayjs(data.updatedAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-    ...(data?.createdAt
-      ? [
-          {
-            key: 'created',
-            operator: displayOrDash(data.createdBy),
-            action: '创建记录',
-            time: dayjs(data.createdAt).format('YYYY-MM-DD HH:mm'),
-          },
-        ]
-      : []),
-  ];
 
   const anchors = [
     { key: 'basic', label: '基础信息' },
@@ -208,24 +187,7 @@ export default function UserDetailPage() {
               </div>
             </div>
             <div className="master-section-body">
-              {query.isLoading && !data ? (
-                <Skeleton active paragraph={{ rows: 3 }} />
-              ) : operationRecords.length ? (
-                <div className="master-status-timeline">
-                  {operationRecords.map((record, index) => (
-                    <div className="master-tl-item" key={record.key}>
-                      <div className={`master-tl-dot${index === operationRecords.length - 1 ? ' gray' : ''}`} />
-                      <div className="master-tl-content">
-                        <div className="master-tl-operator">操作人：{record.operator}</div>
-                        <div className="master-tl-action">操作记录：{record.action}</div>
-                        <div className="master-tl-time">操作时间：{record.time}</div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="master-meta-value empty">—</div>
-              )}
+              <ActivityTimeline resourceType="users" resourceId={id} />
             </div>
           </section>
         </div>


### PR DESCRIPTION
## Summary
- add backend operation log module, migration, and audit interceptor for POST/PATCH/DELETE actions
- replace static detail-page operation records with a shared activity timeline backed by real operation logs
- improve timeline readability with detailed chinese labels, enum rendering, relation name resolution, and exact timestamps

## Test Plan
- pnpm --filter api build
- pnpm --filter api exec jest src/common/interceptors/audit.interceptor.spec.ts --runInBand
- pnpm --filter web exec tsc -b --pretty false