### PR TITLE
feat: complete shipping demands list

### DIFF
--- a/_bmad-output/implementation-artifacts/5-3-发货需求列表页.md
+++ b/_bmad-output/implementation-artifacts/5-3-发货需求列表页.md
@@ -1,0 +1,152 @@
+# Story 5.3: 发货需求列表页
+
+Status: done
+
+## Story
+
+As a 商务跟单,
+I want 查看发货需求单列表（按状态和关联销售订单筛选）,
+so that 我可以快速找到需要处理的发货需求并跟进。
+
+## Scope Adjustment
+
+- 本 Story 基于 Story 5.2 已落地的发货需求列表页、只读详情页和 `ShippingDemandsModule` 做补齐/完善，不重复实现列表页或重写发货需求模块。
+- 本次重点补齐：
+  - 列表页验收字段：需求编号、关联销售订单编号、客户名称、SKU 数量、状态、创建时间。
+  - 筛选验收：状态筛选、关联销售订单筛选、关键字搜索、分页。
+  - 后端列表查询契约：分页、筛选、SKU 数量聚合。
+  - 权限口径确认：沿用全局 JWT 鉴权，本 Story 不新增 RBAC。
+  - 操作记录口径确认：列表页不新增操作记录；详情页继续使用 `ActivityTimeline`，本 Story 不新增状态动作。
+
+## Acceptance Criteria
+
+1. 发货需求列表页复用现有 `ProTable`，加载完成后展示列：发货需求编号（蓝色链接）、来源销售订单（蓝色链接）、客户名称、SKU 数量、状态（彩色 Tag/Pill）、创建时间。
+2. 列表支持关键字搜索，搜索范围至少包含发货需求编号、来源销售订单编号、客户名称、客户代码。
+3. 列表支持状态筛选，状态值来自 `packages/shared` 的 `ShippingDemandStatus`，前后端不得重复定义枚举。
+4. 列表支持关联销售订单筛选：可按来源销售订单编号筛选；后端同时支持 `salesOrderId` 精确筛选，供后续跨页面预设筛选复用。
+5. 列表分页遵循项目统一分页契约：`page`、`pageSize` 入参，返回 `list/total/page/pageSize/totalPages`，前端分页支持 10/20/50 和“共 N 条记录”。
+6. 点击发货需求编号跳转 `/shipping-demands/:id`；点击来源销售订单编号跳转 `/sales-orders/:id`。
+7. 权限规则：发货需求列表接口和页面沿用全局登录鉴权；未登录访问由现有 `JwtAuthGuard` / 前端 401 处理，不在本 Story 新增角色权限或按钮级权限分叉。
+8. 操作记录规则：列表页不写操作记录；发货需求详情页继续使用统一 `ActivityTimeline`，显示已有创建/状态变更等审计日志。本 Story 不新增发货需求状态推进动作，不直接写库存数量。
+9. 后端发货需求主表与明细字段继续沿用 Story 5.2 已落地实体；列表补齐不得引入临时库存表、mock 库存 API、重复状态枚举或直接目标状态 PATCH。
+
+## Tasks / Subtasks
+
+- [x] Story 与验收边界补齐（AC: 1-9）
+  - [x] 明确本 Story 是现有列表页补齐，不重复实现。
+  - [x] 写明字段、筛选、分页、权限、操作记录规则。
+- [x] 后端列表查询补齐（AC: 1-5, 9）
+  - [x] `QueryShippingDemandDto` 增加 `salesOrderId` 与 `sourceDocumentCode` 查询参数。
+  - [x] `ShippingDemandsRepository.findAll()` 支持来源销售订单筛选。
+  - [x] `findAll()` 返回每条发货需求的 SKU 数量聚合。
+  - [x] 增加定向测试覆盖列表查询参数透传与 SKU 数量返回契约。
+- [x] 前端列表页补齐（AC: 1-6）
+  - [x] `ShippingDemand` API 类型增加 `skuCount`、筛选参数增加 `salesOrderId/sourceDocumentCode`。
+  - [x] 列表页增加“SKU 数量”列。
+  - [x] 高级筛选区增加来源销售订单编号筛选，并纳入 Tag 与清除全部。
+  - [x] 保持现有分页、状态 Tag、链接跳转和空状态体验。
+- [x] 权限与操作记录规则确认（AC: 7-8）
+  - [x] 确认列表接口未标记 `@Public()`，继续受全局 JWT 鉴权保护。
+  - [x] 确认本 Story 不新增写操作和审计噪音；详情页继续使用 `ActivityTimeline`。
+- [x] 验证与记录
+  - [x] 运行后端定向测试。
+  - [x] 运行可行的构建验证。
+  - [x] 更新 Dev Agent Record、File List、Completion Notes。
+  - [x] 更新 sprint-status。
+
+### Review Findings
+
+- [x] [Review][Decision] SKU 数量口径需确认 — 已确认 SKU 数量按发货需求明细行数统计，保留 `loadRelationCountAndMap('demand.skuCount', 'demand.items')` 口径。
+- [x] [Review][Patch] URL/预设 `salesOrderId` 精确筛选在列表页不可达 [apps/web/src/pages/shipping-demands/index.tsx:57]
+- [x] [Review][Patch] `sourceDocumentCode` LIKE 查询未转义通配符且后端未规整空白输入 [apps/api/src/modules/shipping-demands/shipping-demands.repository.ts:63]
+- [x] [Review][Patch] `sourceDocumentCode` DTO 缺少长度约束 [apps/api/src/modules/shipping-demands/dto/query-shipping-demand.dto.ts:23]
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic 或旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 发货需求由销售订单审核通过后手动触发生成，列表页只展示和筛选，不触发生成。
+- 发货需求状态只能由领域动作服务按数量聚合结果推进；本 Story 不新增状态推进接口，不允许通用 PATCH 修改状态。
+- 发货需求是履约数量权威单据；列表页只读取聚合结果，不写 `shipping_demand_items` 数量字段。
+- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、后续库存分配表和库存流水；本 Story 不新增库存写操作。
+- 禁止临时库存表、mock 库存 API、硬编码库存数据或重复定义 `ShippingDemandStatus`。
+
+### Field / Filter Confirmation
+
+基于 Epic 5.3、现有代码和用户备注，本 Story 确认列表页字段与筛选如下：
+
+- 列表必显字段：发货需求编号、来源销售订单、客户名称、SKU 数量、状态、创建时间。
+- 现有扩展展示字段可保留：客户代码、币种、订单金额、运抵国、目的港、商务跟单、要求到货日期、操作列。
+- 快捷搜索字段：发货需求编号、来源销售订单编号、客户名称、客户代码。
+- 高级筛选字段：需求状态、来源销售订单编号。
+- 后端预留筛选字段：`salesOrderId`，用于后续从销售订单或关联单据跳转时传入精确筛选。
+
+### Existing Implementation Context
+
+- Story 5.2 已新增 `apps/api/src/modules/shipping-demands/`、`apps/web/src/api/shipping-demands.api.ts`、`apps/web/src/pages/shipping-demands/index.tsx` 和 `detail.tsx`。
+- 现有列表页已经具备 `ProTable`、状态筛选、关键字搜索、分页、空状态、发货需求详情链接和来源销售订单链接。
+- 当前缺口是：列表没有 SKU 数量列；后端列表查询没有 SKU 数量聚合；关联销售订单筛选只有关键字模糊命中，缺少显式筛选参数。
+- 现有项目暂无角色/权限装饰器，接口通过全局 `JwtAuthGuard` 鉴权；本 Story 不引入 RBAC 结构。
+- 操作记录统一规范见 `docs/operation-log-standard.md`；发货需求字段标签和枚举中文化已在 Story 5.2 补齐，详情页已使用 `ActivityTimeline`。
+
+### Implementation Boundaries
+
+- 不实现 Story 5.4 的发货需求枢纽详情页、库存分配、FlowProgress、SmartButton 或 FIFO 锁定。
+- 不实现 Story 5.5 的作废完整逻辑。
+- 不实现采购订单、物流单、出库单入口或状态联动。
+- 不新增数据库表或迁移；本 Story 只补查询聚合和前端展示筛选。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/.codex/worktrees/741d/infitek_erp`
+- Branch: `codex/story-5-3-shipping-demands-list`
+- WORKTREE_MODE: false
+
+### Completion Notes List
+
+- 已基于 Story 5.2 现有发货需求列表页补齐，不重复实现列表页或改写交易状态逻辑。
+- 已确认列表字段、筛选、分页、权限、操作记录规则：列表页只读展示和筛选，不新增状态动作、不写库存数量、不产生审计噪音。
+- 后端 `QueryShippingDemandDto` 增加 `salesOrderId` 与 `sourceDocumentCode`，`findAll()` 支持来源销售订单筛选。
+- 后端列表查询使用 `loadRelationCountAndMap('demand.skuCount', 'demand.items')` 返回每条发货需求的 SKU 数量。
+- 前端列表页增加“SKU 数量”列，新增“来源销售订单编号”高级筛选，并接入筛选 Tag、清除全部和分页重置。
+- Code review 已确认 SKU 数量按发货需求明细行数统计。
+- Code review 后已补齐 URL `salesOrderId` 预设筛选，支持从关联页面通过 `?salesOrderId=` 精确过滤发货需求。
+- Code review 后已补齐 `sourceDocumentCode` 后端空白规整、长度约束和 LIKE 通配符转义。
+- 权限口径保持全局 JWT 鉴权；`shipping-demands` 列表接口未标记 `@Public()`，本 Story 不新增 RBAC。
+- 操作记录口径保持详情页 `ActivityTimeline`；本 Story 不新增写操作和审计日志。
+- 初次验证因当前 worktree 缺少 `node_modules` 导致 `jest/tsc` 不可用；已执行 `pnpm install --frozen-lockfile` 补齐依赖。
+- 定向测试通过：`pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`，2 个测试套件、9 个用例通过。
+- 构建验证通过：`pnpm --filter api build`、`pnpm --filter web build`。Web build 仍有既有 Vite chunk size 警告。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-3-发货需求列表页.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `apps/api/src/modules/shipping-demands/dto/query-shipping-demand.dto.ts`
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts`
+- `apps/api/src/modules/shipping-demands/shipping-demands.repository.ts`
+- `apps/api/src/modules/shipping-demands/tests/shipping-demands.repository.spec.ts`
+- `apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts`
+- `apps/web/src/api/shipping-demands.api.ts`
+- `apps/web/src/pages/shipping-demands/index.tsx`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-04-28 | 0.1 | 创建 Story 5.3，明确基于现有列表页补齐验收，不重复实现 | GPT-5 Codex |
+| 2026-04-28 | 1.0 | 完成发货需求列表页字段、筛选、分页、权限与操作记录验收补齐 | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-28 (story-5.2-done)
+# last_updated: 2026-04-28 (story-5.3-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-04-28 (story-5.2-done)
+last_updated: 2026-04-28 (story-5.3-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -110,7 +110,7 @@ development_status:
   5-1-销售订单创建与确认: done
   5-0-库存双层结构查询接口与期初录入: done
   5-2-销售订单列表与详情: done
-  5-3-发货需求列表页: backlog
+  5-3-发货需求列表页: done
   5-4-发货需求枢纽详情页: backlog
   5-5-发货需求下游入口与完整作废逻辑: backlog
   epic-5-retrospective: optional

--- a/apps/api/src/modules/shipping-demands/dto/query-shipping-demand.dto.ts
+++ b/apps/api/src/modules/shipping-demands/dto/query-shipping-demand.dto.ts
@@ -1,7 +1,13 @@
-import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
 import { ShippingDemandStatus } from '@infitek/shared';
 import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+
+function normalizeOptionalString(value: unknown) {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
 
 export class QueryShippingDemandDto extends BaseQueryDto {
   @IsOptional()
@@ -13,4 +19,16 @@ export class QueryShippingDemandDto extends BaseQueryDto {
   @IsInt()
   @Min(1)
   customerId?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  salesOrderId?: number;
+
+  @IsOptional()
+  @Transform(({ value }) => normalizeOptionalString(value))
+  @IsString()
+  @MaxLength(100)
+  sourceDocumentCode?: string;
 }

--- a/apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts
+++ b/apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts
@@ -214,4 +214,7 @@ export class ShippingDemand extends BaseEntity {
   @OneToMany(() => ShippingDemandItem, (item) => item.shippingDemand, { cascade: false })
   @Expose()
   items?: ShippingDemandItem[];
+
+  @Expose()
+  skuCount?: number;
 }

--- a/apps/api/src/modules/shipping-demands/shipping-demands.repository.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.repository.ts
@@ -6,6 +6,10 @@ import { QueryShippingDemandDto } from './dto/query-shipping-demand.dto';
 import { ShippingDemandItem } from './entities/shipping-demand-item.entity';
 import { ShippingDemand } from './entities/shipping-demand.entity';
 
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
 @Injectable()
 export class ShippingDemandsRepository {
   constructor(
@@ -30,7 +34,15 @@ export class ShippingDemandsRepository {
   }
 
   async findAll(query: QueryShippingDemandDto) {
-    const { keyword, status, customerId, page = 1, pageSize = 20 } = query;
+    const {
+      keyword,
+      status,
+      customerId,
+      salesOrderId,
+      sourceDocumentCode,
+      page = 1,
+      pageSize = 20,
+    } = query;
     const qb = this.shippingDemandRepo.createQueryBuilder('demand');
 
     if (keyword) {
@@ -48,7 +60,19 @@ export class ShippingDemandsRepository {
       qb.andWhere('demand.customer_id = :customerId', { customerId });
     }
 
+    if (salesOrderId != null) {
+      qb.andWhere('demand.sales_order_id = :salesOrderId', { salesOrderId });
+    }
+
+    const normalizedSourceDocumentCode = sourceDocumentCode?.trim();
+    if (normalizedSourceDocumentCode) {
+      qb.andWhere('demand.source_document_code LIKE :sourceDocumentCode ESCAPE \'\\\\\'', {
+        sourceDocumentCode: `%${escapeLike(normalizedSourceDocumentCode)}%`,
+      });
+    }
+
     const [list, total] = await qb
+      .loadRelationCountAndMap('demand.skuCount', 'demand.items')
       .orderBy('demand.created_at', 'DESC')
       .skip((page - 1) * pageSize)
       .take(pageSize)

--- a/apps/api/src/modules/shipping-demands/tests/shipping-demands.repository.spec.ts
+++ b/apps/api/src/modules/shipping-demands/tests/shipping-demands.repository.spec.ts
@@ -1,0 +1,143 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { ShippingDemandStatus } from '@infitek/shared';
+import { QueryShippingDemandDto } from '../dto/query-shipping-demand.dto';
+import { ShippingDemandsRepository } from '../shipping-demands.repository';
+
+describe('ShippingDemandsRepository', () => {
+  const makeQueryBuilder = (list: unknown[] = [], total = 0) => {
+    const qb = {
+      andWhere: jest.fn(() => qb),
+      loadRelationCountAndMap: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      skip: jest.fn(() => qb),
+      take: jest.fn(() => qb),
+      getManyAndCount: jest.fn().mockResolvedValue([list, total]),
+    };
+    return qb;
+  };
+
+  it('filters list by status, customer, sales order, source document and returns sku count', async () => {
+    const rows = [
+      {
+        id: 500,
+        demandCode: 'SD2026042800001',
+        skuCount: 2,
+      },
+    ];
+    const qb = makeQueryBuilder(rows, 1);
+    const shippingDemandRepo = {
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    const repository = new ShippingDemandsRepository(
+      { createQueryRunner: jest.fn() } as any,
+      shippingDemandRepo as any,
+      {} as any,
+    );
+
+    const result = await repository.findAll({
+      keyword: '客户A',
+      status: ShippingDemandStatus.PENDING_ALLOCATION,
+      customerId: 12,
+      salesOrderId: 34,
+      sourceDocumentCode: ' SO_20260428% ',
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(shippingDemandRepo.createQueryBuilder).toHaveBeenCalledWith(
+      'demand',
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      '(demand.demand_code LIKE :kw OR demand.source_document_code LIKE :kw OR demand.customer_name LIKE :kw OR demand.customer_code LIKE :kw)',
+      { kw: '%客户A%' },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith('demand.status = :status', {
+      status: ShippingDemandStatus.PENDING_ALLOCATION,
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'demand.customer_id = :customerId',
+      {
+        customerId: 12,
+      },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'demand.sales_order_id = :salesOrderId',
+      {
+        salesOrderId: 34,
+      },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'demand.source_document_code LIKE :sourceDocumentCode ESCAPE \'\\\\\'',
+      { sourceDocumentCode: '%SO\\_20260428\\%%' },
+    );
+    expect(qb.loadRelationCountAndMap).toHaveBeenCalledWith(
+      'demand.skuCount',
+      'demand.items',
+    );
+    expect(qb.skip).toHaveBeenCalledWith(10);
+    expect(qb.take).toHaveBeenCalledWith(10);
+    expect(result).toEqual({
+      list: rows,
+      total: 1,
+      page: 2,
+      pageSize: 10,
+      totalPages: 1,
+    });
+  });
+
+  it('ignores blank source document filters', async () => {
+    const qb = makeQueryBuilder([], 0);
+    const shippingDemandRepo = {
+      createQueryBuilder: jest.fn(() => qb),
+    };
+    const repository = new ShippingDemandsRepository(
+      { createQueryRunner: jest.fn() } as any,
+      shippingDemandRepo as any,
+      {} as any,
+    );
+
+    await repository.findAll({
+      sourceDocumentCode: '   ',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(qb.andWhere).not.toHaveBeenCalledWith(
+      expect.stringContaining('source_document_code'),
+      expect.anything(),
+    );
+  });
+});
+
+describe('QueryShippingDemandDto', () => {
+  async function validateQuery(input: Record<string, unknown>) {
+    const dto = plainToInstance(QueryShippingDemandDto, input);
+    const errors = await validate(dto);
+    return { dto, errors };
+  }
+
+  it('trims source document code and normalizes blanks', async () => {
+    const { dto: trimmedDto, errors: trimmedErrors } = await validateQuery({
+      sourceDocumentCode: ' SO20260428 ',
+    });
+    const { dto: blankDto, errors: blankErrors } = await validateQuery({
+      sourceDocumentCode: '   ',
+    });
+
+    expect(trimmedErrors).toHaveLength(0);
+    expect(trimmedDto.sourceDocumentCode).toBe('SO20260428');
+    expect(blankErrors).toHaveLength(0);
+    expect(blankDto.sourceDocumentCode).toBeUndefined();
+  });
+
+  it('rejects overlong source document code filters', async () => {
+    const { errors } = await validateQuery({
+      sourceDocumentCode: 'S'.repeat(101),
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('sourceDocumentCode');
+  });
+});

--- a/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
+++ b/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
@@ -24,7 +24,9 @@ describe('ShippingDemandsService', () => {
     findAvailable: jest.fn(),
   };
 
-  const makeOrder = (status = SalesOrderStatus.APPROVED): Partial<SalesOrder> => ({
+  const makeOrder = (
+    status = SalesOrderStatus.APPROVED,
+  ): Partial<SalesOrder> => ({
     id: 10,
     erpSalesOrderCode: 'SO2026042800001',
     status,
@@ -123,7 +125,9 @@ describe('ShippingDemandsService', () => {
     }
     if (entity === ShippingDemand) {
       return {
-        createQueryBuilder: jest.fn(() => makeQueryBuilder(state.existingDemand ?? state.latestDemand ?? null)),
+        createQueryBuilder: jest.fn(() =>
+          makeQueryBuilder(state.existingDemand ?? state.latestDemand ?? null),
+        ),
         create: jest.fn((data) => data),
         save: jest.fn().mockImplementation(async (data) => {
           state.savedDemand = { id: 500, ...data };
@@ -186,6 +190,8 @@ describe('ShippingDemandsService', () => {
     const result = await service.findAll({
       keyword: 'SD20260428',
       status: ShippingDemandStatus.PENDING_ALLOCATION,
+      salesOrderId: 10,
+      sourceDocumentCode: 'SO20260428',
       page: 1,
       pageSize: 20,
     });
@@ -194,6 +200,8 @@ describe('ShippingDemandsService', () => {
     expect(shippingDemandsRepository.findAll).toHaveBeenCalledWith({
       keyword: 'SD20260428',
       status: ShippingDemandStatus.PENDING_ALLOCATION,
+      salesOrderId: 10,
+      sourceDocumentCode: 'SO20260428',
       page: 1,
       pageSize: 20,
     });
@@ -223,7 +231,9 @@ describe('ShippingDemandsService', () => {
 
     expect(result.demandCode).toBe('SD2026042800001');
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
-    expect(inventoryService.findAvailable).toHaveBeenCalledWith({ skuIds: [11] });
+    expect(inventoryService.findAvailable).toHaveBeenCalledWith({
+      skuIds: [11],
+    });
     expect(state.savedDemand).toEqual(
       expect.objectContaining({
         status: ShippingDemandStatus.PENDING_ALLOCATION,
@@ -300,7 +310,9 @@ describe('ShippingDemandsService', () => {
     expect(result.demandCode).toBe('SD2026042800002');
     expect(firstQueryRunner.rollbackTransaction).toHaveBeenCalled();
     expect(secondQueryRunner.commitTransaction).toHaveBeenCalled();
-    expect(shippingDemandsRepository.createQueryRunner).toHaveBeenCalledTimes(2);
+    expect(shippingDemandsRepository.createQueryRunner).toHaveBeenCalledTimes(
+      2,
+    );
   });
 
   it('rejects non-approved sales order', async () => {
@@ -320,7 +332,10 @@ describe('ShippingDemandsService', () => {
   it('rejects duplicate active shipping demand', async () => {
     const state: Record<string, unknown> = {
       order: makeOrder(),
-      existingDemand: { id: 88, status: ShippingDemandStatus.PENDING_ALLOCATION },
+      existingDemand: {
+        id: 88,
+        status: ShippingDemandStatus.PENDING_ALLOCATION,
+      },
     };
     const queryRunner = makeQueryRunner(state);
     shippingDemandsRepository.createQueryRunner.mockReturnValue(queryRunner);

--- a/apps/web/src/api/shipping-demands.api.ts
+++ b/apps/web/src/api/shipping-demands.api.ts
@@ -32,6 +32,7 @@ export interface ShippingDemand {
   status: ShippingDemandStatus;
   customerName: string;
   customerCode: string;
+  skuCount?: number;
   currencyCode?: string | null;
   destinationCountryName?: string | null;
   destinationPortName?: string | null;
@@ -47,6 +48,8 @@ export interface ShippingDemandListParams {
   keyword?: string;
   status?: ShippingDemandStatus;
   customerId?: number;
+  salesOrderId?: number;
+  sourceDocumentCode?: string;
   page?: number;
   pageSize?: number;
 }

--- a/apps/web/src/pages/shipping-demands/index.tsx
+++ b/apps/web/src/pages/shipping-demands/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import { Button, Empty, Result, Select, Skeleton, Space, Typography, theme } from 'antd';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Button, Empty, Input, Result, Select, Skeleton, Space, Typography, theme } from 'antd';
 import { ProTable } from '@ant-design/pro-components';
 import type { ProColumns } from '@ant-design/pro-components';
 import { useQuery } from '@tanstack/react-query';
@@ -37,27 +37,62 @@ function formatMoney(value?: string | null) {
   return `${integerPart}.${decimalPart.padEnd(2, '0').slice(0, 2)}`;
 }
 
+function parsePositiveIntParam(value: string | null) {
+  const normalized = value?.trim();
+  if (!normalized || !/^\d+$/.test(normalized)) return undefined;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
 export default function ShippingDemandsListPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { token } = theme.useToken();
   const [keywordInput, setKeywordInput] = useState('');
+  const [sourceDocumentCodeInput, setSourceDocumentCodeInput] = useState('');
   const [status, setStatus] = useState<ShippingDemandStatus | undefined>(undefined);
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
 
   const keyword = useDebouncedValue(keywordInput, 300).trim();
-  const hasFilters = Boolean(keyword) || status != null;
+  const sourceDocumentCode = useDebouncedValue(sourceDocumentCodeInput, 300).trim();
+  const salesOrderId = useMemo(
+    () => parsePositiveIntParam(searchParams.get('salesOrderId')),
+    [searchParams],
+  );
+  const hasFilters = Boolean(keyword) || Boolean(sourceDocumentCode) || status != null || salesOrderId != null;
+
+  const clearSalesOrderFilter = () => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    nextSearchParams.delete('salesOrderId');
+    setSearchParams(nextSearchParams, { replace: true });
+    setPage(1);
+  };
+
+  const clearAllFilters = () => {
+    setKeywordInput('');
+    setSourceDocumentCodeInput('');
+    setStatus(undefined);
+    if (searchParams.has('salesOrderId')) {
+      const nextSearchParams = new URLSearchParams(searchParams);
+      nextSearchParams.delete('salesOrderId');
+      setSearchParams(nextSearchParams, { replace: true });
+    }
+    setPage(1);
+  };
 
   useEffect(() => {
     setPage(1);
-  }, [keyword, status]);
+  }, [keyword, sourceDocumentCode, salesOrderId, status]);
 
   const query = useQuery({
-    queryKey: ['shipping-demands', keyword, status, page, pageSize],
+    queryKey: ['shipping-demands', keyword, sourceDocumentCode, salesOrderId, status, page, pageSize],
     placeholderData: (previousData) => previousData,
     queryFn: () =>
       getShippingDemands({
         keyword: keyword || undefined,
+        sourceDocumentCode: sourceDocumentCode || undefined,
+        salesOrderId,
         status,
         page,
         pageSize,
@@ -94,6 +129,13 @@ export default function ShippingDemandsListPage() {
         dataIndex: 'customerName',
         width: 220,
         ellipsis: true,
+      },
+      {
+        title: 'SKU 数量',
+        dataIndex: 'skuCount',
+        width: 100,
+        align: 'right',
+        render: (_, record) => record.skuCount ?? record.items?.length ?? '-',
       },
       {
         title: '客户代码',
@@ -194,11 +236,7 @@ export default function ShippingDemandsListPage() {
     <Empty description="未找到匹配记录">
       <Button
         type="link"
-        onClick={() => {
-          setKeywordInput('');
-          setStatus(undefined);
-          setPage(1);
-        }}
+        onClick={clearAllFilters}
       >
         清除筛选条件
       </Button>
@@ -218,6 +256,23 @@ export default function ShippingDemandsListPage() {
           label: `关键词: ${keyword}`,
           onClose: () => {
             setKeywordInput('');
+            setPage(1);
+          },
+        }
+      : null,
+    salesOrderId != null
+      ? {
+          key: 'salesOrderId',
+          label: `销售订单ID: ${salesOrderId}`,
+          onClose: clearSalesOrderFilter,
+        }
+      : null,
+    sourceDocumentCode
+      ? {
+          key: 'sourceDocumentCode',
+          label: `来源销售订单: ${sourceDocumentCode}`,
+          onClose: () => {
+            setSourceDocumentCodeInput('');
             setPage(1);
           },
         }
@@ -265,23 +320,25 @@ export default function ShippingDemandsListPage() {
                     setPage(1);
                   }}
                 />
+                <Input
+                  allowClear
+                  placeholder="来源销售订单编号"
+                  style={{ width: 220 }}
+                  value={sourceDocumentCodeInput}
+                  onChange={(event) => {
+                    setSourceDocumentCodeInput(event.target.value);
+                    setPage(1);
+                  }}
+                />
               </Space>
             }
             activeTags={activeTags}
-            onClearAll={() => {
-              setKeywordInput('');
-              setStatus(undefined);
-              setPage(1);
-            }}
+            onClearAll={clearAllFilters}
             onQuery={() => {
               setPage(1);
               query.refetch();
             }}
-            onReset={() => {
-              setKeywordInput('');
-              setStatus(undefined);
-              setPage(1);
-            }}
+            onReset={clearAllFilters}
           />
 
           <Skeleton active loading={query.isLoading && !query.data} style={{ marginTop: token.marginMD }}>
@@ -293,7 +350,7 @@ export default function ShippingDemandsListPage() {
               loading={query.isFetching}
               columns={columns}
               dataSource={query.data?.list ?? []}
-              scroll={{ x: 1700, y: 540 }}
+              scroll={{ x: 1800, y: 540 }}
               rowClassName={() => 'shipping-demand-row-height'}
               locale={{ emptyText }}
               pagination={{


### PR DESCRIPTION
## Summary
- complete Story 5.3 shipping demand list acceptance fields, including SKU count
- add source sales order filtering with URL preset salesOrderId support
- harden sourceDocumentCode filtering with trim, max length, and LIKE escaping
- document code review findings and keep sprint status at done

## Validation
- pnpm --filter api exec jest modules/shipping-demands/tests --runInBand
- pnpm --filter api build
- pnpm --filter web build

Note: web build still reports the existing Vite chunk size warning.