### PR TITLE
Story 5.4 发货需求详情与库存分配补齐

### DIFF
--- a/_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md
+++ b/_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md
@@ -1,0 +1,146 @@
+# Story 5.4: 发货需求枢纽详情页
+
+Status: done
+
+## Story
+
+As a 商务跟单,
+I want 在现有发货需求详情页查看与销售订单详情相近的完整字段、流程进度、关联单据入口、核心 KPI 和 SKU 库存状态,
+so that 我可以在一个详情页掌握发货需求全貌，并为后续库存分配、采购和物流动作做决策。
+
+## Scope Adjustment
+
+- 当前代码已经有发货需求列表页和只读详情页，本 Story 不重复实现列表或重写路由。
+- 用户确认重点：详情页缺少很多字段，理应与销售订单字段差不多；本 Story 优先补齐发货需求详情应继承销售订单的主信息、订单信息、收发通、发货要求和产品明细展示。
+- 原 Epic 5.4 的“完整库存锁定”依赖库存分配表、库存流水、采购/物流/出库模块。当前底座尚未完整落地，本 Story 不伪造库存分配或直接写库存状态，只把详情页升级为枢纽详情，并保留后续动作入口/状态展示。
+
+## Acceptance Criteria
+
+1. 发货需求详情页保留现有加载、错误、返回、操作记录能力，并升级为枢纽详情页：顶部展示需求编号、来源销售订单、状态 Tag、客户/币种/金额/要求到货日期摘要。
+2. 页面展示 FlowProgress 流程进度条，步骤为：需求创建、库存检查、采购备货、库存锁定、创建物流、出库发货、完成；当前进度根据 `ShippingDemandStatus` 映射展示，不允许前端直接提交目标状态。
+3. 页面展示 SmartButton 关联单据入口：采购订单、物流单、出库单。当前相关下游列表尚未实现时，按钮保留计数 0 和禁用态/占位，不跳转不存在路由；来源销售订单入口可跳转销售订单详情。
+4. 页面展示 KPI 摘要：总 SKU 种类、总应发数量、已锁定数量、已出库数量，并从发货需求明细聚合，不能写入数量字段。
+5. 基础信息、订单信息、收发通信息、发货要求字段尽量对齐销售订单详情，至少展示：内外销、订单类型、客户、客户代码、联系人、运抵国、付款方式、起运地、签约公司、销售员、商务跟单、贸易术语、运输方式、订单性质、收款状态、合同/已收/待收/产品/费用/总金额、要求到货日期、报关/保险/清关/质保/打托/唛头/开票/随货文件/清关要求等已保存字段。
+6. 产品明细表字段对齐销售订单详情并补足发货需求履约字段，至少包含：SKU、产品中文/英文名、规格、类型、SPU、电参数、插头信息、应发数量、销售单价、币种、金额、单位、采购人员、是否需要采购、需采购数量、使用现有库存数量、已锁定待发、已发货数量、采购已下单、已收货、产品材质、重量体积、图片、库存快照/库存状态。
+7. 库存状态使用生成时的 `availableStockSnapshot` 计算：可用库存合计 >= 应发数量为绿色，0 < 可用库存合计 < 应发数量为橙色，可用库存合计 = 0 为红色。
+8. 后端 `GET /api/shipping-demands/:id` 返回详情所需字段；新生成发货需求时应从销售订单拷贝相关销售订单镜像字段；已有旧数据字段为空时前端显示 `—`，不崩溃。
+9. 附件类字段（合同文件、插头照片、唛头模板）在发货需求详情接口返回可访问 URL，逻辑与销售订单详情一致。
+10. 本 Story 不新增库存写操作、临时库存表、mock 库存 API、重复枚举、通用状态 PATCH；库存锁定和状态推进留待具备分配表/库存流水后的领域动作实现。
+
+## Tasks / Subtasks
+
+- [x] Story 与上下文补齐（AC: 1-10）
+  - [x] 记录用户备注：已有列表和详情，重点补齐详情字段，对齐销售订单详情。
+  - [x] 写明 Epic 5-7 强制 flow 约束与本次收窄边界。
+- [x] 后端详情字段补齐（AC: 5, 8, 9）
+  - [x] `ShippingDemand` 实体补齐销售订单镜像字段。
+  - [x] 新增迁移为 `shipping_demands` 补列。
+  - [x] 生成发货需求时拷贝新增字段。
+  - [x] `findById()` 返回合同/插头/唛头模板签名 URL。
+  - [x] 补充单测覆盖字段拷贝和签名 URL。
+- [x] 前端 API 类型补齐（AC: 5, 6, 9）
+  - [x] `ShippingDemand`/`ShippingDemandItem` 类型补齐详情字段。
+  - [x] 避免附件/可选字段为空时报错。
+- [x] 前端枢纽详情页升级（AC: 1-7）
+  - [x] 增加 FlowProgress、SmartButton、KPI 摘要和库存指示器。
+  - [x] 补齐基础信息、订单信息、收发通、发货要求字段区块。
+  - [x] 产品明细表对齐销售订单详情字段并加入履约/库存列。
+  - [x] 保持操作记录使用统一 `ActivityTimeline`。
+- [x] 验证与记录
+  - [x] 运行后端发货需求定向测试。
+  - [x] 运行 API/Web 构建验证。
+  - [x] 运行 code review 并修复必须项。
+  - [x] 更新 Dev Agent Record、File List、Completion Notes。
+  - [x] 更新 sprint-status。
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic 或旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 发货需求由销售订单审核通过后手动触发生成，详情页只展示生成结果和后续决策上下文。
+- 发货需求是履约数量权威单据；销售订单明细上的履约数量只能作为展示缓存或聚合结果。
+- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、后续库存分配表和库存流水。
+- 状态推进必须由领域动作服务在事务内根据数量聚合触发；前端不得直接提交目标状态。
+- 库存锁定必须使用 `InventoryService` 的事务/行锁能力，并在具备分配表和库存流水后记录批次级分配；本 Story 不新增伪锁定。
+- 禁止临时库存表、mock 库存 API、硬编码库存数据或重复定义 `ShippingDemandStatus`/`FulfillmentType`。
+
+### Existing Implementation Context
+
+- Story 5.2 已新增发货需求实体、迁移、生成接口、发货需求列表页和最小只读详情页。
+- Story 5.3 已补齐列表字段、筛选、SKU 数量聚合和 URL 预设筛选。
+- 当前 `shipping_demands` 主表已经保存部分销售订单镜像字段，但缺少销售订单详情里的联系人、行业、汇率、附件、清关/唛头/收发通等字段；前端详情页展示字段更少。
+- 当前 `shipping_demand_items` 已经保存产品明细大部分字段，但前端详情页没有完全展示采购人员、是否需要采购、金额、单位、重量体积、图片等字段。
+- 当前下游采购订单、物流单、出库单模块尚未有页面路由；SmartButton 应作为枢纽占位和未来入口，不应跳转不存在页面。
+
+### Field Reference Check
+
+字段参考来源：
+
+- `docs/系统模块对应字段清单.md` 的“销售订单管理”和“分配库存（发货需求）”字段清单。
+- `apps/web/src/pages/sales-orders/detail.tsx` 的现有销售订单详情字段布局。
+- `apps/api/src/modules/sales-orders/entities/sales-order.entity.ts` 与 `sales-order-item.entity.ts` 的已落地字段。
+- 用户备注：发货需求详情字段应与销售订单字段差不多。
+
+### Implementation Boundaries
+
+- 不实现采购订单创建、物流单创建、出库单创建。
+- 不实现发货需求作废完整逻辑。
+- 不实现库存分配表和库存流水。
+- 不新增通用 `PATCH /shipping-demands/:id` 状态修改。
+- 不在前端伪造库存锁定成功或修改库存数量。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/ai_study/worktrees/codex/story-5-4-shipping-demand-hub-detail`
+- Branch: `codex/story-5-4-shipping-demand-hub-detail`
+- WORKTREE_MODE: true
+
+### Completion Notes List
+
+- 已创建 Story 5.4，并按用户备注明确本次基于已有发货需求列表/详情补齐详情字段。
+- 已完整加载 Epic 5-7 三份强制 flow 文档，并记录本 Story 不伪造库存锁定、不新增直接状态 PATCH、不重复定义枚举。
+- 已为 `shipping_demands` 主表补齐销售订单详情镜像字段，并新增迁移 `20260428000200-add-detail-fields-to-shipping-demands.ts`。
+- 已为 `shipping_demand_items` 补齐采购人员、是否需要采购字段，生成发货需求时从销售订单明细复制。
+- `ShippingDemandsService.findById()` 已返回合同文件、插头照片、唛头模板的签名 URL，逻辑与销售订单详情一致。
+- 前端发货需求详情已升级为枢纽视图：FlowProgress、SmartButton、KPI、库存状态指示、完整基础/订单/收发通/发货要求区块。
+- 产品明细表已对齐销售订单详情字段，并加入履约数量、采购下单/收货数量、库存快照和库存颜色标签。
+- 下游采购订单、物流单、出库单页面尚未实现，SmartButton 保留 0 计数禁用态，避免跳转不存在路由。
+- Code review 已完成并修复来源销售订单入口在详情数据未加载时可能跳转到无效路由的问题。
+- 定向测试通过：`pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`，2 个测试套件、10 个用例通过。
+- 构建验证通过：`pnpm --filter api build`、`pnpm --filter web build`。Web build 仍有既有 Vite chunk size 警告。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `apps/api/src/migrations/20260428000200-add-detail-fields-to-shipping-demands.ts`
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts`
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand-item.entity.ts`
+- `apps/api/src/modules/shipping-demands/shipping-demands.module.ts`
+- `apps/api/src/modules/shipping-demands/shipping-demands.service.ts`
+- `apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts`
+- `apps/web/src/api/shipping-demands.api.ts`
+- `apps/web/src/pages/master-data/master-page.css`
+- `apps/web/src/pages/shipping-demands/detail.tsx`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-04-28 | 0.1 | 创建 Story 5.4，按用户备注收窄为已有详情页字段和枢纽展示补齐 | GPT-5 Codex |
+| 2026-04-28 | 1.0 | 完成发货需求详情字段补齐、枢纽展示、附件签名 URL 和本地验证 | GPT-5 Codex |
+| 2026-04-28 | 1.1 | 完成 code review，修复来源销售订单入口加载态无效跳转 | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md
+++ b/_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md
@@ -5,14 +5,15 @@ Status: done
 ## Story
 
 As a 商务跟单,
-I want 在现有发货需求详情页查看与销售订单详情相近的完整字段、流程进度、关联单据入口、核心 KPI 和 SKU 库存状态,
-so that 我可以在一个详情页掌握发货需求全貌，并为后续库存分配、采购和物流动作做决策。
+I want 在现有发货需求详情页查看与销售订单详情相近的完整字段、流程进度、关联单据入口、核心 KPI 和 SKU 库存状态，并完成履行类型决策和确认分配,
+so that 我可以在一个详情页掌握发货需求全貌，并按 FIFO 锁定可用库存或推进采购备货。
 
 ## Scope Adjustment
 
 - 当前代码已经有发货需求列表页和只读详情页，本 Story 不重复实现列表或重写路由。
 - 用户确认重点：详情页缺少很多字段，理应与销售订单字段差不多；本 Story 优先补齐发货需求详情应继承销售订单的主信息、订单信息、收发通、发货要求和产品明细展示。
-- 原 Epic 5.4 的“完整库存锁定”依赖库存分配表、库存流水、采购/物流/出库模块。当前底座尚未完整落地，本 Story 不伪造库存分配或直接写库存状态，只把详情页升级为枢纽详情，并保留后续动作入口/状态展示。
+- 本 Story 纠偏后按 Epic 5.4 补齐确认分配闭环：履行类型编辑、确认分配动作端点、FIFO 锁定、库存流水、状态推进、前端成功刷新。
+- 采购订单创建、物流单创建、出库单创建和发货需求完整作废属于后续 Story；当前 SmartButton 保留为枢纽入口和禁用占位。
 
 ## Acceptance Criteria
 
@@ -25,7 +26,16 @@ so that 我可以在一个详情页掌握发货需求全貌，并为后续库存
 7. 库存状态使用生成时的 `availableStockSnapshot` 计算：可用库存合计 >= 应发数量为绿色，0 < 可用库存合计 < 应发数量为橙色，可用库存合计 = 0 为红色。
 8. 后端 `GET /api/shipping-demands/:id` 返回详情所需字段；新生成发货需求时应从销售订单拷贝相关销售订单镜像字段；已有旧数据字段为空时前端显示 `—`，不崩溃。
 9. 附件类字段（合同文件、插头照片、唛头模板）在发货需求详情接口返回可访问 URL，逻辑与销售订单详情一致。
-10. 本 Story 不新增库存写操作、临时库存表、mock 库存 API、重复枚举、通用状态 PATCH；库存锁定和状态推进留待具备分配表/库存流水后的领域动作实现。
+10. 待分配状态下，产品明细表支持履行类型选择：全部采购、部分采购、使用现有库存；使用库存时选择仓库并填写本次使用库存数量，前端按所选仓库可用量校验。
+11. 待分配状态下，产品明细表展示所选仓库的 FIFO 批次预览：入库日期、来源单据类型、批次数量、批次可用量；实际批次分配以后端 FIFO 锁定结果为准。
+12. 点击“确认分配”后，前端集中提交所有 SKU 行；未设置履行类型、数量不符合履行类型规则、库存数量超过所选仓库可用量时阻止提交并提示错误。
+13. 后端通过 `POST /api/shipping-demands/:id/confirm-allocation` 专用动作端点确认分配，不新增通用状态 PATCH，不允许前端直接提交目标状态。
+14. 后端仅允许 `pending_allocation` 的发货需求确认分配；所有行必须提交且不能重复，重复确认不得再次锁定库存。
+15. 使用现有库存或部分采购的库存数量必须调用 `InventoryService.lockStockInTransaction()` 在事务中按 FIFO 锁定库存，不绕过库存服务直接写 `inventory_summary` 或 `inventory_batch`。
+16. 库存锁定成功后写入 `shipping_demand_inventory_allocations` 批次级分配记录和 `inventory_transactions` 锁定流水；明细回填 `fulfillment_type`、`stock_required_quantity`、`purchase_required_quantity`、`locked_remaining_quantity`。
+17. 确认分配后，若无采购数量则发货需求状态推进为 `prepared` 且销售订单推进为 `prepared`；若存在采购数量则发货需求推进为 `purchasing`。
+18. 成功后前端展示 `Notification.success`，刷新发货需求详情、发货需求列表和操作记录，KPI 与库存状态随详情结果更新。
+19. 并发冲突或重复键冲突按指数退避最多 3 次重试，超限返回 `ConflictException({ code: 'CONCURRENT_UPDATE' })`。
 
 ## Tasks / Subtasks
 
@@ -46,6 +56,12 @@ so that 我可以在一个详情页掌握发货需求全貌，并为后续库存
   - [x] 补齐基础信息、订单信息、收发通、发货要求字段区块。
   - [x] 产品明细表对齐销售订单详情字段并加入履约/库存列。
   - [x] 保持操作记录使用统一 `ActivityTimeline`。
+- [x] 确认分配闭环纠偏（AC: 10-19）
+  - [x] 新增发货需求库存分配表、库存流水表、共享分配状态枚举和迁移。
+  - [x] 新增确认分配 DTO 与 `POST /shipping-demands/:id/confirm-allocation` 动作端点。
+  - [x] 后端事务内校验履行类型和数量，调用 `InventoryService.lockStockInTransaction()` 完成 FIFO 锁定。
+  - [x] 写入批次级 allocation、库存锁定流水和操作日志，并按采购数量推进发货需求/销售订单状态。
+  - [x] 前端支持履行类型编辑、仓库选择、库存数量输入、FIFO 批次预览、提交前校验、成功通知和刷新。
 - [x] 验证与记录
   - [x] 运行后端发货需求定向测试。
   - [x] 运行 API/Web 构建验证。
@@ -67,9 +83,9 @@ so that 我可以在一个详情页掌握发货需求全貌，并为后续库存
 
 - 发货需求由销售订单审核通过后手动触发生成，详情页只展示生成结果和后续决策上下文。
 - 发货需求是履约数量权威单据；销售订单明细上的履约数量只能作为展示缓存或聚合结果。
-- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、后续库存分配表和库存流水。
+- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、`shipping_demand_inventory_allocations` 和 `inventory_transactions`。
 - 状态推进必须由领域动作服务在事务内根据数量聚合触发；前端不得直接提交目标状态。
-- 库存锁定必须使用 `InventoryService` 的事务/行锁能力，并在具备分配表和库存流水后记录批次级分配；本 Story 不新增伪锁定。
+- 库存锁定必须使用 `InventoryService` 的事务/行锁能力，并记录批次级分配和锁定流水；本 Story 不新增伪锁定。
 - 禁止临时库存表、mock 库存 API、硬编码库存数据或重复定义 `ShippingDemandStatus`/`FulfillmentType`。
 
 ### Existing Implementation Context
@@ -79,6 +95,7 @@ so that 我可以在一个详情页掌握发货需求全貌，并为后续库存
 - 当前 `shipping_demands` 主表已经保存部分销售订单镜像字段，但缺少销售订单详情里的联系人、行业、汇率、附件、清关/唛头/收发通等字段；前端详情页展示字段更少。
 - 当前 `shipping_demand_items` 已经保存产品明细大部分字段，但前端详情页没有完全展示采购人员、是否需要采购、金额、单位、重量体积、图片等字段。
 - 当前下游采购订单、物流单、出库单模块尚未有页面路由；SmartButton 应作为枢纽占位和未来入口，不应跳转不存在页面。
+- Story 5.4 纠偏后已经建立 `shipping_demand_inventory_allocations` 和 `inventory_transactions`，供后续作废释放、采购收货自动锁定、出库消费分配继续使用。
 
 ### Field Reference Check
 
@@ -93,9 +110,9 @@ so that 我可以在一个详情页掌握发货需求全貌，并为后续库存
 
 - 不实现采购订单创建、物流单创建、出库单创建。
 - 不实现发货需求作废完整逻辑。
-- 不实现库存分配表和库存流水。
 - 不新增通用 `PATCH /shipping-demands/:id` 状态修改。
 - 不在前端伪造库存锁定成功或修改库存数量。
+- 不让前端指定具体批次；前端只预览 FIFO 批次，实际分配以后端锁定结果为准。
 
 ## Dev Agent Record
 
@@ -118,24 +135,38 @@ GPT-5 Codex
 - `ShippingDemandsService.findById()` 已返回合同文件、插头照片、唛头模板的签名 URL，逻辑与销售订单详情一致。
 - 前端发货需求详情已升级为枢纽视图：FlowProgress、SmartButton、KPI、库存状态指示、完整基础/订单/收发通/发货要求区块。
 - 产品明细表已对齐销售订单详情字段，并加入履约数量、采购下单/收货数量、库存快照和库存颜色标签。
+- 已按纠偏方案补齐 Epic 5.4 的确认分配闭环：履行类型编辑、确认分配按钮、确认分配接口、FIFO 锁定、批次级 allocation、库存流水、操作日志、前端校验和成功刷新。
+- 待分配状态下，前端支持按所选仓库校验可用量，并展示该仓库的 FIFO 批次预览；后端仍是批次分配权威。
 - 下游采购订单、物流单、出库单页面尚未实现，SmartButton 保留 0 计数禁用态，避免跳转不存在路由。
 - Code review 已完成并修复来源销售订单入口在详情数据未加载时可能跳转到无效路由的问题。
-- 定向测试通过：`pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`，2 个测试套件、10 个用例通过。
+- 本轮 Code review 已完成，修复 Story 文档仍停留在只读边界、前端仓库校验使用总库存、非待分配状态展示草稿仓库的问题，并补充库存不足回滚测试。
+- 定向测试通过：`pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`，2 个测试套件、14 个用例通过。
 - 构建验证通过：`pnpm --filter api build`、`pnpm --filter web build`。Web build 仍有既有 Vite chunk size 警告。
 
 ### File List
 
 - `_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md`
+- `_bmad-output/implementation-artifacts/spec-5-4-shipping-demand-confirm-allocation.md`
 - `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-28-story-5-4-correct-course.md`
 - `apps/api/src/migrations/20260428000200-add-detail-fields-to-shipping-demands.ts`
+- `apps/api/src/migrations/20260428000300-create-shipping-demand-inventory-allocations.ts`
+- `apps/api/src/migrations/20260428000400-create-inventory-transactions.ts`
+- `apps/api/src/modules/inventory/entities/inventory-transaction.entity.ts`
+- `apps/api/src/modules/inventory/inventory.module.ts`
+- `apps/api/src/modules/shipping-demands/dto/confirm-shipping-demand-allocation.dto.ts`
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts`
 - `apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts`
 - `apps/api/src/modules/shipping-demands/entities/shipping-demand-item.entity.ts`
+- `apps/api/src/modules/shipping-demands/shipping-demands.controller.ts`
 - `apps/api/src/modules/shipping-demands/shipping-demands.module.ts`
 - `apps/api/src/modules/shipping-demands/shipping-demands.service.ts`
 - `apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts`
 - `apps/web/src/api/shipping-demands.api.ts`
 - `apps/web/src/pages/master-data/master-page.css`
 - `apps/web/src/pages/shipping-demands/detail.tsx`
+- `packages/shared/src/enums/shipping-demand-allocation-status.enum.ts`
+- `packages/shared/src/index.ts`
 
 ## Change Log
 
@@ -144,3 +175,4 @@ GPT-5 Codex
 | 2026-04-28 | 0.1 | 创建 Story 5.4，按用户备注收窄为已有详情页字段和枢纽展示补齐 | GPT-5 Codex |
 | 2026-04-28 | 1.0 | 完成发货需求详情字段补齐、枢纽展示、附件签名 URL 和本地验证 | GPT-5 Codex |
 | 2026-04-28 | 1.1 | 完成 code review，修复来源销售订单入口加载态无效跳转 | GPT-5 Codex |
+| 2026-04-28 | 2.0 | 完成 Epic 5.4 纠偏：确认分配、FIFO 锁定、库存流水、前端校验和成功刷新 | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/spec-5-4-shipping-demand-confirm-allocation.md
+++ b/_bmad-output/implementation-artifacts/spec-5-4-shipping-demand-confirm-allocation.md
@@ -1,0 +1,79 @@
+---
+title: 'Story 5.4 发货需求确认分配纠偏'
+type: 'feature'
+created: '2026-04-28'
+status: 'done'
+baseline_commit: '3cfae3d3c3df6c70e85da95b8dbe83a6db608a7e'
+context:
+  - '_bmad-output/planning-artifacts/epics.md'
+  - '_bmad-output/planning-artifacts/flow-quantity-data-lineage.md'
+  - '_bmad-output/planning-artifacts/flow-state-machine.md'
+  - '_bmad-output/planning-artifacts/flow-cross-document-trigger.md'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** 当前 Story 5.4 实现只完成发货需求详情字段补齐和只读枢纽展示，未满足 Epic 5.4 的操作按钮、履行类型编辑、确认分配、FIFO 库存锁定和成功刷新要求。
+
+**Approach:** 保留当前字段补齐成果作为 5.4 第一部分，继续补齐确认分配闭环：前端可编辑履行类型并提交，后端通过专用动作端点在事务中持久化分配、调用现有 InventoryService FIFO 锁定库存、更新发货需求明细和状态，并记录操作轨迹。
+
+## Boundaries & Constraints
+
+**Always:** 遵守 Epic 5-7 三份 flow 文档；状态推进必须由后端领域动作完成；库存写操作必须使用 QueryRunner 事务和现有 InventoryService 行锁能力；锁定结果必须写入发货需求库存分配表，不能只改明细缓存数量；前端 API 调用必须走 `apps/web/src/api`。
+
+**Ask First:** 如果发现必须重构 InventoryService 公共事务模型、大幅改动库存基础表、或需要提前实现完整采购/物流/出库模块，先暂停确认。
+
+**Never:** 不新增 mock 库存 API；不通过通用 PATCH 直接改状态；不重复定义共享枚举；不回滚已完成的详情字段补齐；不实现 Story 5.5 的作废和完整物流创建。
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| 全部使用库存 | 发货需求 `pending_allocation`，所有行选择 `use_stock` 且库存足够 | 写入 allocation，明细 `locked_remaining_quantity = required_quantity`，需求状态进入 `prepared`，详情刷新 KPI | N/A |
+| 部分采购 | 至少一行选择 `partial_purchase` 或 `full_purchase` | 库存部分锁定，采购部分写入 `purchase_required_quantity`，需求状态进入 `purchasing` | N/A |
+| 未选履行类型 | 任一行缺少履行类型 | 阻止提交，提示需完整设置 | 前端内联/消息提示，后端 400 |
+| 库存不足 | 提交的库存使用量超过可用库存 | 不产生重复锁定，返回 SKU/可用量相关错误 | 后端 400 `STOCK_INSUFFICIENT`，前端显示错误 |
+| 重复确认 | 需求已离开 `pending_allocation` 后再次提交 | 不再次锁定库存 | 后端返回业务错误 |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `apps/api/src/modules/shipping-demands/shipping-demands.controller.ts` -- 发货需求动作端点入口。
+- `apps/api/src/modules/shipping-demands/shipping-demands.service.ts` -- 生成、详情、确认分配事务逻辑。
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand-item.entity.ts` -- 履行数量缓存字段已存在。
+- `apps/api/src/modules/inventory/inventory.service.ts` -- 已有 FIFO 锁定、解锁、扣减和并发重试能力。
+- `apps/api/src/modules/inventory/entities/inventory-batch.entity.ts` -- 批次锁定数量权威字段。
+- `apps/web/src/pages/shipping-demands/detail.tsx` -- 发货需求详情枢纽 UI。
+- `apps/web/src/api/shipping-demands.api.ts` -- 前端发货需求 API 类型和动作调用。
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts` -- 新增发货需求库存分配实体，保存需求明细到仓库/批次的锁定结果。
+- [x] `apps/api/src/migrations/*shipping-demand-inventory-allocations*.ts` -- 新增分配表迁移。
+- [x] `apps/api/src/modules/shipping-demands/dto/confirm-shipping-demand-allocation.dto.ts` -- 新增确认分配输入 DTO。
+- [x] `apps/api/src/modules/shipping-demands/shipping-demands.service.ts` -- 新增确认分配事务、校验、FIFO 锁定、状态推进和操作日志。
+- [x] `apps/api/src/modules/shipping-demands/shipping-demands.controller.ts` -- 新增 `POST /shipping-demands/:id/confirm-allocation` 动作端点。
+- [x] `apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts` -- 覆盖全部库存、部分采购、状态防重复和库存不足。
+- [x] `apps/web/src/api/shipping-demands.api.ts` -- 新增确认分配 payload 类型和 API 函数。
+- [x] `apps/web/src/pages/shipping-demands/detail.tsx` -- 新增履行类型编辑、所选仓库库存使用数量校验、FIFO 批次预览、确认分配按钮和成功刷新。
+- [x] `_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md` -- 更新 Story 记录，移除“只读完成”的错误终态，记录纠偏完成。
+
+**Acceptance Criteria:**
+- Given 发货需求处于 `pending_allocation`，when 用户完成履行类型选择并确认分配，then 后端持久化履行类型、库存/采购数量、批次 allocation，并按结果推进状态。
+- Given 有库存使用数量，when 确认分配，then 系统按 FIFO 锁定库存并刷新详情 KPI。
+- Given 需求已确认分配，when 再次提交，then 不重复锁定库存并返回业务错误。
+
+## Design Notes
+
+本次只实现 Story 5.4 的确认分配闭环。采购订单创建、物流单创建、作废释放库存、出库消费 allocation 属于后续 Story，但 allocation 表必须现在建立，避免后续只能从明细缓存反推批次。
+
+## Verification
+
+**Commands:**
+- `pnpm --filter api exec jest modules/shipping-demands/tests --runInBand` -- passed: 2 个测试套件、14 个用例通过。
+- `pnpm --filter api build` -- passed: TypeScript 编译通过。
+- `pnpm --filter web build` -- passed: 前端构建通过；保留既有 Vite chunk size warning。

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-28 (story-5.3-done)
+# last_updated: 2026-04-28 (story-5.4-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-04-28 (story-5.3-done)
+last_updated: 2026-04-28 (story-5.4-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -111,7 +111,7 @@ development_status:
   5-0-库存双层结构查询接口与期初录入: done
   5-2-销售订单列表与详情: done
   5-3-发货需求列表页: done
-  5-4-发货需求枢纽详情页: backlog
+  5-4-发货需求枢纽详情页: done
   5-5-发货需求下游入口与完整作废逻辑: backlog
   epic-5-retrospective: optional
 

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-28-story-5-4-correct-course.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-28-story-5-4-correct-course.md
@@ -1,0 +1,112 @@
+# Sprint Change Proposal: Story 5.4 发货需求枢纽详情页纠偏
+
+Date: 2026-04-28
+Project: infitek_erp
+Owner: friday
+
+## 1. Issue Summary
+
+Story 5.4 已实现并提交为“发货需求详情字段补齐 + 只读枢纽展示”，但与 `_bmad-output/planning-artifacts/epics.md` 中 Story 5.4 的原验收标准存在偏差。Epic 5.4 要求“含完整库存锁定”：用户应能在发货需求详情页为每个 SKU 设置履行类型，集中确认分配，并由系统按 FIFO 锁定库存。
+
+发现证据：
+
+- 当前实现的 story 文件在 `Scope Adjustment` 中主动排除了库存写操作、确认分配、采购/物流/出库创建。
+- 当前前端只读展示 `fulfillmentType`，没有履行类型选择器、内联仓库/批次分配区和“确认分配”按钮。
+- 当前后端 `ShippingDemandsController` 仅提供列表、详情、从销售订单生成接口，缺少确认分配动作端点。
+- 库存模块已有 `InventoryService.lockStockInTransaction()`、FIFO 批次锁定、库存汇总刷新、并发重试能力；因此不应继续把 5.4 缩减为只读详情。
+
+问题类型：对原 Story 5.4 范围的误解和实现收窄，需要在当前 sprint 中纠偏。
+
+## 2. Impact Analysis
+
+### Epic Impact
+
+Epic 5 仍可按原计划完成，无需新增 Epic 或重新排序。当前实现可保留为 Story 5.4 的第一部分：销售订单镜像字段、附件 URL、FlowProgress、SmartButton 占位、KPI 和产品明细展示。
+
+需要补齐的 Epic 5.4 验收点：
+
+- 产品明细行履行类型选择器。
+- “使用现有库存 / 部分采购”对应的库存使用数量确认。
+- 页面底部或顶部操作区“确认分配”按钮。
+- 后端确认分配动作端点。
+- FIFO 锁定库存，写入发货需求库存分配记录。
+- 更新发货需求明细 `stock_required_quantity`、`purchase_required_quantity`、`locked_remaining_quantity`。
+- 根据分配结果将发货需求状态推进为 `purchasing` 或 `prepared`。
+- 刷新详情页 InventoryIndicator 和 KPI。
+- ActivityTimeline 记录确认分配/库存锁定事件。
+
+Story 5.5、Epic 6、Epic 7 依赖本次补齐后的库存分配结果，尤其是后续采购、物流计划、出库确认要消费 `shipping_demand_inventory_allocations`。
+
+### Artifact Conflicts
+
+- PRD：不需要修改。FR26、FR27、FR30、FR42、FR49 的方向仍然成立。
+- Epics：不需要缩小 Story 5.4；应按原 Epic 5.4 补实现。
+- Architecture：需要落实 flow 文档中要求的库存分配表，而不是只在明细上写锁定数量。
+- UX：需要补齐 UX-DR26 的操作按钮直达和履行类型选择体验。
+- Story 实现记录：需要将当前 Story 5.4 从“只读字段补齐”改为“第一部分已完成，继续补齐确认分配闭环”，完成后再标记 done。
+
+## 3. Recommended Approach
+
+选择路径：Direct Adjustment。
+
+理由：
+
+- 当前实现没有破坏数据模型，字段补齐和详情展示可直接保留。
+- 库存基础模块已存在，补齐确认分配主要是把发货需求领域动作接入现有 InventoryService。
+- 回滚当前提交不会降低复杂度，反而会丢失已完成的详情字段价值。
+- 不需要重新定义 MVP，仅需完成 Epic 5.4 的原验收标准。
+
+范围分类：Minor to Moderate。由 Developer agent 直接继续实现，之后运行单测、构建和 code review。
+
+## 4. Detailed Change Proposals
+
+### Story 5.4 Acceptance Criteria
+
+OLD:
+
+- 本 Story 不新增库存写操作、临时库存表、mock 库存 API、重复枚举、通用状态 PATCH；库存锁定和状态推进留待具备分配表/库存流水后的领域动作实现。
+
+NEW:
+
+- 本 Story 保留已完成的详情字段补齐，同时补齐 Epic 5.4 的确认分配闭环：履行类型编辑、确认分配动作端点、FIFO 库存锁定、发货需求库存分配记录、明细数量回填、状态推进和操作记录。
+- 状态推进必须通过专用动作端点执行，不允许前端提交目标状态。
+- 库存锁定必须消费现有 `InventoryService` 的事务/行锁能力，并写入 `shipping_demand_inventory_allocations`，供后续出库和作废解锁消费。
+
+Rationale:
+
+Epic 5.4 原始验收标准明确要求“含完整库存锁定”。当前底座已有库存双层结构与 FIFO 锁定服务，继续保留只读边界会阻塞 Story 5.5、Epic 6 和 Epic 7。
+
+### Backend Proposal
+
+- 新增 `shipping_demand_inventory_allocations` 实体和迁移，字段包含：`shipping_demand_id`、`shipping_demand_item_id`、`sku_id`、`warehouse_id`、`inventory_batch_id`、`locked_quantity`、`shipped_quantity`、`status`、`source_action_key`。
+- 新增确认分配 DTO，行级字段包含 `itemId`、`fulfillmentType`、`stockQuantity`、`warehouseId`。
+- 新增动作端点：`POST /shipping-demands/:id/confirm-allocation`。
+- 后端校验发货需求必须处于 `pending_allocation`；所有行必须提交履行类型；数量满足 `required = stock + purchase`。
+- 对 `stockQuantity > 0` 的行调用 `InventoryService.lockStockInTransaction()` 按 FIFO 锁定，并保存返回的批次 allocation。
+- 更新发货需求明细和发货需求状态：有采购数量则 `purchasing`，否则 `prepared`。
+- 写入操作日志，记录状态、履行类型和库存锁定摘要。
+
+### Frontend Proposal
+
+- 产品明细表在 `pending_allocation` 状态显示履行类型 Select。
+- 根据履行类型自动计算默认库存使用数量：库存充足时默认使用库存，否则不足部分采购。
+- 提供仓库选择/使用数量输入，提交前校验必填和数量边界。
+- 增加 Primary“确认分配”按钮，Popconfirm 确认后调用动作端点。
+- 成功后 Notification.success，刷新发货需求详情和操作记录。
+- 非 `pending_allocation` 状态保持只读展示。
+
+## 5. Implementation Handoff
+
+执行角色：Developer agent。
+
+成功标准：
+
+- Story 5.4 不再只是只读详情；可在详情页完成履行类型决策和确认分配。
+- 后端通过事务完成 FIFO 锁定，写入分配表并更新明细缓存数量。
+- 发货需求状态按分配结果自动推进。
+- 前端成功提交后刷新 KPI、库存状态和操作记录。
+- 定向单测、API build、Web build 通过。
+
+## 6. Approval
+
+用户已明确批准方向：当前实现视为 5.4 第一部分，继续补齐 Epic 5.4 缺口，包括操作按钮、履行类型编辑、确认分配接口、FIFO 锁定、库存流水、前端校验和成功刷新，完成后再把 story 标成 done。

--- a/apps/api/src/__mocks__/infitek-shared.ts
+++ b/apps/api/src/__mocks__/infitek-shared.ts
@@ -82,6 +82,14 @@ export const ShippingDemandStatus = {
 export type ShippingDemandStatus =
   (typeof ShippingDemandStatus)[keyof typeof ShippingDemandStatus];
 
+export const ShippingDemandAllocationStatus = {
+  ACTIVE: 'active',
+  RELEASED: 'released',
+  SHIPPED: 'shipped',
+} as const;
+export type ShippingDemandAllocationStatus =
+  (typeof ShippingDemandAllocationStatus)[keyof typeof ShippingDemandAllocationStatus];
+
 export const FulfillmentType = {
   FULL_PURCHASE: 'full_purchase',
   PARTIAL_PURCHASE: 'partial_purchase',

--- a/apps/api/src/migrations/20260428000200-add-detail-fields-to-shipping-demands.ts
+++ b/apps/api/src/migrations/20260428000200-add-detail-fields-to-shipping-demands.ts
@@ -1,0 +1,173 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  TableColumn,
+  TableForeignKey,
+} from 'typeorm';
+
+export class AddDetailFieldsToShippingDemands20260428000200
+  implements MigrationInterface
+{
+  name = 'AddDetailFieldsToShippingDemands20260428000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('shipping_demands', [
+      new TableColumn({ name: 'order_source', type: 'varchar', length: '30', isNullable: true }),
+      new TableColumn({ name: 'external_order_code', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'customer_contact_person', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'after_sales_source_order_id', type: 'bigint', unsigned: true, isNullable: true }),
+      new TableColumn({ name: 'after_sales_source_order_code', type: 'varchar', length: '32', isNullable: true }),
+      new TableColumn({ name: 'after_sales_product_summary', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'bank_account', type: 'varchar', length: '255', isNullable: true }),
+      new TableColumn({ name: 'extra_viewer_id', type: 'bigint', unsigned: true, isNullable: true }),
+      new TableColumn({ name: 'extra_viewer_name', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'primary_industry', type: 'varchar', length: '50', isNullable: true }),
+      new TableColumn({ name: 'secondary_industry', type: 'varchar', length: '50', isNullable: true }),
+      new TableColumn({ name: 'exchange_rate', type: 'decimal', precision: 18, scale: 6, isNullable: true }),
+      new TableColumn({ name: 'crm_signed_at', type: 'date', isNullable: true }),
+      new TableColumn({ name: 'is_split_in_advance', type: 'varchar', length: '10', isNullable: true }),
+      new TableColumn({ name: 'requires_maternity_handover', type: 'varchar', length: '10', isNullable: true }),
+      new TableColumn({ name: 'customs_declaration_method', type: 'varchar', length: '30', isNullable: true }),
+      new TableColumn({ name: 'ali_trade_assurance_order_code', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'forwarder_quote_note', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'contract_file_keys', type: 'json', isNullable: true }),
+      new TableColumn({ name: 'contract_file_names', type: 'json', isNullable: true }),
+      new TableColumn({ name: 'plug_photo_keys', type: 'json', isNullable: true }),
+      new TableColumn({ name: 'consignee_company', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'consignee_other_info', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'notify_company', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'notify_other_info', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'shipper_company', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'shipper_other_info_company_id', type: 'bigint', unsigned: true, isNullable: true }),
+      new TableColumn({ name: 'shipper_other_info_company_name', type: 'varchar', length: '200', isNullable: true }),
+      new TableColumn({ name: 'domestic_customer_company', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'domestic_customer_delivery_info', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'uses_default_shipping_mark', type: 'varchar', length: '10', isNullable: true }),
+      new TableColumn({ name: 'shipping_mark_note', type: 'varchar', length: '255', isNullable: true }),
+      new TableColumn({ name: 'shipping_mark_template_key', type: 'varchar', length: '255', isNullable: true }),
+      new TableColumn({ name: 'needs_invoice', type: 'varchar', length: '10', isNullable: true }),
+      new TableColumn({ name: 'invoice_type', type: 'varchar', length: '30', isNullable: true }),
+      new TableColumn({ name: 'shipping_documents_note', type: 'varchar', length: '500', isNullable: true }),
+      new TableColumn({ name: 'bl_type', type: 'varchar', length: '30', isNullable: true }),
+      new TableColumn({ name: 'original_mail_address', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'business_rectification_note', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'customs_document_note', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'other_requirement_note', type: 'text', isNullable: true }),
+      new TableColumn({ name: 'product_total_amount', type: 'decimal', precision: 18, scale: 2, default: 0 }),
+      new TableColumn({ name: 'expense_total_amount', type: 'decimal', precision: 18, scale: 2, default: 0 }),
+    ]);
+
+    await queryRunner.addColumns('shipping_demand_items', [
+      new TableColumn({ name: 'purchaser_id', type: 'bigint', unsigned: true, isNullable: true }),
+      new TableColumn({ name: 'purchaser_name', type: 'varchar', length: '100', isNullable: true }),
+      new TableColumn({ name: 'needs_purchase', type: 'varchar', length: '10', isNullable: true }),
+    ]);
+
+    await queryRunner.createForeignKeys('shipping_demands', [
+      new TableForeignKey({
+        columnNames: ['after_sales_source_order_id'],
+        referencedTableName: 'sales_orders',
+        referencedColumnNames: ['id'],
+      }),
+      new TableForeignKey({
+        columnNames: ['extra_viewer_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+      }),
+      new TableForeignKey({
+        columnNames: ['shipper_other_info_company_id'],
+        referencedTableName: 'companies',
+        referencedColumnNames: ['id'],
+      }),
+    ]);
+
+    await queryRunner.createForeignKey(
+      'shipping_demand_items',
+      new TableForeignKey({
+        columnNames: ['purchaser_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const demandTable = await queryRunner.getTable('shipping_demands');
+    const itemTable = await queryRunner.getTable('shipping_demand_items');
+
+    for (const columnName of [
+      'after_sales_source_order_id',
+      'extra_viewer_id',
+      'shipper_other_info_company_id',
+    ]) {
+      const foreignKey = demandTable?.foreignKeys.find((key) =>
+        key.columnNames.includes(columnName),
+      );
+      if (foreignKey) {
+        await queryRunner.dropForeignKey('shipping_demands', foreignKey);
+      }
+    }
+
+    const purchaserForeignKey = itemTable?.foreignKeys.find((key) =>
+      key.columnNames.includes('purchaser_id'),
+    );
+    if (purchaserForeignKey) {
+      await queryRunner.dropForeignKey(
+        'shipping_demand_items',
+        purchaserForeignKey,
+      );
+    }
+
+    await queryRunner.dropColumns('shipping_demand_items', [
+      'purchaser_id',
+      'purchaser_name',
+      'needs_purchase',
+    ]);
+
+    await queryRunner.dropColumns('shipping_demands', [
+      'order_source',
+      'external_order_code',
+      'customer_contact_person',
+      'after_sales_source_order_id',
+      'after_sales_source_order_code',
+      'after_sales_product_summary',
+      'bank_account',
+      'extra_viewer_id',
+      'extra_viewer_name',
+      'primary_industry',
+      'secondary_industry',
+      'exchange_rate',
+      'crm_signed_at',
+      'is_split_in_advance',
+      'requires_maternity_handover',
+      'customs_declaration_method',
+      'ali_trade_assurance_order_code',
+      'forwarder_quote_note',
+      'contract_file_keys',
+      'contract_file_names',
+      'plug_photo_keys',
+      'consignee_company',
+      'consignee_other_info',
+      'notify_company',
+      'notify_other_info',
+      'shipper_company',
+      'shipper_other_info_company_id',
+      'shipper_other_info_company_name',
+      'domestic_customer_company',
+      'domestic_customer_delivery_info',
+      'uses_default_shipping_mark',
+      'shipping_mark_note',
+      'shipping_mark_template_key',
+      'needs_invoice',
+      'invoice_type',
+      'shipping_documents_note',
+      'bl_type',
+      'original_mail_address',
+      'business_rectification_note',
+      'customs_document_note',
+      'other_requirement_note',
+      'product_total_amount',
+      'expense_total_amount',
+    ]);
+  }
+}

--- a/apps/api/src/migrations/20260428000300-create-shipping-demand-inventory-allocations.ts
+++ b/apps/api/src/migrations/20260428000300-create-shipping-demand-inventory-allocations.ts
@@ -1,0 +1,96 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateShippingDemandInventoryAllocations20260428000300
+  implements MigrationInterface
+{
+  name = 'CreateShippingDemandInventoryAllocations20260428000300';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'shipping_demand_inventory_allocations',
+        columns: [
+          { name: 'id', type: 'bigint', unsigned: true, isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+          { name: 'shipping_demand_id', type: 'bigint', unsigned: true },
+          { name: 'shipping_demand_item_id', type: 'bigint', unsigned: true },
+          { name: 'sales_order_item_id', type: 'bigint', unsigned: true },
+          { name: 'sku_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'inventory_batch_id', type: 'bigint', unsigned: true },
+          { name: 'lock_source', type: 'varchar', length: '40' },
+          { name: 'source_document_type', type: 'varchar', length: '40' },
+          { name: 'source_document_id', type: 'bigint', unsigned: true },
+          { name: 'original_locked_quantity', type: 'int', default: 0 },
+          { name: 'locked_quantity', type: 'int', default: 0 },
+          { name: 'shipped_quantity', type: 'int', default: 0 },
+          { name: 'released_quantity', type: 'int', default: 0 },
+          { name: 'status', type: 'varchar', length: '20' },
+          { name: 'source_action_key', type: 'varchar', length: '120' },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' },
+          { name: 'created_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'updated_by', type: 'varchar', length: '100', isNullable: true },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('shipping_demand_inventory_allocations', [
+      new TableIndex({ name: 'idx_sd_allocations_demand_id', columnNames: ['shipping_demand_id'] }),
+      new TableIndex({ name: 'idx_sd_allocations_item_id', columnNames: ['shipping_demand_item_id'] }),
+      new TableIndex({ name: 'idx_sd_allocations_sku_warehouse', columnNames: ['sku_id', 'warehouse_id'] }),
+      new TableIndex({ name: 'idx_sd_allocations_batch_id', columnNames: ['inventory_batch_id'] }),
+      new TableIndex({ name: 'idx_sd_allocations_status', columnNames: ['status'] }),
+      new TableIndex({ name: 'uq_sd_allocations_action_batch', columnNames: ['source_action_key', 'inventory_batch_id'], isUnique: true }),
+    ]);
+
+    await queryRunner.createForeignKeys('shipping_demand_inventory_allocations', [
+      new TableForeignKey({
+        columnNames: ['shipping_demand_id'],
+        referencedTableName: 'shipping_demands',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['shipping_demand_item_id'],
+        referencedTableName: 'shipping_demand_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['sales_order_item_id'],
+        referencedTableName: 'sales_order_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['sku_id'],
+        referencedTableName: 'skus',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['warehouse_id'],
+        referencedTableName: 'warehouses',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['inventory_batch_id'],
+        referencedTableName: 'inventory_batch',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('shipping_demand_inventory_allocations');
+  }
+}

--- a/apps/api/src/migrations/20260428000400-create-inventory-transactions.ts
+++ b/apps/api/src/migrations/20260428000400-create-inventory-transactions.ts
@@ -1,0 +1,77 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateInventoryTransactions20260428000400
+  implements MigrationInterface
+{
+  name = 'CreateInventoryTransactions20260428000400';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'inventory_transactions',
+        columns: [
+          { name: 'id', type: 'bigint', unsigned: true, isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+          { name: 'sku_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'inventory_batch_id', type: 'bigint', unsigned: true, isNullable: true },
+          { name: 'change_type', type: 'varchar', length: '30' },
+          { name: 'actual_quantity_delta', type: 'int', default: 0 },
+          { name: 'locked_quantity_delta', type: 'int', default: 0 },
+          { name: 'available_quantity_delta', type: 'int', default: 0 },
+          { name: 'before_actual_quantity', type: 'int', default: 0 },
+          { name: 'after_actual_quantity', type: 'int', default: 0 },
+          { name: 'before_locked_quantity', type: 'int', default: 0 },
+          { name: 'after_locked_quantity', type: 'int', default: 0 },
+          { name: 'before_available_quantity', type: 'int', default: 0 },
+          { name: 'after_available_quantity', type: 'int', default: 0 },
+          { name: 'source_document_type', type: 'varchar', length: '40' },
+          { name: 'source_document_id', type: 'bigint', unsigned: true },
+          { name: 'source_document_item_id', type: 'bigint', unsigned: true, isNullable: true },
+          { name: 'source_action_key', type: 'varchar', length: '160' },
+          { name: 'operated_by', type: 'varchar', length: '100', isNullable: true },
+          { name: 'operated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('inventory_transactions', [
+      new TableIndex({ name: 'idx_inventory_transactions_sku_warehouse', columnNames: ['sku_id', 'warehouse_id'] }),
+      new TableIndex({ name: 'idx_inventory_transactions_change_type', columnNames: ['change_type'] }),
+      new TableIndex({ name: 'idx_inventory_transactions_source', columnNames: ['source_document_type', 'source_document_id'] }),
+      new TableIndex({ name: 'uq_inventory_transactions_action_key', columnNames: ['source_action_key'], isUnique: true }),
+      new TableIndex({ name: 'idx_inventory_transactions_created_at', columnNames: ['operated_at'] }),
+    ]);
+
+    await queryRunner.createForeignKeys('inventory_transactions', [
+      new TableForeignKey({
+        columnNames: ['sku_id'],
+        referencedTableName: 'skus',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['warehouse_id'],
+        referencedTableName: 'warehouses',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['inventory_batch_id'],
+        referencedTableName: 'inventory_batch',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('inventory_transactions');
+  }
+}

--- a/apps/api/src/modules/inventory/entities/inventory-transaction.entity.ts
+++ b/apps/api/src/modules/inventory/entities/inventory-transaction.entity.ts
@@ -1,0 +1,91 @@
+import { Expose } from 'class-transformer';
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { InventoryChangeType } from '@infitek/shared';
+
+@Entity('inventory_transactions')
+@Index('idx_inventory_transactions_sku_warehouse', ['skuId', 'warehouseId'])
+@Index('idx_inventory_transactions_change_type', ['changeType'])
+@Index('idx_inventory_transactions_source', ['sourceDocumentType', 'sourceDocumentId'])
+@Index('uq_inventory_transactions_action_key', ['sourceActionKey'], { unique: true })
+@Index('idx_inventory_transactions_created_at', ['operatedAt'])
+export class InventoryTransaction {
+  @PrimaryGeneratedColumn({ type: 'bigint', unsigned: true })
+  @Expose()
+  id: number;
+
+  @Column({ name: 'sku_id', type: 'bigint', unsigned: true })
+  @Expose()
+  skuId: number;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'inventory_batch_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  inventoryBatchId: number | null;
+
+  @Column({ name: 'change_type', type: 'varchar', length: 30 })
+  @Expose()
+  changeType: InventoryChangeType;
+
+  @Column({ name: 'actual_quantity_delta', type: 'int', default: 0 })
+  @Expose()
+  actualQuantityDelta: number;
+
+  @Column({ name: 'locked_quantity_delta', type: 'int', default: 0 })
+  @Expose()
+  lockedQuantityDelta: number;
+
+  @Column({ name: 'available_quantity_delta', type: 'int', default: 0 })
+  @Expose()
+  availableQuantityDelta: number;
+
+  @Column({ name: 'before_actual_quantity', type: 'int', default: 0 })
+  @Expose()
+  beforeActualQuantity: number;
+
+  @Column({ name: 'after_actual_quantity', type: 'int', default: 0 })
+  @Expose()
+  afterActualQuantity: number;
+
+  @Column({ name: 'before_locked_quantity', type: 'int', default: 0 })
+  @Expose()
+  beforeLockedQuantity: number;
+
+  @Column({ name: 'after_locked_quantity', type: 'int', default: 0 })
+  @Expose()
+  afterLockedQuantity: number;
+
+  @Column({ name: 'before_available_quantity', type: 'int', default: 0 })
+  @Expose()
+  beforeAvailableQuantity: number;
+
+  @Column({ name: 'after_available_quantity', type: 'int', default: 0 })
+  @Expose()
+  afterAvailableQuantity: number;
+
+  @Column({ name: 'source_document_type', type: 'varchar', length: 40 })
+  @Expose()
+  sourceDocumentType: string;
+
+  @Column({ name: 'source_document_id', type: 'bigint', unsigned: true })
+  @Expose()
+  sourceDocumentId: number;
+
+  @Column({ name: 'source_document_item_id', type: 'bigint', unsigned: true, nullable: true })
+  @Expose()
+  sourceDocumentItemId: number | null;
+
+  @Column({ name: 'source_action_key', type: 'varchar', length: 160 })
+  @Expose()
+  sourceActionKey: string;
+
+  @Column({ name: 'operated_by', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  operatedBy: string | null;
+
+  @CreateDateColumn({ name: 'operated_at' })
+  @Expose()
+  operatedAt: Date;
+}

--- a/apps/api/src/modules/inventory/inventory.module.ts
+++ b/apps/api/src/modules/inventory/inventory.module.ts
@@ -4,13 +4,14 @@ import { SkusModule } from '../master-data/skus/skus.module';
 import { WarehousesModule } from '../master-data/warehouses/warehouses.module';
 import { InventoryBatch } from './entities/inventory-batch.entity';
 import { InventorySummary } from './entities/inventory-summary.entity';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
 import { InventoryController } from './inventory.controller';
 import { InventoryRepository } from './inventory.repository';
 import { InventoryService } from './inventory.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([InventorySummary, InventoryBatch]),
+    TypeOrmModule.forFeature([InventorySummary, InventoryBatch, InventoryTransaction]),
     SkusModule,
     WarehousesModule,
   ],

--- a/apps/api/src/modules/shipping-demands/dto/confirm-shipping-demand-allocation.dto.ts
+++ b/apps/api/src/modules/shipping-demands/dto/confirm-shipping-demand-allocation.dto.ts
@@ -1,0 +1,38 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayNotEmpty,
+  IsIn,
+  IsInt,
+  IsOptional,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { FulfillmentType } from '@infitek/shared';
+
+export class ConfirmShippingDemandAllocationItemDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  itemId: number;
+
+  @IsIn(Object.values(FulfillmentType))
+  fulfillmentType: FulfillmentType;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  stockQuantity: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  warehouseId?: number;
+}
+
+export class ConfirmShippingDemandAllocationDto {
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => ConfirmShippingDemandAllocationItemDto)
+  items: ConfirmShippingDemandAllocationItemDto[];
+}

--- a/apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts
+++ b/apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts
@@ -1,0 +1,90 @@
+import { Expose } from 'class-transformer';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { ShippingDemandAllocationStatus } from '@infitek/shared';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { InventoryBatch } from '../../inventory/entities/inventory-batch.entity';
+import { ShippingDemandItem } from './shipping-demand-item.entity';
+import { ShippingDemand } from './shipping-demand.entity';
+
+@Entity('shipping_demand_inventory_allocations')
+@Index('idx_sd_allocations_demand_id', ['shippingDemandId'])
+@Index('idx_sd_allocations_item_id', ['shippingDemandItemId'])
+@Index('idx_sd_allocations_sku_warehouse', ['skuId', 'warehouseId'])
+@Index('idx_sd_allocations_batch_id', ['inventoryBatchId'])
+@Index('idx_sd_allocations_status', ['status'])
+@Index('uq_sd_allocations_action_batch', ['sourceActionKey', 'inventoryBatchId'], {
+  unique: true,
+})
+export class ShippingDemandInventoryAllocation extends BaseEntity {
+  @Column({ name: 'shipping_demand_id', type: 'bigint', unsigned: true })
+  @Expose()
+  shippingDemandId: number;
+
+  @ManyToOne(() => ShippingDemand, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'shipping_demand_id' })
+  shippingDemand?: ShippingDemand;
+
+  @Column({ name: 'shipping_demand_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  shippingDemandItemId: number;
+
+  @ManyToOne(() => ShippingDemandItem, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'shipping_demand_item_id' })
+  shippingDemandItem?: ShippingDemandItem;
+
+  @Column({ name: 'sales_order_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  salesOrderItemId: number;
+
+  @Column({ name: 'sku_id', type: 'bigint', unsigned: true })
+  @Expose()
+  skuId: number;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'inventory_batch_id', type: 'bigint', unsigned: true })
+  @Expose()
+  inventoryBatchId: number;
+
+  @ManyToOne(() => InventoryBatch, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'inventory_batch_id' })
+  inventoryBatch?: InventoryBatch;
+
+  @Column({ name: 'lock_source', type: 'varchar', length: 40 })
+  @Expose()
+  lockSource: string;
+
+  @Column({ name: 'source_document_type', type: 'varchar', length: 40 })
+  @Expose()
+  sourceDocumentType: string;
+
+  @Column({ name: 'source_document_id', type: 'bigint', unsigned: true })
+  @Expose()
+  sourceDocumentId: number;
+
+  @Column({ name: 'original_locked_quantity', type: 'int', default: 0 })
+  @Expose()
+  originalLockedQuantity: number;
+
+  @Column({ name: 'locked_quantity', type: 'int', default: 0 })
+  @Expose()
+  lockedQuantity: number;
+
+  @Column({ name: 'shipped_quantity', type: 'int', default: 0 })
+  @Expose()
+  shippedQuantity: number;
+
+  @Column({ name: 'released_quantity', type: 'int', default: 0 })
+  @Expose()
+  releasedQuantity: number;
+
+  @Column({ name: 'status', type: 'varchar', length: 20 })
+  @Expose()
+  status: ShippingDemandAllocationStatus;
+
+  @Column({ name: 'source_action_key', type: 'varchar', length: 120 })
+  @Expose()
+  sourceActionKey: string;
+}

--- a/apps/api/src/modules/shipping-demands/entities/shipping-demand-item.entity.ts
+++ b/apps/api/src/modules/shipping-demands/entities/shipping-demand-item.entity.ts
@@ -88,6 +88,18 @@ export class ShippingDemandItem extends BaseEntity {
   @Expose()
   unitName: string | null;
 
+  @Column({ name: 'purchaser_id', type: 'bigint', nullable: true })
+  @Expose()
+  purchaserId: number | null;
+
+  @Column({ name: 'purchaser_name', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  purchaserName: string | null;
+
+  @Column({ name: 'needs_purchase', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  needsPurchase: YesNo | null;
+
   @Column({ name: 'required_quantity', type: 'int', default: 0 })
   @Expose()
   requiredQuantity: number;

--- a/apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts
+++ b/apps/api/src/modules/shipping-demands/entities/shipping-demand.entity.ts
@@ -1,11 +1,17 @@
 import { Expose } from 'class-transformer';
 import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, Unique } from 'typeorm';
 import {
+  BlType,
+  CustomsDeclarationMethod,
   DomesticTradeType,
+  InvoiceType,
   OrderNature,
   PaymentTerm,
+  PrimaryIndustry,
   ReceiptStatus,
   SalesOrderType,
+  SalesOrderSource,
+  SecondaryIndustry,
   ShippingDemandStatus,
   TradeTerm,
   TransportationMethod,
@@ -51,9 +57,17 @@ export class ShippingDemand extends BaseEntity {
   @Expose()
   orderType: SalesOrderType;
 
+  @Column({ name: 'order_source', type: 'varchar', length: 30, nullable: true })
+  @Expose()
+  orderSource: SalesOrderSource | null;
+
   @Column({ name: 'domestic_trade_type', type: 'varchar', length: 20 })
   @Expose()
   domesticTradeType: DomesticTradeType;
+
+  @Column({ name: 'external_order_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  externalOrderCode: string | null;
 
   @Column({ name: 'customer_id', type: 'bigint' })
   @Expose()
@@ -66,6 +80,22 @@ export class ShippingDemand extends BaseEntity {
   @Column({ name: 'customer_code', type: 'varchar', length: 50 })
   @Expose()
   customerCode: string;
+
+  @Column({ name: 'customer_contact_person', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  customerContactPerson: string | null;
+
+  @Column({ name: 'after_sales_source_order_id', type: 'bigint', nullable: true })
+  @Expose()
+  afterSalesSourceOrderId: number | null;
+
+  @Column({ name: 'after_sales_source_order_code', type: 'varchar', length: 32, nullable: true })
+  @Expose()
+  afterSalesSourceOrderCode: string | null;
+
+  @Column({ name: 'after_sales_product_summary', type: 'text', nullable: true })
+  @Expose()
+  afterSalesProductSummary: string | null;
 
   @Column({ name: 'currency_id', type: 'bigint', nullable: true })
   @Expose()
@@ -86,6 +116,34 @@ export class ShippingDemand extends BaseEntity {
   @Column({ name: 'trade_term', type: 'varchar', length: 10, nullable: true })
   @Expose()
   tradeTerm: TradeTerm | null;
+
+  @Column({ name: 'bank_account', type: 'varchar', length: 255, nullable: true })
+  @Expose()
+  bankAccount: string | null;
+
+  @Column({ name: 'extra_viewer_id', type: 'bigint', nullable: true })
+  @Expose()
+  extraViewerId: number | null;
+
+  @Column({ name: 'extra_viewer_name', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  extraViewerName: string | null;
+
+  @Column({ name: 'primary_industry', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  primaryIndustry: PrimaryIndustry | null;
+
+  @Column({ name: 'secondary_industry', type: 'varchar', length: 50, nullable: true })
+  @Expose()
+  secondaryIndustry: SecondaryIndustry | null;
+
+  @Column({ name: 'exchange_rate', type: 'decimal', precision: 18, scale: 6, nullable: true })
+  @Expose()
+  exchangeRate: string | null;
+
+  @Column({ name: 'crm_signed_at', type: 'date', nullable: true })
+  @Expose()
+  crmSignedAt: string | null;
 
   @Column({ name: 'payment_term', type: 'varchar', length: 80, nullable: true })
   @Expose()
@@ -179,6 +237,10 @@ export class ShippingDemand extends BaseEntity {
   @Expose()
   isPalletized: YesNo | null;
 
+  @Column({ name: 'is_split_in_advance', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  isSplitInAdvance: YesNo | null;
+
   @Column({ name: 'requires_export_customs', type: 'varchar', length: 10, nullable: true })
   @Expose()
   requiresExportCustoms: YesNo | null;
@@ -191,9 +253,117 @@ export class ShippingDemand extends BaseEntity {
   @Expose()
   requiresCustomsCertificate: YesNo | null;
 
+  @Column({ name: 'requires_maternity_handover', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  requiresMaternityHandover: YesNo | null;
+
+  @Column({ name: 'customs_declaration_method', type: 'varchar', length: 30, nullable: true })
+  @Expose()
+  customsDeclarationMethod: CustomsDeclarationMethod | null;
+
   @Column({ name: 'uses_marketing_fund', type: 'varchar', length: 10, nullable: true })
   @Expose()
   usesMarketingFund: YesNo | null;
+
+  @Column({ name: 'ali_trade_assurance_order_code', type: 'varchar', length: 100, nullable: true })
+  @Expose()
+  aliTradeAssuranceOrderCode: string | null;
+
+  @Column({ name: 'forwarder_quote_note', type: 'text', nullable: true })
+  @Expose()
+  forwarderQuoteNote: string | null;
+
+  @Column({ name: 'contract_file_keys', type: 'json', nullable: true })
+  @Expose()
+  contractFileKeys: string[] | null;
+
+  @Column({ name: 'contract_file_names', type: 'json', nullable: true })
+  @Expose()
+  contractFileNames: string[] | null;
+
+  @Column({ name: 'plug_photo_keys', type: 'json', nullable: true })
+  @Expose()
+  plugPhotoKeys: string[] | null;
+
+  @Column({ name: 'consignee_company', type: 'text', nullable: true })
+  @Expose()
+  consigneeCompany: string | null;
+
+  @Column({ name: 'consignee_other_info', type: 'text', nullable: true })
+  @Expose()
+  consigneeOtherInfo: string | null;
+
+  @Column({ name: 'notify_company', type: 'text', nullable: true })
+  @Expose()
+  notifyCompany: string | null;
+
+  @Column({ name: 'notify_other_info', type: 'text', nullable: true })
+  @Expose()
+  notifyOtherInfo: string | null;
+
+  @Column({ name: 'shipper_company', type: 'text', nullable: true })
+  @Expose()
+  shipperCompany: string | null;
+
+  @Column({ name: 'shipper_other_info_company_id', type: 'bigint', nullable: true })
+  @Expose()
+  shipperOtherInfoCompanyId: number | null;
+
+  @Column({ name: 'shipper_other_info_company_name', type: 'varchar', length: 200, nullable: true })
+  @Expose()
+  shipperOtherInfoCompanyName: string | null;
+
+  @Column({ name: 'domestic_customer_company', type: 'text', nullable: true })
+  @Expose()
+  domesticCustomerCompany: string | null;
+
+  @Column({ name: 'domestic_customer_delivery_info', type: 'text', nullable: true })
+  @Expose()
+  domesticCustomerDeliveryInfo: string | null;
+
+  @Column({ name: 'uses_default_shipping_mark', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  usesDefaultShippingMark: YesNo | null;
+
+  @Column({ name: 'shipping_mark_note', type: 'varchar', length: 255, nullable: true })
+  @Expose()
+  shippingMarkNote: string | null;
+
+  @Column({ name: 'shipping_mark_template_key', type: 'varchar', length: 255, nullable: true })
+  @Expose()
+  shippingMarkTemplateKey: string | null;
+
+  @Column({ name: 'needs_invoice', type: 'varchar', length: 10, nullable: true })
+  @Expose()
+  needsInvoice: YesNo | null;
+
+  @Column({ name: 'invoice_type', type: 'varchar', length: 30, nullable: true })
+  @Expose()
+  invoiceType: InvoiceType | null;
+
+  @Column({ name: 'shipping_documents_note', type: 'varchar', length: 500, nullable: true })
+  @Expose()
+  shippingDocumentsNote: string | null;
+
+  @Column({ name: 'bl_type', type: 'varchar', length: 30, nullable: true })
+  @Expose()
+  blType: BlType | null;
+
+  @Column({ name: 'original_mail_address', type: 'text', nullable: true })
+  @Expose()
+  originalMailAddress: string | null;
+
+  @Column({ name: 'business_rectification_note', type: 'text', nullable: true })
+  @Expose()
+  businessRectificationNote: string | null;
+
+  @Column({ name: 'customs_document_note', type: 'text', nullable: true })
+  @Expose()
+  customsDocumentNote: string | null;
+
+  @Column({ name: 'other_requirement_note', type: 'text', nullable: true })
+  @Expose()
+  otherRequirementNote: string | null;
 
   @Column({ name: 'contract_amount', type: 'decimal', precision: 18, scale: 2, default: 0 })
   @Expose()
@@ -211,10 +381,27 @@ export class ShippingDemand extends BaseEntity {
   @Expose()
   totalAmount: string;
 
+  @Column({ name: 'product_total_amount', type: 'decimal', precision: 18, scale: 2, default: 0 })
+  @Expose()
+  productTotalAmount: string;
+
+  @Column({ name: 'expense_total_amount', type: 'decimal', precision: 18, scale: 2, default: 0 })
+  @Expose()
+  expenseTotalAmount: string;
+
   @OneToMany(() => ShippingDemandItem, (item) => item.shippingDemand, { cascade: false })
   @Expose()
   items?: ShippingDemandItem[];
 
   @Expose()
   skuCount?: number;
+
+  @Expose()
+  contractFileUrls?: string[] | null;
+
+  @Expose()
+  plugPhotoUrls?: string[] | null;
+
+  @Expose()
+  shippingMarkTemplateUrl?: string | null;
 }

--- a/apps/api/src/modules/shipping-demands/shipping-demands.controller.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { ConfirmShippingDemandAllocationDto } from './dto/confirm-shipping-demand-allocation.dto';
 import { QueryShippingDemandDto } from './dto/query-shipping-demand.dto';
 import { ShippingDemandsService } from './shipping-demands.service';
 
@@ -15,6 +16,19 @@ export class ShippingDemandsController {
   @Get(':id')
   findById(@Param('id', ParseIntPipe) id: number) {
     return this.shippingDemandsService.findById(id);
+  }
+
+  @Post(':id/confirm-allocation')
+  confirmAllocation(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: ConfirmShippingDemandAllocationDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.shippingDemandsService.confirmAllocation(
+      id,
+      dto,
+      user?.username,
+    );
   }
 
   @Post('generate-from-sales-order/:salesOrderId')

--- a/apps/api/src/modules/shipping-demands/shipping-demands.module.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { FilesModule } from '../../files/files.module';
 import { InventoryModule } from '../inventory/inventory.module';
+import { InventoryTransaction } from '../inventory/entities/inventory-transaction.entity';
+import { ShippingDemandInventoryAllocation } from './entities/shipping-demand-inventory-allocation.entity';
 import { ShippingDemandItem } from './entities/shipping-demand-item.entity';
 import { ShippingDemand } from './entities/shipping-demand.entity';
 import { ShippingDemandsController } from './shipping-demands.controller';
@@ -10,7 +12,12 @@ import { ShippingDemandsService } from './shipping-demands.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ShippingDemand, ShippingDemandItem]),
+    TypeOrmModule.forFeature([
+      ShippingDemand,
+      ShippingDemandItem,
+      ShippingDemandInventoryAllocation,
+      InventoryTransaction,
+    ]),
     FilesModule,
     InventoryModule,
   ],

--- a/apps/api/src/modules/shipping-demands/shipping-demands.module.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { FilesModule } from '../../files/files.module';
 import { InventoryModule } from '../inventory/inventory.module';
 import { ShippingDemandItem } from './entities/shipping-demand-item.entity';
 import { ShippingDemand } from './entities/shipping-demand.entity';
@@ -10,6 +11,7 @@ import { ShippingDemandsService } from './shipping-demands.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([ShippingDemand, ShippingDemandItem]),
+    FilesModule,
     InventoryModule,
   ],
   controllers: [ShippingDemandsController],

--- a/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
@@ -42,6 +42,12 @@ interface PreparedAllocationLine {
   warehouseId: number | null;
 }
 
+const FULFILLMENT_TYPE_LABELS: Record<FulfillmentType, string> = {
+  [FulfillmentType.FULL_PURCHASE]: '全部采购',
+  [FulfillmentType.PARTIAL_PURCHASE]: '部分采购',
+  [FulfillmentType.USE_STOCK]: '使用现有库存',
+};
+
 @Injectable()
 export class ShippingDemandsService {
   constructor(
@@ -620,6 +626,8 @@ export class ShippingDemandsService {
     operator?: string,
   ): Promise<void> {
     const operationLogRepo = queryRunner.manager.getRepository(OperationLog);
+    const allocationSummary = this.buildAllocationOperationSummary(lines);
+    const allocationDetails = this.buildAllocationOperationDetails(lines);
     await operationLogRepo.save(
       operationLogRepo.create({
         operator: operator ?? 'system',
@@ -633,6 +641,7 @@ export class ShippingDemandsService {
           lockedQuantity: lines.reduce((sum, line) => sum + line.stockQuantity, 0),
           purchaseQuantity: lines.reduce((sum, line) => sum + line.purchaseQuantity, 0),
           itemCount: lines.length,
+          allocationSummary,
         },
         changeSummary: [
           {
@@ -642,21 +651,47 @@ export class ShippingDemandsService {
             newValue: newStatus,
           },
           {
-            field: 'allocation',
-            fieldLabel: '库存分配',
+            field: 'allocationSummary',
+            fieldLabel: '分配结果',
             oldValue: null,
-            newValue: lines.map((line) => ({
-              itemId: Number(line.item.id),
-              skuCode: line.item.skuCode,
-              fulfillmentType: line.fulfillmentType,
-              stockQuantity: line.stockQuantity,
-              purchaseQuantity: line.purchaseQuantity,
-              warehouseId: line.warehouseId,
-            })),
+            newValue: allocationSummary,
+          },
+          {
+            field: 'allocationDetails',
+            fieldLabel: '分配明细',
+            oldValue: null,
+            newValue: allocationDetails,
           },
         ],
       }),
     );
+  }
+
+  private buildAllocationOperationSummary(lines: PreparedAllocationLine[]): string {
+    const lockedQuantity = lines.reduce((sum, line) => sum + line.stockQuantity, 0);
+    const purchaseQuantity = lines.reduce((sum, line) => sum + line.purchaseQuantity, 0);
+    const stockLineCount = lines.filter((line) => line.stockQuantity > 0).length;
+    const purchaseLineCount = lines.filter((line) => line.purchaseQuantity > 0).length;
+
+    return [
+      `共 ${lines.length} 个 SKU`,
+      `锁定现有库存 ${lockedQuantity}`,
+      `需采购 ${purchaseQuantity}`,
+      `使用库存 ${stockLineCount} 行`,
+      `涉及采购 ${purchaseLineCount} 行`,
+    ].join('；');
+  }
+
+  private buildAllocationOperationDetails(lines: PreparedAllocationLine[]): string {
+    return lines
+      .map((line, index) => {
+        const productName = line.item.productNameCn || line.item.productNameEn;
+        const productText = productName ? ` / ${productName}` : '';
+        const warehouseText = line.warehouseId ? `，仓库 ${line.warehouseId}` : '';
+
+        return `${index + 1}. ${line.item.skuCode}${productText}：${FULFILLMENT_TYPE_LABELS[line.fulfillmentType] ?? line.fulfillmentType}，应发 ${line.item.requiredQuantity}，锁定库存 ${line.stockQuantity}，需采购 ${line.purchaseQuantity}${warehouseText}`;
+      })
+      .join('\n');
   }
 
   private buildAllocationActionKey(

--- a/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { SalesOrderStatus, ShippingDemandStatus } from '@infitek/shared';
 import { QueryRunner } from 'typeorm';
+import { FilesService } from '../../files/files.service';
 import { InventoryService, type AvailableInventoryItem } from '../inventory/inventory.service';
 import {
   OperationLog,
@@ -26,14 +27,15 @@ export class ShippingDemandsService {
   constructor(
     private readonly shippingDemandsRepository: ShippingDemandsRepository,
     private readonly inventoryService: InventoryService,
+    private readonly filesService: FilesService,
   ) {}
 
-  async findById(id: number): Promise<ShippingDemand> {
+  async findById(id: number): Promise<ShippingDemand & Record<string, unknown>> {
     const demand = await this.shippingDemandsRepository.findById(id);
     if (!demand) {
       throw new NotFoundException('发货需求不存在');
     }
-    return demand;
+    return this.withSignedUrls(demand);
   }
 
   findAll(query: QueryShippingDemandDto) {
@@ -86,15 +88,28 @@ export class ShippingDemandsService {
         sourceDocumentType: 'sales_order',
         status: ShippingDemandStatus.PENDING_ALLOCATION,
         orderType: order.orderType,
+        orderSource: order.orderSource,
         domesticTradeType: order.domesticTradeType,
+        externalOrderCode: order.externalOrderCode,
         customerId: order.customerId,
         customerName: order.customerName,
         customerCode: order.customerCode,
+        customerContactPerson: order.customerContactPerson,
+        afterSalesSourceOrderId: order.afterSalesSourceOrderId,
+        afterSalesSourceOrderCode: order.afterSalesSourceOrderCode,
+        afterSalesProductSummary: order.afterSalesProductSummary,
         currencyId: order.currencyId,
         currencyCode: order.currencyCode,
         currencyName: order.currencyName,
         currencySymbol: order.currencySymbol,
         tradeTerm: order.tradeTerm,
+        bankAccount: order.bankAccount,
+        extraViewerId: order.extraViewerId,
+        extraViewerName: order.extraViewerName,
+        primaryIndustry: order.primaryIndustry,
+        secondaryIndustry: order.secondaryIndustry,
+        exchangeRate: order.exchangeRate,
+        crmSignedAt: order.crmSignedAt,
         paymentTerm: order.paymentTerm,
         shipmentOriginCountryId: order.shipmentOriginCountryId,
         shipmentOriginCountryName: order.shipmentOriginCountryName,
@@ -118,13 +133,43 @@ export class ShippingDemandsService {
         isAliTradeAssurance: order.isAliTradeAssurance,
         isInsured: order.isInsured,
         isPalletized: order.isPalletized,
+        isSplitInAdvance: order.isSplitInAdvance,
         requiresExportCustoms: order.requiresExportCustoms,
         requiresWarrantyCard: order.requiresWarrantyCard,
         requiresCustomsCertificate: order.requiresCustomsCertificate,
+        requiresMaternityHandover: order.requiresMaternityHandover,
+        customsDeclarationMethod: order.customsDeclarationMethod,
         usesMarketingFund: order.usesMarketingFund,
+        aliTradeAssuranceOrderCode: order.aliTradeAssuranceOrderCode,
+        forwarderQuoteNote: order.forwarderQuoteNote,
+        contractFileKeys: order.contractFileKeys,
+        contractFileNames: order.contractFileNames,
+        plugPhotoKeys: order.plugPhotoKeys,
+        consigneeCompany: order.consigneeCompany,
+        consigneeOtherInfo: order.consigneeOtherInfo,
+        notifyCompany: order.notifyCompany,
+        notifyOtherInfo: order.notifyOtherInfo,
+        shipperCompany: order.shipperCompany,
+        shipperOtherInfoCompanyId: order.shipperOtherInfoCompanyId,
+        shipperOtherInfoCompanyName: order.shipperOtherInfoCompanyName,
+        domesticCustomerCompany: order.domesticCustomerCompany,
+        domesticCustomerDeliveryInfo: order.domesticCustomerDeliveryInfo,
+        usesDefaultShippingMark: order.usesDefaultShippingMark,
+        shippingMarkNote: order.shippingMarkNote,
+        shippingMarkTemplateKey: order.shippingMarkTemplateKey,
+        needsInvoice: order.needsInvoice,
+        invoiceType: order.invoiceType,
+        shippingDocumentsNote: order.shippingDocumentsNote,
+        blType: order.blType,
+        originalMailAddress: order.originalMailAddress,
+        businessRectificationNote: order.businessRectificationNote,
+        customsDocumentNote: order.customsDocumentNote,
+        otherRequirementNote: order.otherRequirementNote,
         contractAmount: order.contractAmount,
         receivedAmount: order.receivedAmount,
         outstandingAmount: order.outstandingAmount,
+        productTotalAmount: order.productTotalAmount,
+        expenseTotalAmount: order.expenseTotalAmount,
         totalAmount: order.totalAmount,
         createdBy: operator,
         updatedBy: operator,
@@ -150,6 +195,9 @@ export class ShippingDemandsService {
         currencyCode: item.currencyCode,
         unitId: item.unitId,
         unitName: item.unitName,
+        purchaserId: item.purchaserId,
+        purchaserName: item.purchaserName,
+        needsPurchase: item.needsPurchase,
         requiredQuantity: item.quantity,
         availableStockSnapshot: availableBySkuId.get(Number(item.skuId)) ?? [],
         fulfillmentType: null,
@@ -333,5 +381,41 @@ export class ShippingDemandsService {
       result.set(skuId, rows);
     }
     return result;
+  }
+
+  private async withSignedUrls(demand: ShippingDemand) {
+    const contractFileUrls = demand.contractFileKeys
+      ? await Promise.all(
+          demand.contractFileKeys.map(async (key) => {
+            try {
+              return await this.filesService.getSignedUrl(key);
+            } catch {
+              return key;
+            }
+          }),
+        )
+      : null;
+    const plugPhotoUrls = demand.plugPhotoKeys
+      ? await Promise.all(
+          demand.plugPhotoKeys.map(async (key) => {
+            try {
+              return await this.filesService.getSignedUrl(key);
+            } catch {
+              return key;
+            }
+          }),
+        )
+      : null;
+    const shippingMarkTemplateUrl = demand.shippingMarkTemplateKey
+      ? await this.filesService
+          .getSignedUrl(demand.shippingMarkTemplateKey)
+          .catch(() => demand.shippingMarkTemplateKey)
+      : null;
+    return {
+      ...demand,
+      contractFileUrls,
+      plugPhotoUrls,
+      shippingMarkTemplateUrl,
+    };
   }
 }

--- a/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
+++ b/apps/api/src/modules/shipping-demands/shipping-demands.service.ts
@@ -4,9 +4,17 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { SalesOrderStatus, ShippingDemandStatus } from '@infitek/shared';
-import { QueryRunner } from 'typeorm';
+import {
+  FulfillmentType,
+  InventoryChangeType,
+  SalesOrderStatus,
+  ShippingDemandAllocationStatus,
+  ShippingDemandStatus,
+} from '@infitek/shared';
+import { QueryRunner, Repository } from 'typeorm';
 import { FilesService } from '../../files/files.service';
+import { InventorySummary } from '../inventory/entities/inventory-summary.entity';
+import { InventoryTransaction } from '../inventory/entities/inventory-transaction.entity';
 import { InventoryService, type AvailableInventoryItem } from '../inventory/inventory.service';
 import {
   OperationLog,
@@ -14,13 +22,25 @@ import {
 } from '../operation-logs/entities/operation-log.entity';
 import { SalesOrder } from '../sales-orders/entities/sales-order.entity';
 import { SalesOrderItem } from '../sales-orders/entities/sales-order-item.entity';
+import { ConfirmShippingDemandAllocationDto } from './dto/confirm-shipping-demand-allocation.dto';
 import { QueryShippingDemandDto } from './dto/query-shipping-demand.dto';
+import { ShippingDemandInventoryAllocation } from './entities/shipping-demand-inventory-allocation.entity';
 import { ShippingDemandItem } from './entities/shipping-demand-item.entity';
 import { ShippingDemand } from './entities/shipping-demand.entity';
 import { ShippingDemandsRepository } from './shipping-demands.repository';
 
 const MAX_DEMAND_CODE_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 50;
+const MAX_CONFIRM_ALLOCATION_RETRIES = 3;
+const INITIAL_CONFIRM_ALLOCATION_RETRY_DELAY_MS = 25;
+
+interface PreparedAllocationLine {
+  item: ShippingDemandItem;
+  fulfillmentType: FulfillmentType;
+  stockQuantity: number;
+  purchaseQuantity: number;
+  warehouseId: number | null;
+}
 
 @Injectable()
 export class ShippingDemandsService {
@@ -55,6 +75,21 @@ export class ShippingDemandsService {
 
       return Number(savedDemand.id);
     });
+
+    return this.findById(demandId);
+  }
+
+  async confirmAllocation(
+    id: number,
+    dto: ConfirmShippingDemandAllocationDto,
+    operator?: string,
+  ): Promise<ShippingDemand & Record<string, unknown>> {
+    const demandId = await this.executeWithConfirmAllocationRetry(
+      async (queryRunner) => {
+        await this.confirmAllocationInTransaction(queryRunner, id, dto, operator);
+        return id;
+      },
+    );
 
     return this.findById(demandId);
   }
@@ -230,6 +265,238 @@ export class ShippingDemandsService {
     return savedDemand;
   }
 
+  private async confirmAllocationInTransaction(
+    queryRunner: QueryRunner,
+    id: number,
+    dto: ConfirmShippingDemandAllocationDto,
+    operator?: string,
+  ): Promise<void> {
+    const demand = await this.findShippingDemandForAllocation(queryRunner, id);
+    const preparedLines = this.prepareAllocationLines(demand, dto);
+    const oldStatus = demand.status;
+    const hasPurchaseQuantity = preparedLines.some((line) => line.purchaseQuantity > 0);
+    const nextStatus = hasPurchaseQuantity
+      ? ShippingDemandStatus.PURCHASING
+      : ShippingDemandStatus.PREPARED;
+
+    const itemRepo = queryRunner.manager.getRepository(ShippingDemandItem);
+    const allocationRepo = queryRunner.manager.getRepository(
+      ShippingDemandInventoryAllocation,
+    );
+    const inventoryTransactionRepo =
+      queryRunner.manager.getRepository(InventoryTransaction);
+
+    for (const line of preparedLines) {
+      line.item.fulfillmentType = line.fulfillmentType;
+      line.item.stockRequiredQuantity = line.stockQuantity;
+      line.item.purchaseRequiredQuantity = line.purchaseQuantity;
+      line.item.lockedRemainingQuantity = line.stockQuantity;
+      if (operator !== undefined) {
+        line.item.updatedBy = operator;
+      }
+
+      if (line.stockQuantity > 0) {
+        const warehouseId = line.warehouseId;
+        if (!warehouseId) {
+          throw new BadRequestException({
+            code: 'WAREHOUSE_REQUIRED',
+            message: `${line.item.skuCode} 使用库存时必须选择仓库`,
+          });
+        }
+        const lockResult = await this.inventoryService.lockStockInTransaction(
+          queryRunner,
+          {
+            skuId: Number(line.item.skuId),
+            warehouseId,
+            quantity: line.stockQuantity,
+            operator,
+          },
+        );
+        await allocationRepo.save(
+          (lockResult.allocations ?? []).map((allocation) =>
+            allocationRepo.create({
+              shippingDemandId: Number(demand.id),
+              shippingDemandItemId: Number(line.item.id),
+              salesOrderItemId: Number(line.item.salesOrderItemId),
+              skuId: Number(line.item.skuId),
+              warehouseId,
+              inventoryBatchId: allocation.batchId,
+              lockSource: 'existing_stock',
+              sourceDocumentType: 'shipping_demand',
+              sourceDocumentId: Number(demand.id),
+              originalLockedQuantity: allocation.quantity,
+              lockedQuantity: allocation.quantity,
+              shippedQuantity: 0,
+              releasedQuantity: 0,
+              status: ShippingDemandAllocationStatus.ACTIVE,
+              sourceActionKey: this.buildAllocationActionKey(
+                demand,
+                line.item,
+                allocation.batchId,
+              ),
+              createdBy: operator,
+              updatedBy: operator,
+            }),
+          ),
+        );
+        await inventoryTransactionRepo.save(
+          this.buildLockInventoryTransactions(
+            inventoryTransactionRepo,
+            demand,
+            line.item,
+            warehouseId,
+            lockResult.summary,
+            lockResult.allocations ?? [],
+            operator,
+          ),
+        );
+      }
+
+      await itemRepo.save(line.item);
+    }
+
+    demand.status = nextStatus;
+    if (operator !== undefined) {
+      demand.updatedBy = operator;
+    }
+    await queryRunner.manager.getRepository(ShippingDemand).save(demand);
+
+    if (nextStatus === ShippingDemandStatus.PREPARED) {
+      await queryRunner.manager.getRepository(SalesOrder).update(demand.salesOrderId, {
+        status: SalesOrderStatus.PREPARED,
+        updatedBy: operator,
+      });
+    }
+
+    await this.writeShippingDemandAllocationOperationLog(
+      queryRunner,
+      demand,
+      oldStatus,
+      nextStatus,
+      preparedLines,
+      operator,
+    );
+  }
+
+  private async findShippingDemandForAllocation(
+    queryRunner: QueryRunner,
+    id: number,
+  ): Promise<ShippingDemand> {
+    const demand = await queryRunner.manager
+      .getRepository(ShippingDemand)
+      .createQueryBuilder('demand')
+      .leftJoinAndSelect('demand.items', 'items')
+      .setLock('pessimistic_write')
+      .where('demand.id = :id', { id })
+      .orderBy('items.id', 'ASC')
+      .getOne();
+
+    if (!demand) {
+      throw new NotFoundException('发货需求不存在');
+    }
+    if (demand.status !== ShippingDemandStatus.PENDING_ALLOCATION) {
+      throw new BadRequestException({
+        code: 'ALLOCATION_ALREADY_CONFIRMED',
+        message: '只有待分配库存的发货需求可以确认分配',
+      });
+    }
+    if (!demand.items?.length) {
+      throw new BadRequestException('发货需求没有产品明细，无法确认分配');
+    }
+    return demand;
+  }
+
+  private prepareAllocationLines(
+    demand: ShippingDemand,
+    dto: ConfirmShippingDemandAllocationDto,
+  ): PreparedAllocationLine[] {
+    const items = demand.items ?? [];
+    const dtoByItemId = new Map<number, ConfirmShippingDemandAllocationDto['items'][number]>();
+    for (const line of dto.items ?? []) {
+      if (dtoByItemId.has(line.itemId)) {
+        throw new BadRequestException({
+          code: 'DUPLICATE_ALLOCATION_ITEM',
+          message: '发货需求明细不能重复提交',
+        });
+      }
+      dtoByItemId.set(line.itemId, line);
+    }
+    if (dtoByItemId.size !== items.length) {
+      throw new BadRequestException({
+        code: 'ALLOCATION_ITEMS_INCOMPLETE',
+        message: '所有发货需求明细都必须设置履行类型',
+      });
+    }
+
+    return items.map((item) => {
+      const input = dtoByItemId.get(Number(item.id));
+      if (!input) {
+        throw new BadRequestException({
+          code: 'ALLOCATION_ITEM_MISSING',
+          message: `${item.skuCode} 未设置履行类型`,
+        });
+      }
+      const requiredQuantity = Number(item.requiredQuantity ?? 0);
+      if (!Number.isInteger(requiredQuantity) || requiredQuantity <= 0) {
+        throw new BadRequestException({
+          code: 'INVALID_REQUIRED_QUANTITY',
+          message: `${item.skuCode} 应发数量必须为正整数`,
+        });
+      }
+      const stockQuantity = Number(input.stockQuantity ?? 0);
+      if (!Number.isInteger(stockQuantity) || stockQuantity < 0) {
+        throw new BadRequestException({
+          code: 'INVALID_STOCK_QUANTITY',
+          message: `${item.skuCode} 使用库存数量必须为非负整数`,
+        });
+      }
+      if (stockQuantity > requiredQuantity) {
+        throw new BadRequestException({
+          code: 'STOCK_QUANTITY_EXCEEDS_REQUIRED',
+          message: `${item.skuCode} 使用库存数量不能超过应发数量`,
+        });
+      }
+      const purchaseQuantity = requiredQuantity - stockQuantity;
+      this.assertFulfillmentQuantity(item, input.fulfillmentType, stockQuantity, purchaseQuantity);
+      return {
+        item,
+        fulfillmentType: input.fulfillmentType,
+        stockQuantity,
+        purchaseQuantity,
+        warehouseId: stockQuantity > 0 ? Number(input.warehouseId) : null,
+      };
+    });
+  }
+
+  private assertFulfillmentQuantity(
+    item: ShippingDemandItem,
+    fulfillmentType: FulfillmentType,
+    stockQuantity: number,
+    purchaseQuantity: number,
+  ): void {
+    if (fulfillmentType === FulfillmentType.FULL_PURCHASE && stockQuantity !== 0) {
+      throw new BadRequestException({
+        code: 'INVALID_FULL_PURCHASE_QUANTITY',
+        message: `${item.skuCode} 全部采购时使用库存数量必须为 0`,
+      });
+    }
+    if (fulfillmentType === FulfillmentType.USE_STOCK && purchaseQuantity !== 0) {
+      throw new BadRequestException({
+        code: 'INVALID_USE_STOCK_QUANTITY',
+        message: `${item.skuCode} 使用现有库存时必须覆盖全部应发数量`,
+      });
+    }
+    if (
+      fulfillmentType === FulfillmentType.PARTIAL_PURCHASE &&
+      (stockQuantity <= 0 || purchaseQuantity <= 0)
+    ) {
+      throw new BadRequestException({
+        code: 'INVALID_PARTIAL_PURCHASE_QUANTITY',
+        message: `${item.skuCode} 部分采购必须同时包含库存数量和采购数量`,
+      });
+    }
+  }
+
   private async findSalesOrderForGeneration(
     queryRunner: QueryRunner,
     salesOrderId: number,
@@ -300,6 +567,113 @@ export class ShippingDemandsService {
     );
   }
 
+  private buildLockInventoryTransactions(
+    repo: Repository<InventoryTransaction>,
+    demand: ShippingDemand,
+    item: ShippingDemandItem,
+    warehouseId: number,
+    summary: InventorySummary,
+    allocations: Array<{ batchId: number; quantity: number }>,
+    operator?: string,
+  ): InventoryTransaction[] {
+    const lockedQuantity = allocations.reduce(
+      (sum, allocation) => sum + Number(allocation.quantity ?? 0),
+      0,
+    );
+    if (lockedQuantity <= 0) return [];
+    const afterActual = Number(summary.actualQuantity ?? 0);
+    const afterLocked = Number(summary.lockedQuantity ?? 0);
+    const afterAvailable = Number(summary.availableQuantity ?? 0);
+    const beforeLocked = afterLocked - lockedQuantity;
+    const beforeAvailable = afterAvailable + lockedQuantity;
+
+    return [
+      repo.create({
+        skuId: Number(item.skuId),
+        warehouseId,
+        inventoryBatchId: null,
+        changeType: InventoryChangeType.LOCK,
+        actualQuantityDelta: 0,
+        lockedQuantityDelta: lockedQuantity,
+        availableQuantityDelta: -lockedQuantity,
+        beforeActualQuantity: afterActual,
+        afterActualQuantity: afterActual,
+        beforeLockedQuantity: beforeLocked,
+        afterLockedQuantity: afterLocked,
+        beforeAvailableQuantity: beforeAvailable,
+        afterAvailableQuantity: afterAvailable,
+        sourceDocumentType: 'shipping_demand',
+        sourceDocumentId: Number(demand.id),
+        sourceDocumentItemId: Number(item.id),
+        sourceActionKey: this.buildInventoryTransactionActionKey(demand, item),
+        operatedBy: operator ?? 'system',
+      }),
+    ] as InventoryTransaction[];
+  }
+
+  private async writeShippingDemandAllocationOperationLog(
+    queryRunner: QueryRunner,
+    demand: ShippingDemand,
+    oldStatus: ShippingDemandStatus,
+    newStatus: ShippingDemandStatus,
+    lines: PreparedAllocationLine[],
+    operator?: string,
+  ): Promise<void> {
+    const operationLogRepo = queryRunner.manager.getRepository(OperationLog);
+    await operationLogRepo.save(
+      operationLogRepo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.UPDATE,
+        resourceType: 'shipping-demands',
+        resourceId: String(demand.id),
+        resourcePath: `/api/shipping-demands/${demand.id}/confirm-allocation`,
+        requestSummary: {
+          sourceAction: 'confirm_shipping_demand_allocation',
+          lockedQuantity: lines.reduce((sum, line) => sum + line.stockQuantity, 0),
+          purchaseQuantity: lines.reduce((sum, line) => sum + line.purchaseQuantity, 0),
+          itemCount: lines.length,
+        },
+        changeSummary: [
+          {
+            field: 'status',
+            fieldLabel: '发货需求状态',
+            oldValue: oldStatus,
+            newValue: newStatus,
+          },
+          {
+            field: 'allocation',
+            fieldLabel: '库存分配',
+            oldValue: null,
+            newValue: lines.map((line) => ({
+              itemId: Number(line.item.id),
+              skuCode: line.item.skuCode,
+              fulfillmentType: line.fulfillmentType,
+              stockQuantity: line.stockQuantity,
+              purchaseQuantity: line.purchaseQuantity,
+              warehouseId: line.warehouseId,
+            })),
+          },
+        ],
+      }),
+    );
+  }
+
+  private buildAllocationActionKey(
+    demand: ShippingDemand,
+    item: ShippingDemandItem,
+    batchId: number,
+  ): string {
+    return `shipping-demand:${demand.id}:confirm-allocation:item:${item.id}:batch:${batchId}`;
+  }
+
+  private buildInventoryTransactionActionKey(
+    demand: ShippingDemand,
+    item: ShippingDemandItem,
+  ): string {
+    return `shipping-demand:${demand.id}:confirm-allocation:item:${item.id}:lock`;
+  }
+
   private async generateDemandCode(queryRunner: QueryRunner): Promise<string> {
     const now = new Date();
     const year = now.getFullYear();
@@ -357,9 +731,65 @@ export class ShippingDemandsService {
     }
   }
 
+  private async executeWithConfirmAllocationRetry<T>(
+    operation: (queryRunner: QueryRunner) => Promise<T>,
+  ): Promise<T> {
+    let retryCount = 0;
+    while (true) {
+      const queryRunner = this.shippingDemandsRepository.createQueryRunner();
+      let transactionStarted = false;
+
+      try {
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+        transactionStarted = true;
+        const result = await operation(queryRunner);
+        await queryRunner.commitTransaction();
+        return result;
+      } catch (error) {
+        if (transactionStarted) {
+          await queryRunner.rollbackTransaction();
+        }
+
+        if (
+          this.isRetryableConcurrencyError(error) &&
+          retryCount < MAX_CONFIRM_ALLOCATION_RETRIES
+        ) {
+          retryCount += 1;
+          await this.delay(
+            INITIAL_CONFIRM_ALLOCATION_RETRY_DELAY_MS * 2 ** (retryCount - 1),
+          );
+          continue;
+        }
+
+        if (this.isRetryableConcurrencyError(error)) {
+          throw new ConflictException({
+            code: 'CONCURRENT_UPDATE',
+            message: '库存并发更新失败，请稍后重试',
+          });
+        }
+
+        throw error;
+      } finally {
+        await queryRunner.release();
+      }
+    }
+  }
+
   private isDuplicateEntryError(error: unknown): boolean {
     const maybeError = error as { code?: string; errno?: number };
     return maybeError?.code === 'ER_DUP_ENTRY' || maybeError?.errno === 1062;
+  }
+
+  private isRetryableConcurrencyError(error: unknown): boolean {
+    return this.isDeadlockError(error) || this.isDuplicateEntryError(error);
+  }
+
+  private isDeadlockError(error: unknown): boolean {
+    const maybeError = error as { code?: string; errno?: number };
+    return (
+      maybeError?.code === 'ER_LOCK_DEADLOCK' || maybeError?.errno === 1213
+    );
   }
 
   private delay(ms: number): Promise<void> {

--- a/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
+++ b/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
@@ -2,8 +2,10 @@ import { BadRequestException } from '@nestjs/common';
 import {
   DomesticTradeType,
   SalesOrderStatus,
+  SalesOrderSource,
   SalesOrderType,
   ShippingDemandStatus,
+  YesNo,
 } from '@infitek/shared';
 import {
   OperationLog,
@@ -23,23 +25,39 @@ describe('ShippingDemandsService', () => {
   const inventoryService = {
     findAvailable: jest.fn(),
   };
+  const filesService = {
+    getSignedUrl: jest.fn(),
+  };
 
   const makeOrder = (
     status = SalesOrderStatus.APPROVED,
   ): Partial<SalesOrder> => ({
     id: 10,
     erpSalesOrderCode: 'SO2026042800001',
+    externalOrderCode: 'EXT-001',
+    orderSource: SalesOrderSource.MANUAL,
     status,
     orderType: SalesOrderType.SALES,
     domesticTradeType: DomesticTradeType.FOREIGN,
     customerId: 1,
     customerName: '测试客户',
     customerCode: 'KH001',
+    customerContactPerson: '张三',
+    afterSalesSourceOrderId: null,
+    afterSalesSourceOrderCode: null,
+    afterSalesProductSummary: null,
     currencyId: 2,
     currencyCode: 'USD',
     currencyName: '美元',
     currencySymbol: '$',
     tradeTerm: null,
+    bankAccount: 'BOC-001',
+    extraViewerId: null,
+    extraViewerName: null,
+    primaryIndustry: null,
+    secondaryIndustry: null,
+    exchangeRate: '7.100000',
+    crmSignedAt: '2026-04-27',
     paymentTerm: null,
     shipmentOriginCountryId: null,
     shipmentOriginCountryName: null,
@@ -63,13 +81,43 @@ describe('ShippingDemandsService', () => {
     isAliTradeAssurance: null,
     isInsured: null,
     isPalletized: null,
+    isSplitInAdvance: YesNo.NO,
     requiresExportCustoms: null,
     requiresWarrantyCard: null,
     requiresCustomsCertificate: null,
+    requiresMaternityHandover: null,
+    customsDeclarationMethod: null,
     usesMarketingFund: null,
+    aliTradeAssuranceOrderCode: null,
+    forwarderQuoteNote: '询价货代备注',
+    contractFileKeys: ['contracts/a.pdf'],
+    contractFileNames: ['合同A.pdf'],
+    plugPhotoKeys: ['plugs/a.png'],
+    consigneeCompany: 'Consignee Co.',
+    consigneeOtherInfo: 'Consignee Info',
+    notifyCompany: 'Notify Co.',
+    notifyOtherInfo: 'Notify Info',
+    shipperCompany: 'Shipper Co.',
+    shipperOtherInfoCompanyId: null,
+    shipperOtherInfoCompanyName: null,
+    domesticCustomerCompany: null,
+    domesticCustomerDeliveryInfo: null,
+    usesDefaultShippingMark: YesNo.YES,
+    shippingMarkNote: '唛头备注',
+    shippingMarkTemplateKey: 'shipping-mark/a.docx',
+    needsInvoice: YesNo.YES,
+    invoiceType: null,
+    shippingDocumentsNote: '随货文件',
+    blType: null,
+    originalMailAddress: 'Mail address',
+    businessRectificationNote: '业务整改',
+    customsDocumentNote: '清关要求',
+    otherRequirementNote: '其他要求',
     contractAmount: '1000.00',
     receivedAmount: '0.00',
     outstandingAmount: '1000.00',
+    productTotalAmount: '600.00',
+    expenseTotalAmount: '0.00',
     totalAmount: '600.00',
     items: [
       {
@@ -89,6 +137,9 @@ describe('ShippingDemandsService', () => {
         currencyCode: 'USD',
         unitId: 6,
         unitName: '台',
+        purchaserId: 8,
+        purchaserName: '采购员A',
+        needsPurchase: YesNo.YES,
         quantity: 2,
         amount: '600.00',
         material: '金属',
@@ -174,6 +225,35 @@ describe('ShippingDemandsService', () => {
     service = new ShippingDemandsService(
       shippingDemandsRepository as any,
       inventoryService as any,
+      filesService as any,
+    );
+  });
+
+  it('finds shipping demand detail with signed urls', async () => {
+    shippingDemandsRepository.findById.mockResolvedValue({
+      id: 500,
+      demandCode: 'SD2026042800001',
+      status: ShippingDemandStatus.PENDING_ALLOCATION,
+      contractFileKeys: ['contracts/a.pdf'],
+      contractFileNames: ['合同A.pdf'],
+      plugPhotoKeys: ['plugs/a.png'],
+      shippingMarkTemplateKey: 'shipping-mark/a.docx',
+      items: [],
+    });
+    filesService.getSignedUrl.mockImplementation(async (key: string) => {
+      return `https://signed.example.com/${key}`;
+    });
+
+    const result = await service.findById(500);
+
+    expect(result.contractFileUrls).toEqual([
+      'https://signed.example.com/contracts/a.pdf',
+    ]);
+    expect(result.plugPhotoUrls).toEqual([
+      'https://signed.example.com/plugs/a.png',
+    ]);
+    expect(result.shippingMarkTemplateUrl).toBe(
+      'https://signed.example.com/shipping-mark/a.docx',
     );
   });
 
@@ -239,12 +319,29 @@ describe('ShippingDemandsService', () => {
         status: ShippingDemandStatus.PENDING_ALLOCATION,
         salesOrderId: 10,
         sourceDocumentCode: 'SO2026042800001',
+        externalOrderCode: 'EXT-001',
+        customerContactPerson: '张三',
+        bankAccount: 'BOC-001',
+        exchangeRate: '7.100000',
+        crmSignedAt: '2026-04-27',
+        contractFileKeys: ['contracts/a.pdf'],
+        contractFileNames: ['合同A.pdf'],
+        plugPhotoKeys: ['plugs/a.png'],
+        consigneeCompany: 'Consignee Co.',
+        notifyCompany: 'Notify Co.',
+        shipperCompany: 'Shipper Co.',
+        shippingMarkTemplateKey: 'shipping-mark/a.docx',
+        productTotalAmount: '600.00',
+        expenseTotalAmount: '0.00',
       }),
     );
     expect(state.savedItems).toEqual([
       expect.objectContaining({
         salesOrderItemId: 101,
         requiredQuantity: 2,
+        purchaserId: 8,
+        purchaserName: '采购员A',
+        needsPurchase: YesNo.YES,
         fulfillmentType: null,
         availableStockSnapshot: [
           {

--- a/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
+++ b/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
@@ -526,6 +526,23 @@ describe('ShippingDemandsService', () => {
         resourceId: '500',
       }),
     );
+    expect(state.savedOperationLog).toEqual(
+      expect.objectContaining({
+        requestSummary: expect.objectContaining({
+          allocationSummary: '共 1 个 SKU；锁定现有库存 2；需采购 0；使用库存 1 行；涉及采购 0 行',
+        }),
+        changeSummary: expect.arrayContaining([
+          expect.objectContaining({
+            field: 'allocationSummary',
+            newValue: '共 1 个 SKU；锁定现有库存 2；需采购 0；使用库存 1 行；涉及采购 0 行',
+          }),
+          expect.objectContaining({
+            field: 'allocationDetails',
+            newValue: '1. SKU001 / 离心机：使用现有库存，应发 2，锁定库存 2，需采购 0，仓库 22',
+          }),
+        ]),
+      }),
+    );
   });
 
   it('confirms allocation and keeps demand purchasing when purchase quantity remains', async () => {

--- a/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
+++ b/apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts
@@ -1,17 +1,22 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   DomesticTradeType,
+  FulfillmentType,
+  InventoryChangeType,
   SalesOrderStatus,
   SalesOrderSource,
   SalesOrderType,
+  ShippingDemandAllocationStatus,
   ShippingDemandStatus,
   YesNo,
 } from '@infitek/shared';
+import { InventoryTransaction } from '../../inventory/entities/inventory-transaction.entity';
 import {
   OperationLog,
   OperationLogAction,
 } from '../../operation-logs/entities/operation-log.entity';
 import { SalesOrder } from '../../sales-orders/entities/sales-order.entity';
+import { ShippingDemandInventoryAllocation } from '../entities/shipping-demand-inventory-allocation.entity';
 import { ShippingDemandItem } from '../entities/shipping-demand-item.entity';
 import { ShippingDemand } from '../entities/shipping-demand.entity';
 import { ShippingDemandsService } from '../shipping-demands.service';
@@ -24,6 +29,7 @@ describe('ShippingDemandsService', () => {
   };
   const inventoryService = {
     findAvailable: jest.fn(),
+    lockStockInTransaction: jest.fn(),
   };
   const filesService = {
     getSignedUrl: jest.fn(),
@@ -153,6 +159,35 @@ describe('ShippingDemandsService', () => {
     ],
   });
 
+  const makeDemandForAllocation = (
+    overrides: Partial<ShippingDemand> = {},
+  ): Partial<ShippingDemand> => ({
+    id: 500,
+    demandCode: 'SD2026042800001',
+    salesOrderId: 10,
+    sourceDocumentCode: 'SO2026042800001',
+    status: ShippingDemandStatus.PENDING_ALLOCATION,
+    items: [
+      {
+        id: 700,
+        shippingDemandId: 500,
+        salesOrderItemId: 101,
+        skuId: 11,
+        skuCode: 'SKU001',
+        productNameCn: '离心机',
+        requiredQuantity: 2,
+        fulfillmentType: null,
+        stockRequiredQuantity: 0,
+        purchaseRequiredQuantity: 0,
+        lockedRemainingQuantity: 0,
+        shippedQuantity: 0,
+        purchaseOrderedQuantity: 0,
+        receivedQuantity: 0,
+      } as ShippingDemandItem,
+    ],
+    ...overrides,
+  });
+
   const makeQueryBuilder = (result: unknown) => {
     const qb = {
       leftJoinAndSelect: jest.fn(() => qb),
@@ -177,7 +212,9 @@ describe('ShippingDemandsService', () => {
     if (entity === ShippingDemand) {
       return {
         createQueryBuilder: jest.fn(() =>
-          makeQueryBuilder(state.existingDemand ?? state.latestDemand ?? null),
+          makeQueryBuilder(
+            state.demand ?? state.existingDemand ?? state.latestDemand ?? null,
+          ),
         ),
         create: jest.fn((data) => data),
         save: jest.fn().mockImplementation(async (data) => {
@@ -190,7 +227,32 @@ describe('ShippingDemandsService', () => {
       return {
         create: jest.fn((data) => data),
         save: jest.fn().mockImplementation(async (data) => {
-          state.savedItems = data;
+          if (Array.isArray(data)) {
+            state.savedItems = data;
+          } else {
+            state.savedAllocationItems = [
+              ...((state.savedAllocationItems as unknown[]) ?? []),
+              { ...data },
+            ];
+          }
+          return data;
+        }),
+      };
+    }
+    if (entity === ShippingDemandInventoryAllocation) {
+      return {
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedAllocations = data;
+          return data;
+        }),
+      };
+    }
+    if (entity === InventoryTransaction) {
+      return {
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedInventoryTransactions = data;
           return data;
         }),
       };
@@ -373,6 +435,214 @@ describe('ShippingDemandsService', () => {
         ],
       }),
     );
+  });
+
+  it('confirms allocation and prepares demand when all items use stock', async () => {
+    const state: Record<string, unknown> = {
+      demand: makeDemandForAllocation(),
+    };
+    const queryRunner = makeQueryRunner(state);
+    shippingDemandsRepository.createQueryRunner.mockReturnValue(queryRunner);
+    shippingDemandsRepository.findById.mockResolvedValue({
+      id: 500,
+      demandCode: 'SD2026042800001',
+      status: ShippingDemandStatus.PREPARED,
+      items: [{ id: 700, lockedRemainingQuantity: 2 }],
+    });
+    inventoryService.lockStockInTransaction.mockResolvedValue({
+      summary: {
+        actualQuantity: 5,
+        lockedQuantity: 2,
+        availableQuantity: 3,
+      },
+      batches: [],
+      allocations: [{ batchId: 901, quantity: 2 }],
+    });
+
+    const result = await service.confirmAllocation(
+      500,
+      {
+        items: [
+          {
+            itemId: 700,
+            fulfillmentType: FulfillmentType.USE_STOCK,
+            stockQuantity: 2,
+            warehouseId: 22,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(result.status).toBe(ShippingDemandStatus.PREPARED);
+    expect(queryRunner.commitTransaction).toHaveBeenCalled();
+    expect(inventoryService.lockStockInTransaction).toHaveBeenCalledWith(
+      queryRunner,
+      {
+        skuId: 11,
+        warehouseId: 22,
+        quantity: 2,
+        operator: 'admin',
+      },
+    );
+    expect(state.savedAllocationItems).toEqual([
+      expect.objectContaining({
+        id: 700,
+        fulfillmentType: FulfillmentType.USE_STOCK,
+        stockRequiredQuantity: 2,
+        purchaseRequiredQuantity: 0,
+        lockedRemainingQuantity: 2,
+      }),
+    ]);
+    expect(state.savedDemand).toEqual(
+      expect.objectContaining({ status: ShippingDemandStatus.PREPARED }),
+    );
+    expect(state.salesOrderUpdate).toEqual({
+      status: SalesOrderStatus.PREPARED,
+      updatedBy: 'admin',
+    });
+    expect(state.savedAllocations).toEqual([
+      expect.objectContaining({
+        shippingDemandId: 500,
+        shippingDemandItemId: 700,
+        inventoryBatchId: 901,
+        lockedQuantity: 2,
+        status: ShippingDemandAllocationStatus.ACTIVE,
+      }),
+    ]);
+    expect(state.savedInventoryTransactions).toEqual([
+      expect.objectContaining({
+        changeType: InventoryChangeType.LOCK,
+        lockedQuantityDelta: 2,
+        availableQuantityDelta: -2,
+        sourceDocumentType: 'shipping_demand',
+        sourceDocumentId: 500,
+        sourceDocumentItemId: 700,
+      }),
+    ]);
+    expect(state.savedOperationLog).toEqual(
+      expect.objectContaining({
+        resourceType: 'shipping-demands',
+        resourceId: '500',
+      }),
+    );
+  });
+
+  it('confirms allocation and keeps demand purchasing when purchase quantity remains', async () => {
+    const state: Record<string, unknown> = {
+      demand: makeDemandForAllocation(),
+    };
+    const queryRunner = makeQueryRunner(state);
+    shippingDemandsRepository.createQueryRunner.mockReturnValue(queryRunner);
+    shippingDemandsRepository.findById.mockResolvedValue({
+      id: 500,
+      demandCode: 'SD2026042800001',
+      status: ShippingDemandStatus.PURCHASING,
+      items: [{ id: 700, lockedRemainingQuantity: 1 }],
+    });
+    inventoryService.lockStockInTransaction.mockResolvedValue({
+      summary: {
+        actualQuantity: 5,
+        lockedQuantity: 1,
+        availableQuantity: 4,
+      },
+      batches: [],
+      allocations: [{ batchId: 901, quantity: 1 }],
+    });
+
+    await service.confirmAllocation(
+      500,
+      {
+        items: [
+          {
+            itemId: 700,
+            fulfillmentType: FulfillmentType.PARTIAL_PURCHASE,
+            stockQuantity: 1,
+            warehouseId: 22,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(state.savedAllocationItems).toEqual([
+      expect.objectContaining({
+        fulfillmentType: FulfillmentType.PARTIAL_PURCHASE,
+        stockRequiredQuantity: 1,
+        purchaseRequiredQuantity: 1,
+        lockedRemainingQuantity: 1,
+      }),
+    ]);
+    expect(state.savedDemand).toEqual(
+      expect.objectContaining({ status: ShippingDemandStatus.PURCHASING }),
+    );
+    expect(state.salesOrderUpdate).toBeUndefined();
+  });
+
+  it('rejects confirming allocation for non-pending demand', async () => {
+    const state: Record<string, unknown> = {
+      demand: makeDemandForAllocation({
+        status: ShippingDemandStatus.PURCHASING,
+      }),
+    };
+    const queryRunner = makeQueryRunner(state);
+    shippingDemandsRepository.createQueryRunner.mockReturnValue(queryRunner);
+
+    await expect(
+      service.confirmAllocation(
+        500,
+        {
+          items: [
+            {
+              itemId: 700,
+              fulfillmentType: FulfillmentType.USE_STOCK,
+              stockQuantity: 2,
+              warehouseId: 22,
+            },
+          ],
+        },
+        'admin',
+      ),
+    ).rejects.toThrow(BadRequestException);
+    expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
+    expect(inventoryService.lockStockInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when stock is insufficient during allocation confirmation', async () => {
+    const state: Record<string, unknown> = {
+      demand: makeDemandForAllocation(),
+    };
+    const queryRunner = makeQueryRunner(state);
+    shippingDemandsRepository.createQueryRunner.mockReturnValue(queryRunner);
+    inventoryService.lockStockInTransaction.mockRejectedValue(
+      new BadRequestException({
+        code: 'STOCK_INSUFFICIENT',
+        message: '可用库存不足，当前可用 1',
+      }),
+    );
+
+    await expect(
+      service.confirmAllocation(
+        500,
+        {
+          items: [
+            {
+              itemId: 700,
+              fulfillmentType: FulfillmentType.USE_STOCK,
+              stockQuantity: 2,
+              warehouseId: 22,
+            },
+          ],
+        },
+        'admin',
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(queryRunner.rollbackTransaction).toHaveBeenCalled();
+    expect(queryRunner.commitTransaction).not.toHaveBeenCalled();
+    expect(state.savedAllocations).toBeUndefined();
+    expect(state.savedInventoryTransactions).toBeUndefined();
+    expect(state.savedDemand).toBeUndefined();
   });
 
   it('retries demand code duplicate key conflicts', async () => {

--- a/apps/web/src/api/shipping-demands.api.ts
+++ b/apps/web/src/api/shipping-demands.api.ts
@@ -185,6 +185,17 @@ export interface ShippingDemandListData {
   totalPages: number;
 }
 
+export interface ConfirmShippingDemandAllocationItemPayload {
+  itemId: number;
+  fulfillmentType: FulfillmentType;
+  stockQuantity: number;
+  warehouseId?: number;
+}
+
+export interface ConfirmShippingDemandAllocationPayload {
+  items: ConfirmShippingDemandAllocationItemPayload[];
+}
+
 function normalizeApiError(error: unknown): never {
   if (typeof error === 'object' && error !== null) throw error;
   throw { message: '请求失败，请稍后重试' };
@@ -210,4 +221,15 @@ export const generateShippingDemandFromSalesOrder = (
 export const getShippingDemandById = (id: number): Promise<ShippingDemand> =>
   request
     .get<unknown, ShippingDemand>(`/shipping-demands/${id}`)
+    .catch(normalizeApiError);
+
+export const confirmShippingDemandAllocation = (
+  id: number,
+  payload: ConfirmShippingDemandAllocationPayload,
+): Promise<ShippingDemand> =>
+  request
+    .post<unknown, ShippingDemand>(
+      `/shipping-demands/${id}/confirm-allocation`,
+      payload,
+    )
     .catch(normalizeApiError);

--- a/apps/web/src/api/shipping-demands.api.ts
+++ b/apps/web/src/api/shipping-demands.api.ts
@@ -1,4 +1,23 @@
-import { ShippingDemandStatus } from '@infitek/shared';
+import {
+  BlType,
+  CustomsDeclarationMethod,
+  DomesticTradeType,
+  FulfillmentType,
+  InvoiceType,
+  OrderNature,
+  PaymentTerm,
+  PlugType,
+  PrimaryIndustry,
+  ProductLineType,
+  ReceiptStatus,
+  SalesOrderSource,
+  SalesOrderType,
+  SecondaryIndustry,
+  ShippingDemandStatus,
+  TradeTerm,
+  TransportationMethod,
+  YesNo,
+} from '@infitek/shared';
 import request from './request';
 
 export interface ShippingDemandItem {
@@ -9,6 +28,20 @@ export interface ShippingDemandItem {
   skuCode: string;
   productNameCn?: string | null;
   productNameEn?: string | null;
+  lineType?: ProductLineType | null;
+  spuId?: number | null;
+  spuName?: string | null;
+  electricalParams?: string | null;
+  hasPlug?: YesNo | null;
+  plugType?: PlugType | null;
+  unitPrice: string;
+  currencyId?: number | null;
+  currencyCode?: string | null;
+  unitId?: number | null;
+  unitName?: string | null;
+  purchaserId?: number | null;
+  purchaserName?: string | null;
+  needsPurchase?: YesNo | null;
   requiredQuantity: number;
   availableStockSnapshot?: Array<{
     skuId: number;
@@ -17,11 +50,21 @@ export interface ShippingDemandItem {
     lockedQuantity: number;
     availableQuantity: number;
   }> | null;
-  fulfillmentType?: string | null;
+  fulfillmentType?: FulfillmentType | null;
   stockRequiredQuantity: number;
   purchaseRequiredQuantity: number;
   lockedRemainingQuantity: number;
   shippedQuantity: number;
+  purchaseOrderedQuantity: number;
+  receivedQuantity: number;
+  amount: string;
+  material?: string | null;
+  imageUrl?: string | null;
+  totalVolumeCbm: string;
+  totalWeightKg: string;
+  unitWeightKg: string;
+  unitVolumeCbm: string;
+  skuSpecification?: string | null;
 }
 
 export interface ShippingDemand {
@@ -29,15 +72,95 @@ export interface ShippingDemand {
   demandCode: string;
   salesOrderId: number;
   sourceDocumentCode: string;
+  sourceDocumentType?: string | null;
   status: ShippingDemandStatus;
+  orderType: SalesOrderType;
+  orderSource?: SalesOrderSource | null;
+  domesticTradeType: DomesticTradeType;
+  externalOrderCode?: string | null;
+  customerId: number;
   customerName: string;
   customerCode: string;
+  customerContactPerson?: string | null;
+  afterSalesSourceOrderId?: number | null;
+  afterSalesSourceOrderCode?: string | null;
+  afterSalesProductSummary?: string | null;
   skuCount?: number;
+  currencyId?: number | null;
   currencyCode?: string | null;
+  currencyName?: string | null;
+  currencySymbol?: string | null;
+  tradeTerm?: TradeTerm | null;
+  paymentTerm?: PaymentTerm | null;
+  bankAccount?: string | null;
+  extraViewerId?: number | null;
+  extraViewerName?: string | null;
+  primaryIndustry?: PrimaryIndustry | null;
+  secondaryIndustry?: SecondaryIndustry | null;
+  exchangeRate?: string | null;
+  crmSignedAt?: string | null;
+  shipmentOriginCountryId?: number | null;
+  shipmentOriginCountryName?: string | null;
+  destinationCountryId?: number | null;
   destinationCountryName?: string | null;
+  destinationPortId?: number | null;
   destinationPortName?: string | null;
+  signingCompanyId?: number | null;
+  signingCompanyName?: string | null;
+  salespersonId?: number | null;
+  salespersonName?: string | null;
+  merchandiserId?: number | null;
   merchandiserName?: string | null;
+  merchandiserAbbr?: string | null;
+  orderNature?: OrderNature | null;
+  receiptStatus?: ReceiptStatus | null;
+  transportationMethod?: TransportationMethod | null;
   requiredDeliveryAt?: string | null;
+  isSharedOrder?: YesNo | null;
+  isSinosure?: YesNo | null;
+  isAliTradeAssurance?: YesNo | null;
+  isInsured?: YesNo | null;
+  isPalletized?: YesNo | null;
+  isSplitInAdvance?: YesNo | null;
+  requiresExportCustoms?: YesNo | null;
+  requiresWarrantyCard?: YesNo | null;
+  requiresCustomsCertificate?: YesNo | null;
+  requiresMaternityHandover?: YesNo | null;
+  customsDeclarationMethod?: CustomsDeclarationMethod | null;
+  usesMarketingFund?: YesNo | null;
+  aliTradeAssuranceOrderCode?: string | null;
+  forwarderQuoteNote?: string | null;
+  contractFileKeys?: string[] | null;
+  contractFileNames?: string[] | null;
+  contractFileUrls?: string[] | null;
+  plugPhotoKeys?: string[] | null;
+  plugPhotoUrls?: string[] | null;
+  consigneeCompany?: string | null;
+  consigneeOtherInfo?: string | null;
+  notifyCompany?: string | null;
+  notifyOtherInfo?: string | null;
+  shipperCompany?: string | null;
+  shipperOtherInfoCompanyId?: number | null;
+  shipperOtherInfoCompanyName?: string | null;
+  domesticCustomerCompany?: string | null;
+  domesticCustomerDeliveryInfo?: string | null;
+  usesDefaultShippingMark?: YesNo | null;
+  shippingMarkNote?: string | null;
+  shippingMarkTemplateKey?: string | null;
+  shippingMarkTemplateUrl?: string | null;
+  needsInvoice?: YesNo | null;
+  invoiceType?: InvoiceType | null;
+  shippingDocumentsNote?: string | null;
+  blType?: BlType | null;
+  originalMailAddress?: string | null;
+  businessRectificationNote?: string | null;
+  customsDocumentNote?: string | null;
+  otherRequirementNote?: string | null;
+  contractAmount: string;
+  receivedAmount: string;
+  outstandingAmount: string;
+  productTotalAmount: string;
+  expenseTotalAmount: string;
   totalAmount: string;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/components/ActivityTimeline.tsx
+++ b/apps/web/src/components/ActivityTimeline.tsx
@@ -235,6 +235,11 @@ const ENUM_VALUE_LABELS: Record<string, Record<string, string>> = {
     telex_release: '电放',
     original: '正本',
   },
+  fulfillmentType: {
+    full_purchase: '全部采购',
+    partial_purchase: '部分采购',
+    use_stock: '使用现有库存',
+  },
 };
 
 const RESOURCE_ENUM_VALUE_LABELS: Record<string, Record<string, Record<string, string>>> = {
@@ -453,6 +458,11 @@ const RESOURCE_ENUM_VALUE_LABELS: Record<string, Record<string, Record<string, s
       partially_shipped: '部分发货',
       shipped: '已发货',
       voided: '已作废',
+    },
+    fulfillmentType: {
+      full_purchase: '全部采购',
+      partial_purchase: '部分采购',
+      use_stock: '使用现有库存',
     },
     paymentTerm: {
       '100_tt_in_advance': '100% TT预付',
@@ -833,9 +843,153 @@ function formatChangeValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
+function readRecordValue(
+  value: Record<string, unknown>,
+  key: string,
+): unknown {
+  return value[key];
+}
+
+function formatFulfillmentType(value: unknown): string {
+  const normalizedValue = normalizeLookupId(value);
+  if (!normalizedValue) {
+    return '未设置';
+  }
+
+  return ENUM_VALUE_LABELS.fulfillmentType[normalizedValue] ?? normalizedValue;
+}
+
+function formatAllocationObject(value: Record<string, unknown>, index: number): string {
+  const skuCode = readRecordValue(value, 'skuCode');
+  const productName =
+    readRecordValue(value, 'productNameCn') ??
+    readRecordValue(value, 'productNameEn') ??
+    readRecordValue(value, 'productName');
+  const itemId = readRecordValue(value, 'itemId');
+  const stockQuantity = readRecordValue(value, 'stockQuantity');
+  const purchaseQuantity = readRecordValue(value, 'purchaseQuantity');
+  const warehouseId = readRecordValue(value, 'warehouseId');
+  const skuText = skuCode ? String(skuCode) : `明细 ${itemId ?? index + 1}`;
+  const productText = productName ? ` / ${String(productName)}` : '';
+  const warehouseText = warehouseId ? `，仓库 ID ${String(warehouseId)}` : '';
+
+  return `${index + 1}. ${skuText}${productText}：${formatFulfillmentType(readRecordValue(value, 'fulfillmentType'))}，锁定库存 ${formatChangeValue(stockQuantity)}，需采购 ${formatChangeValue(purchaseQuantity)}${warehouseText}`;
+}
+
+function formatAllocationValue(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const allocationRows = value.filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === 'object' &&
+        item !== null &&
+        ('skuCode' in item || 'fulfillmentType' in item || 'stockQuantity' in item || 'purchaseQuantity' in item),
+    );
+
+    if (!allocationRows.length) {
+      return null;
+    }
+
+    return allocationRows.map((item, index) => formatAllocationObject(item, index)).join('\n');
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    ('skuCode' in value || 'fulfillmentType' in value || 'stockQuantity' in value || 'purchaseQuantity' in value)
+  ) {
+    return formatAllocationObject(value as Record<string, unknown>, 0);
+  }
+
+  return null;
+}
+
+function readFirstKnownValue(
+  value: Record<string, unknown>,
+  keys: string[],
+): unknown {
+  for (const key of keys) {
+    const entryValue = readRecordValue(value, key);
+    if (entryValue !== null && entryValue !== undefined && entryValue !== '') {
+      return entryValue;
+    }
+  }
+
+  return null;
+}
+
+function formatBusinessItemObject(value: Record<string, unknown>, index: number): string {
+  const skuCode = readFirstKnownValue(value, ['skuCode', 'sku_code']);
+  const productName = readFirstKnownValue(value, [
+    'productNameCn',
+    'productNameEn',
+    'productName',
+    'nameCn',
+    'nameEn',
+  ]);
+  const itemId = readFirstKnownValue(value, ['itemId', 'id']);
+  const skuText = skuCode ? String(skuCode) : `明细 ${itemId ?? index + 1}`;
+  const productText = productName ? ` / ${String(productName)}` : '';
+  const segments = [
+    { label: '应发', value: readFirstKnownValue(value, ['requiredQuantity', 'quantity']) },
+    { label: '履行', value: readFirstKnownValue(value, ['fulfillmentType']) },
+    { label: '使用库存', value: readRecordValue(value, 'stockRequiredQuantity') },
+    { label: '需采购', value: readRecordValue(value, 'purchaseRequiredQuantity') },
+    { label: '已锁定', value: readRecordValue(value, 'lockedRemainingQuantity') },
+    { label: '已发货', value: readRecordValue(value, 'shippedQuantity') },
+  ]
+    .filter(({ value: segmentValue }) => segmentValue !== null && segmentValue !== undefined && segmentValue !== '')
+    .map(({ label, value: segmentValue }) =>
+      label === '履行'
+        ? `${label} ${formatFulfillmentType(segmentValue)}`
+        : `${label} ${formatChangeValue(segmentValue)}`,
+    );
+
+  return `${index + 1}. ${skuText}${productText}${segments.length ? `：${segments.join('，')}` : ''}`;
+}
+
+function formatBusinessItemsValue(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const rows = value.filter(
+    (item): item is Record<string, unknown> =>
+      typeof item === 'object' &&
+      item !== null &&
+      ('skuCode' in item || 'skuId' in item || 'productNameCn' in item || 'requiredQuantity' in item || 'quantity' in item),
+  );
+
+  if (!rows.length) {
+    return null;
+  }
+
+  const visibleRows = rows.slice(0, 8).map((item, index) => formatBusinessItemObject(item, index));
+  const remainingCount = rows.length - visibleRows.length;
+
+  return [
+    `共 ${rows.length} 行`,
+    ...visibleRows,
+    ...(remainingCount > 0 ? [`其余 ${remainingCount} 行未展开`] : []),
+  ].join('\n');
+}
+
 function formatFieldValue(field: string, value: unknown): string {
   if (BOOLEAN_FIELDS.has(field) && (value === 0 || value === 1 || typeof value === 'boolean')) {
     return value === 1 || value === true ? '是' : '否';
+  }
+
+  if (field === 'items') {
+    const itemsValue = formatBusinessItemsValue(value);
+    if (itemsValue) {
+      return itemsValue;
+    }
+  }
+
+  if (field === 'allocation' || field === 'allocationDetails') {
+    const allocationValue = formatAllocationValue(value);
+    if (allocationValue) {
+      return allocationValue;
+    }
   }
 
   return formatChangeValue(value);

--- a/apps/web/src/pages/master-data/components/page-scaffold.tsx
+++ b/apps/web/src/pages/master-data/components/page-scaffold.tsx
@@ -150,14 +150,25 @@ export function OperationTimeline({
             <div className="master-tl-action">操作记录：{record.action}</div>
             {record.changes?.length ? (
               <div className="master-tl-changes">
-                {record.changes.map((change) => (
-                  <div className="master-tl-change-chip" key={change.key}>
-                    <span className="master-tl-change-field">{change.fieldLabel}</span>
-                    <span className="master-tl-change-old">{change.oldValue}</span>
-                    <span className="master-tl-change-arrow">→</span>
-                    <span className="master-tl-change-new">{change.newValue}</span>
-                  </div>
-                ))}
+                {record.changes.map((change) => {
+                  const isLongChange =
+                    change.oldValue.length > 80 ||
+                    change.newValue.length > 80 ||
+                    change.oldValue.includes('\n') ||
+                    change.newValue.includes('\n');
+
+                  return (
+                    <div
+                      className={`master-tl-change-chip${isLongChange ? ' master-tl-change-chip-block' : ''}`}
+                      key={change.key}
+                    >
+                      <span className="master-tl-change-field">{change.fieldLabel}</span>
+                      <span className="master-tl-change-old">{change.oldValue}</span>
+                      <span className="master-tl-change-arrow">→</span>
+                      <span className="master-tl-change-new">{change.newValue}</span>
+                    </div>
+                  );
+                })}
               </div>
             ) : null}
             <Tooltip title={dayjs(record.time).fromNow()}>

--- a/apps/web/src/pages/master-data/master-page.css
+++ b/apps/web/src/pages/master-data/master-page.css
@@ -917,6 +917,44 @@
   min-width: 110px;
 }
 
+.shipping-demand-allocation-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.shipping-demand-allocation-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.shipping-demand-allocation-summary span {
+  border: 1px solid #dbe4f0;
+  border-radius: 6px;
+  background: #f8fafc;
+  color: #334155;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 10px;
+}
+
+.shipping-demand-allocation-sku {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.shipping-demand-allocation-sku strong {
+  color: #0f172a;
+  font-size: 13px;
+}
+
+.shipping-demand-allocation-sku span {
+  color: #64748b;
+  font-size: 12px;
+}
+
 @media (max-width: 1200px) {
   .master-summary-meta {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/web/src/pages/master-data/master-page.css
+++ b/apps/web/src/pages/master-data/master-page.css
@@ -697,6 +697,221 @@
   font-weight: 600;
 }
 
+.shipping-demand-hub {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.shipping-demand-flow {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(88px, 1fr));
+  gap: 0;
+  overflow-x: auto;
+  padding: 4px 0 8px;
+}
+
+.shipping-demand-flow-step {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  min-width: 88px;
+}
+
+.shipping-demand-flow-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 17px;
+  left: calc(50% + 22px);
+  right: calc(-50% + 22px);
+  height: 2px;
+  background: #e2e8f0;
+}
+
+.shipping-demand-flow-step.done:not(:last-child)::after {
+  background: #86efac;
+}
+
+.shipping-demand-flow-node {
+  z-index: 1;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.shipping-demand-flow-step.done .shipping-demand-flow-node {
+  color: #166534;
+  background: #dcfce7;
+  border-color: #bbf7d0;
+}
+
+.shipping-demand-flow-step.active .shipping-demand-flow-node {
+  color: #1d4ed8;
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+}
+
+.shipping-demand-flow-label {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+  font-weight: 700;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.shipping-demand-flow-step.done .shipping-demand-flow-label {
+  color: #166534;
+}
+
+.shipping-demand-flow-step.active .shipping-demand-flow-label {
+  color: #1d4ed8;
+}
+
+.shipping-demand-smart-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.shipping-demand-smart-tooltip {
+  display: inline-flex;
+}
+
+.shipping-demand-smart-button {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #dbe3ef;
+  border-radius: 8px;
+  background: #fff;
+  color: #334155;
+  padding: 0 12px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+}
+
+.shipping-demand-smart-button:hover:not(.disabled) {
+  border-color: #2563eb;
+  color: #2563eb;
+  background: #eff6ff;
+}
+
+.shipping-demand-smart-button.disabled {
+  cursor: not-allowed;
+  color: #94a3b8;
+  background: #f8fafc;
+}
+
+.shipping-demand-smart-icon {
+  display: inline-flex;
+  color: inherit;
+}
+
+.shipping-demand-smart-badge {
+  min-width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  background: #2563eb;
+  font-size: 11px;
+  font-weight: 800;
+  padding: 0 6px;
+}
+
+.shipping-demand-smart-badge.zero {
+  background: #cbd5e1;
+}
+
+.shipping-demand-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.shipping-demand-stat {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px 16px;
+}
+
+.shipping-demand-stat-label {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.shipping-demand-stat-value {
+  margin-top: 6px;
+  color: #0f172a;
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.shipping-demand-stat-subtitle {
+  margin-top: 6px;
+  color: #94a3b8;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.shipping-demand-stat-blue .shipping-demand-stat-value {
+  color: #1d4ed8;
+}
+
+.shipping-demand-stat-green .shipping-demand-stat-value {
+  color: #047857;
+}
+
+.shipping-demand-stat-orange .shipping-demand-stat-value {
+  color: #b45309;
+}
+
+.shipping-demand-inventory {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.shipping-demand-inventory-success {
+  color: #065f46;
+  background: #ecfdf5;
+}
+
+.shipping-demand-inventory-warning {
+  color: #92400e;
+  background: #fffbeb;
+}
+
+.shipping-demand-inventory-danger {
+  color: #b91c1c;
+  background: #fef2f2;
+}
+
 @media (max-width: 1200px) {
   .master-summary-meta {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -719,6 +934,10 @@
     position: static;
     flex-direction: row;
     flex-wrap: wrap;
+  }
+
+  .shipping-demand-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -757,6 +976,10 @@
   }
 
   .master-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .shipping-demand-stat-grid {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/src/pages/master-data/master-page.css
+++ b/apps/web/src/pages/master-data/master-page.css
@@ -912,6 +912,11 @@
   background: #fef2f2;
 }
 
+.shipping-demand-allocation-control {
+  width: 100%;
+  min-width: 110px;
+}
+
 @media (max-width: 1200px) {
   .master-summary-meta {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/web/src/pages/master-data/master-page.css
+++ b/apps/web/src/pages/master-data/master-page.css
@@ -666,11 +666,25 @@
   max-width: 100%;
 }
 
+.master-tl-change-chip-block {
+  width: 100%;
+  align-items: flex-start;
+  border-radius: 10px;
+}
+
+.master-tl-change-chip-block .master-tl-change-field {
+  width: 100%;
+}
+
+.master-tl-change-chip-block .master-tl-change-old,
+.master-tl-change-chip-block .master-tl-change-new {
+  flex: 1 1 260px;
+}
+
 .master-tl-change-old,
 .master-tl-change-new {
   border-radius: 8px;
   padding: 1px 6px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -917,10 +931,83 @@
   min-width: 110px;
 }
 
+.shipping-demand-allocation-dialog .ant-modal {
+  max-width: calc(100vw - 48px);
+  top: 24px;
+  padding-bottom: 24px;
+  transform-origin: center center !important;
+}
+
+.shipping-demand-allocation-dialog.ant-modal-wrap,
+.shipping-demand-allocation-dialog .ant-modal-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.shipping-demand-allocation-dialog .ant-modal-centered::before {
+  display: none;
+}
+
+.shipping-demand-allocation-dialog .ant-modal-content {
+  max-height: calc(100vh - 48px);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.shipping-demand-allocation-dialog .ant-modal-header {
+  margin: 0;
+  padding: 18px 24px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.shipping-demand-allocation-dialog .ant-modal-body {
+  flex: 1;
+  min-height: 0;
+  padding: 16px 24px;
+  overflow: hidden;
+}
+
+.shipping-demand-allocation-dialog .ant-modal-footer {
+  margin: 0;
+  padding: 14px 24px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.shipping-demand-allocation-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shipping-demand-allocation-title span {
+  color: #0f172a;
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.4;
+}
+
+.shipping-demand-allocation-title small {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
 .shipping-demand-allocation-modal {
+  height: 100%;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.shipping-demand-allocation-modal .ant-table-wrapper {
+  min-height: 0;
 }
 
 .shipping-demand-allocation-summary {

--- a/apps/web/src/pages/shipping-demands/detail.tsx
+++ b/apps/web/src/pages/shipping-demands/detail.tsx
@@ -1,11 +1,36 @@
-import { Button, Result, Skeleton, Space, Table } from 'antd';
-import { ShippingDemandStatus } from '@infitek/shared';
+import { Button, Image, Result, Skeleton, Space, Table, Tooltip } from 'antd';
+import {
+  BlType,
+  CustomsDeclarationMethod,
+  DomesticTradeType,
+  FulfillmentType,
+  InvoiceType,
+  OrderNature,
+  PlugType,
+  PrimaryIndustry,
+  ProductLineType,
+  ReceiptStatus,
+  SalesOrderSource,
+  SalesOrderType,
+  SecondaryIndustry,
+  ShippingDemandStatus,
+  TransportationMethod,
+  YesNo,
+} from '@infitek/shared';
+import {
+  CheckCircleOutlined,
+  ExportOutlined,
+  FileDoneOutlined,
+  FileProtectOutlined,
+  FileSearchOutlined,
+} from '@ant-design/icons';
 import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
+import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ActivityTimeline } from '../../components/ActivityTimeline';
-import { getShippingDemandById } from '../../api/shipping-demands.api';
+import { getShippingDemandById, type ShippingDemandItem } from '../../api/shipping-demands.api';
 import {
   AnchorNav,
   MetaItem,
@@ -24,6 +49,188 @@ const STATUS_STYLE_MAP: Record<string, { className: string; text: string }> = {
   [ShippingDemandStatus.VOIDED]: { className: 'master-pill-red', text: '已作废' },
 };
 
+const ORDER_SOURCE_LABELS: Record<string, string> = {
+  [SalesOrderSource.MANUAL]: '手工录单',
+  [SalesOrderSource.THIRD_PARTY]: '第三方获取',
+};
+
+const LABEL_MAP: Record<string, string> = {
+  [DomesticTradeType.DOMESTIC]: '内销',
+  [DomesticTradeType.FOREIGN]: '外销',
+  [SalesOrderType.SALES]: '销售订单',
+  [SalesOrderType.AFTER_SALES]: '售后订单',
+  [SalesOrderType.SAMPLE]: '样品销售',
+  [YesNo.YES]: '是',
+  [YesNo.NO]: '否',
+  [ProductLineType.MAIN]: '主品',
+  [ProductLineType.OPTIONAL]: '选配',
+  [ProductLineType.STANDARD]: '标配',
+  [ProductLineType.GIFT]: '赠品',
+  [PlugType.EU]: '欧标',
+  [PlugType.UK]: '英标',
+  [PlugType.US]: '美标',
+  [PlugType.CN]: '中标',
+  [PlugType.OTHER]: '其他',
+  [PlugType.NONE]: '无',
+  [TransportationMethod.SEA]: '海运',
+  [TransportationMethod.AIR]: '空运',
+  [TransportationMethod.ROAD]: '公路',
+  [TransportationMethod.RAIL]: '铁路',
+  [TransportationMethod.EXPRESS]: '快递',
+  [PrimaryIndustry.EDUCATION]: '教育(教学、科研）',
+  [PrimaryIndustry.GOVERNMENT]: '政府',
+  [PrimaryIndustry.MEDICAL]: '医疗',
+  [PrimaryIndustry.ENTERPRISE]: '企业',
+  [SecondaryIndustry.AGRICULTURE_COLLEGE]: '农学院',
+  [SecondaryIndustry.FOOD]: '食品',
+  [SecondaryIndustry.ANIMAL_SCIENCE]: '动物科学学院',
+  [SecondaryIndustry.PHARMACY]: '药学院',
+  [SecondaryIndustry.MEDICAL_COLLEGE]: '医学院',
+  [SecondaryIndustry.PUBLIC_HEALTH]: '公共卫生学院',
+  [SecondaryIndustry.LIFE_SCIENCE]: '生命科学',
+  [SecondaryIndustry.ENVIRONMENT]: '环境',
+  [OrderNature.BIDDING]: '投标订单',
+  [OrderNature.RETAIL]: '零售订单',
+  [OrderNature.STOCK_PREPARE]: '备库存订单',
+  [ReceiptStatus.UNPAID]: '未收款',
+  [ReceiptStatus.PARTIALLY_PAID]: '部分收款',
+  [ReceiptStatus.PAID]: '已收款',
+  [CustomsDeclarationMethod.SELF]: '公司自行报关',
+  [CustomsDeclarationMethod.ALI_ONE_TOUCH]: '阿里一达通报关',
+  [InvoiceType.VAT_SPECIAL]: '增值税专用发票',
+  [InvoiceType.VAT_NORMAL]: '增值税普通发票',
+  [BlType.TELEX_RELEASE]: '电放',
+  [BlType.ORIGINAL]: '正本',
+  [FulfillmentType.FULL_PURCHASE]: '全部采购',
+  [FulfillmentType.PARTIAL_PURCHASE]: '部分采购',
+  [FulfillmentType.USE_STOCK]: '使用现有库存',
+};
+
+function formatLabel(value?: string | null) {
+  if (!value) return '—';
+  return LABEL_MAP[value] ?? value;
+}
+
+function formatDate(value?: string | null) {
+  return value ? dayjs(value).format('YYYY-MM-DD') : '—';
+}
+
+function numberValue(value?: number | string | null) {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function sumAvailableStock(item: ShippingDemandItem) {
+  return (item.availableStockSnapshot ?? []).reduce(
+    (sum, row) => sum + numberValue(row.availableQuantity),
+    0,
+  );
+}
+
+function InventoryIndicator({ available, required }: { available: number; required: number }) {
+  const tone =
+    available >= required && required > 0
+      ? 'success'
+      : available > 0
+        ? 'warning'
+        : 'danger';
+  const text = tone === 'success' ? '充足' : tone === 'warning' ? '部分不足' : '无库存';
+  return (
+    <span className={`shipping-demand-inventory shipping-demand-inventory-${tone}`}>
+      {text} {available}/{required}
+    </span>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  subtitle,
+  tone,
+}: {
+  label: string;
+  value: ReactNode;
+  subtitle: string;
+  tone: 'blue' | 'green' | 'orange' | 'default';
+}) {
+  return (
+    <div className={`shipping-demand-stat shipping-demand-stat-${tone}`}>
+      <div className="shipping-demand-stat-label">{label}</div>
+      <div className="shipping-demand-stat-value">{value}</div>
+      <div className="shipping-demand-stat-subtitle">{subtitle}</div>
+    </div>
+  );
+}
+
+function FlowProgress({ status }: { status?: ShippingDemandStatus }) {
+  const activeIndexByStatus: Record<string, number> = {
+    [ShippingDemandStatus.PENDING_ALLOCATION]: 1,
+    [ShippingDemandStatus.PURCHASING]: 2,
+    [ShippingDemandStatus.PREPARED]: 3,
+    [ShippingDemandStatus.PARTIALLY_SHIPPED]: 5,
+    [ShippingDemandStatus.SHIPPED]: 6,
+    [ShippingDemandStatus.VOIDED]: 0,
+  };
+  const activeIndex = activeIndexByStatus[status ?? ''] ?? 0;
+  const steps = ['需求创建', '库存检查', '采购备货', '库存锁定', '创建物流', '出库发货', '完成'];
+
+  return (
+    <div className="shipping-demand-flow">
+      {steps.map((step, index) => {
+        const done = index < activeIndex;
+        const active = index === activeIndex && status !== ShippingDemandStatus.VOIDED;
+        const className = done ? 'done' : active ? 'active' : 'pending';
+        return (
+          <div className={`shipping-demand-flow-step ${className}`} key={step}>
+            <div className="shipping-demand-flow-node">
+              {done ? <CheckCircleOutlined /> : index + 1}
+            </div>
+            <div className="shipping-demand-flow-label">{step}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function SmartButton({
+  icon,
+  label,
+  count,
+  disabled,
+  disabledTooltip = '下游模块尚未实现',
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  count: number;
+  disabled?: boolean;
+  disabledTooltip?: string;
+  onClick?: () => void;
+}) {
+  const isDisabled = disabled || !onClick;
+  const content = (
+    <button
+      type="button"
+      className={`shipping-demand-smart-button${isDisabled ? ' disabled' : ''}`}
+      disabled={isDisabled}
+      onClick={onClick}
+    >
+      <span className="shipping-demand-smart-icon">{icon}</span>
+      <span>{label}</span>
+      <span className={`shipping-demand-smart-badge${count === 0 ? ' zero' : ''}`}>{count}</span>
+    </button>
+  );
+
+  return isDisabled ? (
+    <Tooltip title={disabledTooltip}>
+      <span className="shipping-demand-smart-tooltip">{content}</span>
+    </Tooltip>
+  ) : (
+    content
+  );
+}
+
 export default function ShippingDemandDetailPage() {
   const navigate = useNavigate();
   const { id = '' } = useParams();
@@ -36,28 +243,59 @@ export default function ShippingDemandDetailPage() {
     enabled: Number.isInteger(demandId) && demandId > 0,
   });
 
+  const data = query.data;
+  const items = data?.items ?? [];
+  const sourceSalesOrderLink = data?.salesOrderId
+    ? () => navigate(`/sales-orders/${data.salesOrderId}`)
+    : undefined;
+  const totalSkuCount = data?.skuCount ?? items.length;
+  const totalRequiredQuantity = items.reduce((sum, item) => sum + numberValue(item.requiredQuantity), 0);
+  const totalLockedQuantity = items.reduce((sum, item) => sum + numberValue(item.lockedRemainingQuantity), 0);
+  const totalShippedQuantity = items.reduce((sum, item) => sum + numberValue(item.shippedQuantity), 0);
+
   const columns = useMemo(
     () => [
       { title: 'SKU', dataIndex: 'skuCode', key: 'skuCode', width: 140, fixed: 'left' as const },
       { title: '产品中文名', dataIndex: 'productNameCn', key: 'productNameCn', width: 180, render: displayOrDash },
       { title: '产品英文名', dataIndex: 'productNameEn', key: 'productNameEn', width: 180, render: displayOrDash },
+      { title: '规格', dataIndex: 'skuSpecification', key: 'skuSpecification', width: 180, render: displayOrDash },
+      { title: '类型', dataIndex: 'lineType', key: 'lineType', width: 100, render: formatLabel },
+      { title: 'SPU', dataIndex: 'spuName', key: 'spuName', width: 140, render: displayOrDash },
+      { title: '电参数', dataIndex: 'electricalParams', key: 'electricalParams', width: 160, render: displayOrDash },
+      { title: '有无插头', dataIndex: 'hasPlug', key: 'hasPlug', width: 100, render: formatLabel },
+      { title: '插头类型', dataIndex: 'plugType', key: 'plugType', width: 100, render: formatLabel },
       { title: '应发数量', dataIndex: 'requiredQuantity', key: 'requiredQuantity', width: 100 },
-      { title: '履行类型', dataIndex: 'fulfillmentType', key: 'fulfillmentType', width: 120, render: displayOrDash },
-      { title: '使用现有库存', dataIndex: 'stockRequiredQuantity', key: 'stockRequiredQuantity', width: 130 },
+      { title: '可用库存', key: 'availableStock', width: 150, render: (_: unknown, record: ShippingDemandItem) => <InventoryIndicator available={sumAvailableStock(record)} required={numberValue(record.requiredQuantity)} /> },
+      { title: '履行类型', dataIndex: 'fulfillmentType', key: 'fulfillmentType', width: 130, render: formatLabel },
+      { title: '销售单价', dataIndex: 'unitPrice', key: 'unitPrice', width: 120 },
+      { title: '币种', dataIndex: 'currencyCode', key: 'currencyCode', width: 90, render: displayOrDash },
+      { title: '总金额', dataIndex: 'amount', key: 'amount', width: 120 },
+      { title: '单位', dataIndex: 'unitName', key: 'unitName', width: 100, render: displayOrDash },
+      { title: '采购人员', dataIndex: 'purchaserName', key: 'purchaserName', width: 120, render: displayOrDash },
+      { title: '是否需要采购', dataIndex: 'needsPurchase', key: 'needsPurchase', width: 120, render: formatLabel },
       { title: '需采购数量', dataIndex: 'purchaseRequiredQuantity', key: 'purchaseRequiredQuantity', width: 120 },
+      { title: '使用现有库存数量', dataIndex: 'stockRequiredQuantity', key: 'stockRequiredQuantity', width: 150 },
       { title: '已锁定待发', dataIndex: 'lockedRemainingQuantity', key: 'lockedRemainingQuantity', width: 120 },
       { title: '已发货数量', dataIndex: 'shippedQuantity', key: 'shippedQuantity', width: 120 },
+      { title: '采购已下单', dataIndex: 'purchaseOrderedQuantity', key: 'purchaseOrderedQuantity', width: 120 },
+      { title: '已收货数量', dataIndex: 'receivedQuantity', key: 'receivedQuantity', width: 120 },
+      { title: '产品材质', dataIndex: 'material', key: 'material', width: 120, render: displayOrDash },
+      { title: '单品重量(kg)', dataIndex: 'unitWeightKg', key: 'unitWeightKg', width: 120 },
+      { title: '单品体积(m³)', dataIndex: 'unitVolumeCbm', key: 'unitVolumeCbm', width: 130 },
+      { title: '总重量(kg)', dataIndex: 'totalWeightKg', key: 'totalWeightKg', width: 120 },
+      { title: '总体积(m³)', dataIndex: 'totalVolumeCbm', key: 'totalVolumeCbm', width: 120 },
+      { title: '图片', dataIndex: 'imageUrl', key: 'imageUrl', width: 100, render: (value: string | null) => value ? <Image width={40} src={value} /> : '—' },
       {
         title: '库存快照',
         dataIndex: 'availableStockSnapshot',
         key: 'availableStockSnapshot',
-        width: 220,
-        render: (value: Array<{ warehouseId: number | null; availableQuantity: number }> | null) =>
+        width: 240,
+        render: (value: ShippingDemandItem['availableStockSnapshot']) =>
           value?.length ? (
             <Space direction="vertical" size={2}>
               {value.map((row) => (
                 <span key={`${row.warehouseId ?? 'none'}-${row.availableQuantity}`}>
-                  仓库 {row.warehouseId ?? '未指定'}：可用 {row.availableQuantity}
+                  仓库 {row.warehouseId ?? '未指定'}：实存 {row.actualQuantity} / 锁定 {row.lockedQuantity} / 可用 {row.availableQuantity}
                 </span>
               ))}
             </Space>
@@ -74,7 +312,7 @@ export default function ShippingDemandDetailPage() {
       <Result
         status="404"
         title="发货需求不存在"
-        extra={<Button type="primary" onClick={() => navigate('/sales-orders')}>返回销售订单</Button>}
+        extra={<Button type="primary" onClick={() => navigate('/shipping-demands')}>返回发货需求</Button>}
       />
     );
   }
@@ -86,20 +324,25 @@ export default function ShippingDemandDetailPage() {
         title="发货需求详情加载失败"
         extra={[
           <Button key="retry" type="primary" onClick={() => query.refetch()}>重试</Button>,
-          <Button key="back" onClick={() => navigate('/sales-orders')}>返回销售订单</Button>,
+          <Button key="back" onClick={() => navigate('/shipping-demands')}>返回发货需求</Button>,
         ]}
       />
     );
   }
 
-  const data = query.data;
   const statusInfo = STATUS_STYLE_MAP[data?.status ?? ''] ?? {
     className: 'master-pill-default',
     text: displayOrDash(data?.status),
   };
   const anchors = [
     { key: 'basic', label: '基础信息' },
+    { key: 'order', label: '订单信息' },
     { key: 'items', label: '产品明细' },
+    { key: 'delivery', label: '收发通信息' },
+    ...(data?.domesticTradeType === DomesticTradeType.DOMESTIC
+      ? [{ key: 'domestic', label: '内销收货信息' }]
+      : []),
+    { key: 'shipping', label: '发货要求' },
     { key: 'operation', label: '操作记录' },
   ];
 
@@ -119,43 +362,177 @@ export default function ShippingDemandDetailPage() {
                 </div>
               </div>
               <div className="master-summary-actions">
-                <Button onClick={() => navigate(`/sales-orders/${data?.salesOrderId}`)}>返回销售订单</Button>
+                <Space wrap>
+                  <Button onClick={() => navigate('/shipping-demands')}>返回列表</Button>
+                  <Button disabled={!sourceSalesOrderLink} onClick={sourceSalesOrderLink}>来源销售订单</Button>
+                </Space>
               </div>
             </div>
             <div className="master-summary-meta">
               <SummaryMetaItem label="客户" value={displayOrDash(data?.customerName)} />
               <SummaryMetaItem label="客户代码" value={displayOrDash(data?.customerCode)} />
               <SummaryMetaItem label="币种" value={displayOrDash(data?.currencyCode)} />
-              <SummaryMetaItem label="订单金额" value={displayOrDash(data?.totalAmount)} />
+              <SummaryMetaItem label="总金额" value={displayOrDash(data?.totalAmount)} />
             </div>
           </>
         )}
       </div>
 
+      <SectionCard id="hub" title="发货枢纽" description="查看流程阶段、关联入口和履约数量摘要。">
+        <div className="shipping-demand-hub">
+          <FlowProgress status={data?.status} />
+          <div className="shipping-demand-smart-row">
+            <SmartButton
+              icon={<FileSearchOutlined />}
+              label="来源销售订单"
+              count={data ? 1 : 0}
+              disabledTooltip="发货需求加载后可跳转"
+              onClick={sourceSalesOrderLink}
+            />
+            <SmartButton icon={<FileProtectOutlined />} label="采购订单" count={0} disabled />
+            <SmartButton icon={<ExportOutlined />} label="物流单" count={0} disabled />
+            <SmartButton icon={<FileDoneOutlined />} label="出库单" count={0} disabled />
+          </div>
+          <div className="shipping-demand-stat-grid">
+            <StatCard label="总 SKU 种类" value={totalSkuCount} subtitle="按发货需求明细统计" tone="blue" />
+            <StatCard label="总应发数量" value={totalRequiredQuantity} subtitle="来自销售订单签约数量" tone="default" />
+            <StatCard label="已锁定数量" value={totalLockedQuantity} subtitle="当前锁定待发数量" tone="green" />
+            <StatCard label="已出库数量" value={totalShippedQuantity} subtitle="累计已发货数量" tone="orange" />
+          </div>
+        </div>
+      </SectionCard>
+
       <div className="master-detail-layout">
         <AnchorNav anchors={anchors} activeKey={activeAnchor} onChange={setActiveAnchor} />
         <div className="master-detail-main">
-          <SectionCard id="basic" title="基础信息" description="查看发货需求来源和状态。">
+          <SectionCard id="basic" title="基础信息" description="查看发货需求来源、客户和主键信息。">
             <div className="master-meta-grid">
               <MetaItem label="发货需求编号" value={displayOrDash(data?.demandCode)} />
-              <MetaItem label="来源销售订单" value={displayOrDash(data?.sourceDocumentCode)} />
+              <MetaItem
+                label="来源销售订单"
+                value={
+                  data?.salesOrderId ? (
+                    <a onClick={sourceSalesOrderLink}>{displayOrDash(data.sourceDocumentCode)}</a>
+                  ) : (
+                    displayOrDash(data?.sourceDocumentCode)
+                  )
+                }
+              />
               <MetaItem label="状态" value={<span className={`master-pill ${statusInfo.className}`}>{statusInfo.text}</span>} />
+              <MetaItem label="订单来源" value={data?.orderSource ? ORDER_SOURCE_LABELS[data.orderSource] ?? data.orderSource : '—'} />
+              <MetaItem label="内外销" value={formatLabel(data?.domesticTradeType)} />
+              <MetaItem label="订单号" value={displayOrDash(data?.externalOrderCode)} />
+              <MetaItem label="订单类型" value={formatLabel(data?.orderType)} />
               <MetaItem label="客户" value={displayOrDash(data?.customerName)} />
+              <MetaItem label="客户代码" value={displayOrDash(data?.customerCode)} />
+              <MetaItem label="联系人" value={displayOrDash(data?.customerContactPerson)} />
+              <MetaItem label="售后原订单号" value={displayOrDash(data?.afterSalesSourceOrderCode)} />
               <MetaItem label="运抵国" value={displayOrDash(data?.destinationCountryName)} />
-              <MetaItem label="目的地" value={displayOrDash(data?.destinationPortName)} />
+              <MetaItem label="起运地" value={displayOrDash(data?.shipmentOriginCountryName)} />
+              <MetaItem label="签约公司" value={displayOrDash(data?.signingCompanyName)} />
+              <MetaItem label="销售员" value={displayOrDash(data?.salespersonName)} />
               <MetaItem label="商务跟单" value={displayOrDash(data?.merchandiserName)} />
-              <MetaItem label="要求到货日期" value={data?.requiredDeliveryAt ? dayjs(data.requiredDeliveryAt).format('YYYY-MM-DD') : '—'} />
+              <MetaItem label="商务跟单英文简写" value={displayOrDash(data?.merchandiserAbbr)} />
+              <MetaItem label="所有售后产品品名及对应总价" value={displayOrDash(data?.afterSalesProductSummary)} full />
             </div>
           </SectionCard>
 
-          <SectionCard id="items" title="产品明细" description="查看生成时继承的订单 SKU 和库存快照。" bodyClassName="master-section-table">
+          <SectionCard id="order" title="订单信息" description="查看交付、收款和订单附加属性。">
+            <div className="master-meta-grid">
+              <MetaItem label="要求到货日期" value={formatDate(data?.requiredDeliveryAt)} />
+              <MetaItem label="付款方式" value={displayOrDash(data?.paymentTerm)} />
+              <MetaItem label="外销币种" value={displayOrDash(data?.currencyCode)} />
+              <MetaItem label="目的地" value={displayOrDash(data?.destinationPortName)} />
+              <MetaItem label="合同金额" value={displayOrDash(data?.contractAmount)} />
+              <MetaItem label="已收款金额" value={displayOrDash(data?.receivedAmount)} />
+              <MetaItem label="待收款金额" value={displayOrDash(data?.outstandingAmount)} />
+              <MetaItem label="产品合计金额" value={displayOrDash(data?.productTotalAmount)} />
+              <MetaItem label="加项费用合计" value={displayOrDash(data?.expenseTotalAmount)} />
+              <MetaItem label="订单总金额" value={displayOrDash(data?.totalAmount)} />
+              <MetaItem label="贸易术语" value={displayOrDash(data?.tradeTerm)} />
+              <MetaItem label="运输方式" value={formatLabel(data?.transportationMethod)} />
+              <MetaItem label="一级行业" value={formatLabel(data?.primaryIndustry)} />
+              <MetaItem label="二级行业" value={formatLabel(data?.secondaryIndustry)} />
+              <MetaItem label="订单性质" value={formatLabel(data?.orderNature)} />
+              <MetaItem label="汇率" value={displayOrDash(data?.exchangeRate)} />
+              <MetaItem label="CRM签约日期" value={formatDate(data?.crmSignedAt)} />
+              <MetaItem label="银行账号" value={displayOrDash(data?.bankAccount)} />
+              <MetaItem label="额外查看人" value={displayOrDash(data?.extraViewerName)} />
+              <MetaItem label="收款状态" value={formatLabel(data?.receiptStatus)} />
+              <MetaItem label="是否分摊订单" value={formatLabel(data?.isSharedOrder)} />
+              <MetaItem label="是否中信保" value={formatLabel(data?.isSinosure)} />
+              <MetaItem label="是否打托" value={formatLabel(data?.isPalletized)} />
+              <MetaItem label="是否需要清关证书" value={formatLabel(data?.requiresCustomsCertificate)} />
+              <MetaItem label="是否提前分单" value={formatLabel(data?.isSplitInAdvance)} />
+              <MetaItem label="是否使用市场经费" value={formatLabel(data?.usesMarketingFund)} />
+              <MetaItem label="是否出口报关" value={formatLabel(data?.requiresExportCustoms)} />
+              <MetaItem label="是否需要质保卡" value={formatLabel(data?.requiresWarrantyCard)} />
+              <MetaItem label="是否产假交接单" value={formatLabel(data?.requiresMaternityHandover)} />
+              <MetaItem label="报关方式" value={formatLabel(data?.customsDeclarationMethod)} />
+              <MetaItem label="是否投保" value={formatLabel(data?.isInsured)} />
+              <MetaItem label="是否阿里信保订单" value={formatLabel(data?.isAliTradeAssurance)} />
+              <MetaItem label="阿里信保订单号" value={displayOrDash(data?.aliTradeAssuranceOrderCode)} />
+              <MetaItem label="询价货代及费用" value={displayOrDash(data?.forwarderQuoteNote)} full />
+              <MetaItem label="合同文件" value={data?.contractFileUrls?.length ? data.contractFileUrls.map((url, idx) => <div key={url}><a href={url} target="_blank" rel="noreferrer">{data.contractFileNames?.[idx] ?? `文件${idx + 1}`}</a></div>) : '—'} full />
+              <MetaItem label="插头照片" value={data?.plugPhotoUrls?.length ? <Space wrap>{data.plugPhotoUrls.map((url) => <Image key={url} width={80} src={url} />)}</Space> : '—'} full />
+            </div>
+          </SectionCard>
+
+          <SectionCard id="items" title="产品明细" description="查看生成时继承的订单 SKU、履约数量和库存快照。" bodyClassName="master-section-table">
             <Table
               rowKey="id"
               pagination={false}
               columns={columns as any}
-              dataSource={data?.items ?? []}
-              scroll={{ x: 1400 }}
+              dataSource={items}
+              scroll={{ x: 4200 }}
             />
+          </SectionCard>
+
+          <SectionCard id="delivery" title="收发通信息" description="收货人、通知人和发货人信息。">
+            <div className="master-meta-grid">
+              <MetaItem label="收货人公司(Consignee)" value={displayOrDash(data?.consigneeCompany)} full />
+              <MetaItem label="收货人其他信息" value={displayOrDash(data?.consigneeOtherInfo)} full />
+              <MetaItem label="通知人公司(Notify)" value={displayOrDash(data?.notifyCompany)} full />
+              <MetaItem label="通知人其他信息" value={displayOrDash(data?.notifyOtherInfo)} full />
+              <MetaItem label="发货人公司(Shipper)" value={displayOrDash(data?.shipperCompany)} full />
+              <MetaItem label="发货人其他信息" value={displayOrDash(data?.shipperOtherInfoCompanyName)} />
+            </div>
+          </SectionCard>
+
+          {data?.domesticTradeType === DomesticTradeType.DOMESTIC ? (
+            <SectionCard id="domestic" title="内销收货信息" description="内销订单的客户收货信息。">
+              <div className="master-meta-grid">
+                <MetaItem label="客户公司" value={displayOrDash(data?.domesticCustomerCompany)} full />
+                <MetaItem label="客户收货信息" value={displayOrDash(data?.domesticCustomerDeliveryInfo)} full />
+              </div>
+            </SectionCard>
+          ) : null}
+
+          <SectionCard id="shipping" title="发货要求" description="查看唛头、发票与清关要求。">
+            <div className="master-meta-grid">
+              <MetaItem label="是否公司常规唛头" value={formatLabel(data?.usesDefaultShippingMark)} />
+              <MetaItem label="唛头补充信息" value={displayOrDash(data?.shippingMarkNote)} />
+              <MetaItem
+                label="唛头模板"
+                value={
+                  data?.shippingMarkTemplateUrl ? (
+                    <a href={data.shippingMarkTemplateUrl} target="_blank" rel="noreferrer">
+                      {data.shippingMarkTemplateKey?.split('/').pop() ?? '查看模板'}
+                    </a>
+                  ) : (
+                    displayOrDash(data?.shippingMarkTemplateKey)
+                  )
+                }
+              />
+              <MetaItem label="客户是否需要开票" value={formatLabel(data?.needsInvoice)} />
+              <MetaItem label="开票类型" value={formatLabel(data?.invoiceType)} />
+              <MetaItem label="随货文件" value={displayOrDash(data?.shippingDocumentsNote)} />
+              <MetaItem label="签单/出提单方式" value={formatLabel(data?.blType)} />
+              <MetaItem label="正本邮寄地址" value={displayOrDash(data?.originalMailAddress)} full />
+              <MetaItem label="业务整改要求" value={displayOrDash(data?.businessRectificationNote)} full />
+              <MetaItem label="清关单据要求" value={displayOrDash(data?.customsDocumentNote)} full />
+              <MetaItem label="其他要求及注意事项" value={displayOrDash(data?.otherRequirementNote)} full />
+            </div>
           </SectionCard>
 
           <SectionCard id="operation" title="操作记录" description="展示发货需求的生成和后续处理轨迹。">

--- a/apps/web/src/pages/shipping-demands/detail.tsx
+++ b/apps/web/src/pages/shipping-demands/detail.tsx
@@ -1,4 +1,4 @@
-import { App, Button, Image, InputNumber, Popconfirm, Result, Select, Skeleton, Space, Table, Tooltip } from 'antd';
+import { App, Button, Image, InputNumber, Modal, Result, Select, Skeleton, Space, Table, Tooltip } from 'antd';
 import {
   BlType,
   CustomsDeclarationMethod,
@@ -38,6 +38,7 @@ import {
   type ShippingDemandItem,
 } from '../../api/shipping-demands.api';
 import { getInventoryBatches, type InventoryBatchItem } from '../../api/inventory.api';
+import { getWarehouses, type Warehouse } from '../../api/warehouses.api';
 import {
   AnchorNav,
   MetaItem,
@@ -59,6 +60,11 @@ const STATUS_STYLE_MAP: Record<string, { className: string; text: string }> = {
 const ORDER_SOURCE_LABELS: Record<string, string> = {
   [SalesOrderSource.MANUAL]: '手工录单',
   [SalesOrderSource.THIRD_PARTY]: '第三方获取',
+};
+
+const INVENTORY_BATCH_SOURCE_LABELS: Record<string, string> = {
+  initial: '期初录入',
+  purchase_receipt: '采购入库',
 };
 
 const FULFILLMENT_OPTIONS = [
@@ -136,6 +142,11 @@ function formatLabel(value?: string | null) {
   return LABEL_MAP[value] ?? value;
 }
 
+function formatBatchSource(value?: string | null) {
+  if (!value) return '—';
+  return INVENTORY_BATCH_SOURCE_LABELS[value] ?? value;
+}
+
 function formatDate(value?: string | null) {
   return value ? dayjs(value).format('YYYY-MM-DD') : '—';
 }
@@ -152,33 +163,54 @@ function sumAvailableStock(item: ShippingDemandItem) {
   );
 }
 
-function uniqueWarehouses(item: ShippingDemandItem): WarehouseOption[] {
+function getWarehouseDisplayName(warehouseMap: Map<number, Warehouse>, warehouseId?: number | null) {
+  if (!warehouseId) return '未指定仓库';
+  const warehouse = warehouseMap.get(warehouseId);
+  if (!warehouse) return `仓库 #${warehouseId}`;
+  return warehouse.warehouseCode
+    ? `${warehouse.name} (${warehouse.warehouseCode})`
+    : warehouse.name;
+}
+
+function uniqueWarehouses(
+  item: ShippingDemandItem,
+  warehouseMap: Map<number, Warehouse> = new Map(),
+): WarehouseOption[] {
   const map = new Map<number, WarehouseOption>();
   for (const row of item.availableStockSnapshot ?? []) {
     const warehouseId = row.warehouseId;
     if (!warehouseId) continue;
     const current = map.get(warehouseId);
     const availableQuantity = numberValue(row.availableQuantity);
+    const totalAvailable = availableQuantity + (current?.availableQuantity ?? 0);
     map.set(warehouseId, {
-      label: `仓库 ${warehouseId} / 可用 ${availableQuantity + (current?.availableQuantity ?? 0)}`,
+      label: `${getWarehouseDisplayName(warehouseMap, warehouseId)} / 可用 ${totalAvailable}`,
       value: warehouseId,
-      availableQuantity: availableQuantity + (current?.availableQuantity ?? 0),
+      availableQuantity: totalAvailable,
     });
   }
   return [...map.values()];
 }
 
-function selectWarehouse(item: ShippingDemandItem, targetQuantity: number) {
-  const warehouses = uniqueWarehouses(item);
+function selectWarehouse(
+  item: ShippingDemandItem,
+  targetQuantity: number,
+  warehouseMap: Map<number, Warehouse> = new Map(),
+) {
+  const warehouses = uniqueWarehouses(item, warehouseMap);
   return (
     warehouses.find((warehouse) => warehouse.availableQuantity >= targetQuantity) ??
     [...warehouses].sort((a, b) => b.availableQuantity - a.availableQuantity)[0]
   );
 }
 
-function getWarehouseAvailable(item: ShippingDemandItem, warehouseId?: number) {
+function getWarehouseAvailable(
+  item: ShippingDemandItem,
+  warehouseId?: number,
+  warehouseMap: Map<number, Warehouse> = new Map(),
+) {
   if (!warehouseId) return 0;
-  return uniqueWarehouses(item).find((warehouse) => warehouse.value === warehouseId)?.availableQuantity ?? 0;
+  return uniqueWarehouses(item, warehouseMap).find((warehouse) => warehouse.value === warehouseId)?.availableQuantity ?? 0;
 }
 
 function getFifoPreviewBatches(
@@ -201,17 +233,20 @@ function getFifoPreviewBatches(
     });
 }
 
-function defaultAllocationDraft(item: ShippingDemandItem): AllocationDraft {
+function defaultAllocationDraft(
+  item: ShippingDemandItem,
+  warehouseMap: Map<number, Warehouse> = new Map(),
+): AllocationDraft {
   const required = numberValue(item.requiredQuantity);
   const stockQuantity = numberValue(item.stockRequiredQuantity);
   if (item.fulfillmentType) {
     return {
       fulfillmentType: item.fulfillmentType,
       stockQuantity,
-      warehouseId: stockQuantity > 0 ? selectWarehouse(item, stockQuantity)?.value : undefined,
+      warehouseId: stockQuantity > 0 ? selectWarehouse(item, stockQuantity, warehouseMap)?.value : undefined,
     };
   }
-  const warehouse = selectWarehouse(item, required);
+  const warehouse = selectWarehouse(item, required, warehouseMap);
   if (warehouse && warehouse.availableQuantity >= required && required > 0) {
     return {
       fulfillmentType: FulfillmentType.USE_STOCK,
@@ -344,6 +379,7 @@ export default function ShippingDemandDetailPage() {
   const demandId = Number(id);
   const [activeAnchor, setActiveAnchor] = useState('basic');
   const [allocationDrafts, setAllocationDrafts] = useState<Record<number, AllocationDraft>>({});
+  const [allocationModalOpen, setAllocationModalOpen] = useState(false);
 
   const query = useQuery({
     queryKey: ['shipping-demand-detail', demandId],
@@ -371,6 +407,18 @@ export default function ShippingDemandDetailPage() {
     queryFn: () => getInventoryBatches({ skuIds: batchSkuIds }),
     enabled: canConfirmAllocation && batchSkuIds.length > 0,
   });
+  const warehousesQuery = useQuery({
+    queryKey: ['shipping-demand-warehouses'],
+    queryFn: () => getWarehouses({ page: 1, pageSize: 500 }),
+  });
+  const warehouseMap = useMemo(() => {
+    const map = new Map<number, Warehouse>();
+    for (const warehouse of warehousesQuery.data?.list ?? []) {
+      const warehouseId = numberValue(warehouse.id);
+      if (warehouseId > 0) map.set(warehouseId, warehouse);
+    }
+    return map;
+  }, [warehousesQuery.data]);
 
   useEffect(() => {
     if (!data?.items?.length) {
@@ -391,6 +439,7 @@ export default function ShippingDemandDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['shipping-demand-detail', demandId] });
       queryClient.invalidateQueries({ queryKey: ['shipping-demands'] });
       queryClient.invalidateQueries({ queryKey: ['operation-logs', 'shipping-demands', demandId] });
+      setAllocationModalOpen(false);
       notification.success({
         message: '库存分配已确认',
         description: '系统已按履行类型更新发货需求，并完成现有库存的 FIFO 锁定。',
@@ -415,7 +464,7 @@ export default function ShippingDemandDetailPage() {
 
   const handleFulfillmentChange = (item: ShippingDemandItem, fulfillmentType: FulfillmentType) => {
     const required = numberValue(item.requiredQuantity);
-    const warehouse = selectWarehouse(item, required);
+    const warehouse = selectWarehouse(item, required, warehouseMap);
     if (fulfillmentType === FulfillmentType.FULL_PURCHASE) {
       updateDraft(item.id, { fulfillmentType, stockQuantity: 0, warehouseId: undefined });
       return;
@@ -445,7 +494,7 @@ export default function ShippingDemandDetailPage() {
         return null;
       }
       const stockQuantity = numberValue(draft.stockQuantity);
-      const warehouseAvailable = getWarehouseAvailable(item, draft.warehouseId);
+      const warehouseAvailable = getWarehouseAvailable(item, draft.warehouseId, warehouseMap);
       if (!Number.isInteger(stockQuantity) || stockQuantity < 0 || stockQuantity > required) {
         message.error(`${item.skuCode} 使用库存数量必须在 0 到 ${required} 之间`);
         return null;
@@ -489,46 +538,51 @@ export default function ShippingDemandDetailPage() {
     confirmAllocationMutation.mutate(payload);
   };
 
-  const columns = useMemo<ColumnsType<ShippingDemandItem>>(
+  const allocationColumns = useMemo<ColumnsType<ShippingDemandItem>>(
     () => [
-      { title: 'SKU', dataIndex: 'skuCode', key: 'skuCode', width: 140, fixed: 'left' as const },
-      { title: '产品中文名', dataIndex: 'productNameCn', key: 'productNameCn', width: 180, render: displayOrDash },
-      { title: '产品英文名', dataIndex: 'productNameEn', key: 'productNameEn', width: 180, render: displayOrDash },
-      { title: '规格', dataIndex: 'skuSpecification', key: 'skuSpecification', width: 180, render: displayOrDash },
-      { title: '类型', dataIndex: 'lineType', key: 'lineType', width: 100, render: formatLabel },
-      { title: 'SPU', dataIndex: 'spuName', key: 'spuName', width: 140, render: displayOrDash },
-      { title: '电参数', dataIndex: 'electricalParams', key: 'electricalParams', width: 160, render: displayOrDash },
-      { title: '有无插头', dataIndex: 'hasPlug', key: 'hasPlug', width: 100, render: formatLabel },
-      { title: '插头类型', dataIndex: 'plugType', key: 'plugType', width: 100, render: formatLabel },
-      { title: '应发数量', dataIndex: 'requiredQuantity', key: 'requiredQuantity', width: 100 },
-      { title: '可用库存', key: 'availableStock', width: 150, render: (_: unknown, record: ShippingDemandItem) => <InventoryIndicator available={sumAvailableStock(record)} required={numberValue(record.requiredQuantity)} /> },
       {
-        title: '履行类型',
-        dataIndex: 'fulfillmentType',
-        key: 'fulfillmentType',
-        width: 160,
-        render: (value: FulfillmentType | null, record: ShippingDemandItem) =>
-          canConfirmAllocation ? (
-            <Select<FulfillmentType>
-              className="shipping-demand-allocation-control"
-              value={allocationDrafts[record.id]?.fulfillmentType}
-              options={FULFILLMENT_OPTIONS}
-              onChange={(nextValue) => handleFulfillmentChange(record, nextValue)}
-            />
-          ) : (
-            formatLabel(value)
-          ),
+        title: 'SKU',
+        dataIndex: 'skuCode',
+        key: 'skuCode',
+        width: 150,
+        fixed: 'left' as const,
+        render: (value: string, record) => (
+          <div className="shipping-demand-allocation-sku">
+            <strong>{displayOrDash(value)}</strong>
+            <span>{displayOrDash(record.productNameCn ?? record.productNameEn)}</span>
+          </div>
+        ),
+      },
+      { title: '规格', dataIndex: 'skuSpecification', key: 'skuSpecification', width: 150, render: displayOrDash },
+      { title: '应发', dataIndex: 'requiredQuantity', key: 'requiredQuantity', width: 80 },
+      {
+        title: '可用库存',
+        key: 'availableStock',
+        width: 130,
+        render: (_: unknown, record) => (
+          <InventoryIndicator available={sumAvailableStock(record)} required={numberValue(record.requiredQuantity)} />
+        ),
       },
       {
-        title: '库存仓库',
-        key: 'allocationWarehouse',
-        width: 170,
-        render: (_: unknown, record: ShippingDemandItem) => {
+        title: '履行类型',
+        key: 'fulfillmentType',
+        width: 150,
+        render: (_: unknown, record) => (
+          <Select<FulfillmentType>
+            className="shipping-demand-allocation-control"
+            value={allocationDrafts[record.id]?.fulfillmentType}
+            options={FULFILLMENT_OPTIONS}
+            onChange={(nextValue) => handleFulfillmentChange(record, nextValue)}
+          />
+        ),
+      },
+      {
+        title: '使用仓库',
+        key: 'warehouseId',
+        width: 190,
+        render: (_: unknown, record) => {
           const draft = allocationDrafts[record.id];
-          const options = uniqueWarehouses(record).map(({ label, value }) => ({ label, value }));
-          if (!canConfirmAllocation) {
-            return '—';
-          }
+          const options = uniqueWarehouses(record, warehouseMap).map(({ label, value }) => ({ label, value }));
           return (
             <Select<number>
               className="shipping-demand-allocation-control"
@@ -542,12 +596,11 @@ export default function ShippingDemandDetailPage() {
         },
       },
       {
-        title: '本次使用库存',
-        key: 'allocationStockQuantity',
-        width: 140,
-        render: (_: unknown, record: ShippingDemandItem) => {
+        title: '使用库存',
+        key: 'stockQuantity',
+        width: 110,
+        render: (_: unknown, record) => {
           const draft = allocationDrafts[record.id];
-          if (!canConfirmAllocation) return displayOrDash(record.stockRequiredQuantity);
           return (
             <InputNumber
               className="shipping-demand-allocation-control"
@@ -562,12 +615,19 @@ export default function ShippingDemandDetailPage() {
         },
       },
       {
+        title: '需采购',
+        key: 'purchaseQuantity',
+        width: 90,
+        render: (_: unknown, record) =>
+          Math.max(0, numberValue(record.requiredQuantity) - numberValue(allocationDrafts[record.id]?.stockQuantity)),
+      },
+      {
         title: 'FIFO 批次预览',
         key: 'fifoBatchPreview',
-        width: 280,
-        render: (_: unknown, record: ShippingDemandItem) => {
+        width: 310,
+        render: (_: unknown, record) => {
           const draft = allocationDrafts[record.id];
-          if (!canConfirmAllocation || !draft?.warehouseId || numberValue(draft.stockQuantity) <= 0) {
+          if (!draft?.warehouseId || numberValue(draft.stockQuantity) <= 0) {
             return '—';
           }
           if (batchesQuery.isLoading) {
@@ -581,13 +641,31 @@ export default function ShippingDemandDetailPage() {
             <Space direction="vertical" size={2}>
               {batches.map((batch) => (
                 <span key={String(batch.id)}>
-                  {formatDate(batch.receiptDate)} / {batch.sourceType} / 批次 {batch.batchQuantity} / 可用 {batch.batchAvailableQuantity}
+                  {formatDate(batch.receiptDate)} / {formatBatchSource(batch.sourceType)} / 批次 {batch.batchQuantity} / 可用 {batch.batchAvailableQuantity}
                 </span>
               ))}
             </Space>
           );
         },
       },
+    ],
+    [allocationDrafts, batchesQuery.data, batchesQuery.isLoading, warehouseMap],
+  );
+
+  const columns = useMemo<ColumnsType<ShippingDemandItem>>(
+    () => [
+      { title: 'SKU', dataIndex: 'skuCode', key: 'skuCode', width: 140, fixed: 'left' as const },
+      { title: '产品中文名', dataIndex: 'productNameCn', key: 'productNameCn', width: 180, render: displayOrDash },
+      { title: '产品英文名', dataIndex: 'productNameEn', key: 'productNameEn', width: 180, render: displayOrDash },
+      { title: '规格', dataIndex: 'skuSpecification', key: 'skuSpecification', width: 180, render: displayOrDash },
+      { title: '类型', dataIndex: 'lineType', key: 'lineType', width: 100, render: formatLabel },
+      { title: 'SPU', dataIndex: 'spuName', key: 'spuName', width: 140, render: displayOrDash },
+      { title: '电参数', dataIndex: 'electricalParams', key: 'electricalParams', width: 160, render: displayOrDash },
+      { title: '有无插头', dataIndex: 'hasPlug', key: 'hasPlug', width: 100, render: formatLabel },
+      { title: '插头类型', dataIndex: 'plugType', key: 'plugType', width: 100, render: formatLabel },
+      { title: '应发数量', dataIndex: 'requiredQuantity', key: 'requiredQuantity', width: 100 },
+      { title: '可用库存', key: 'availableStock', width: 150, render: (_: unknown, record: ShippingDemandItem) => <InventoryIndicator available={sumAvailableStock(record)} required={numberValue(record.requiredQuantity)} /> },
+      { title: '履行类型', dataIndex: 'fulfillmentType', key: 'fulfillmentType', width: 130, render: formatLabel },
       { title: '销售单价', dataIndex: 'unitPrice', key: 'unitPrice', width: 120 },
       { title: '币种', dataIndex: 'currencyCode', key: 'currencyCode', width: 90, render: displayOrDash },
       { title: '总金额', dataIndex: 'amount', key: 'amount', width: 120 },
@@ -599,18 +677,14 @@ export default function ShippingDemandDetailPage() {
         dataIndex: 'purchaseRequiredQuantity',
         key: 'purchaseRequiredQuantity',
         width: 120,
-        render: (value: number, record: ShippingDemandItem) =>
-          canConfirmAllocation
-            ? Math.max(0, numberValue(record.requiredQuantity) - numberValue(allocationDrafts[record.id]?.stockQuantity))
-            : value,
+        render: displayOrDash,
       },
       {
         title: '使用现有库存数量',
         dataIndex: 'stockRequiredQuantity',
         key: 'stockRequiredQuantity',
         width: 150,
-        render: (value: number, record: ShippingDemandItem) =>
-          canConfirmAllocation ? numberValue(allocationDrafts[record.id]?.stockQuantity) : value,
+        render: displayOrDash,
       },
       { title: '已锁定待发', dataIndex: 'lockedRemainingQuantity', key: 'lockedRemainingQuantity', width: 120 },
       { title: '已发货数量', dataIndex: 'shippedQuantity', key: 'shippedQuantity', width: 120 },
@@ -632,7 +706,7 @@ export default function ShippingDemandDetailPage() {
             <Space direction="vertical" size={2}>
               {value.map((row) => (
                 <span key={`${row.warehouseId ?? 'none'}-${row.availableQuantity}`}>
-                  仓库 {row.warehouseId ?? '未指定'}：实存 {row.actualQuantity} / 锁定 {row.lockedQuantity} / 可用 {row.availableQuantity}
+                  {getWarehouseDisplayName(warehouseMap, row.warehouseId)}：实存 {row.actualQuantity} / 锁定 {row.lockedQuantity} / 可用 {row.availableQuantity}
                 </span>
               ))}
             </Space>
@@ -641,7 +715,7 @@ export default function ShippingDemandDetailPage() {
           ),
       },
     ],
-    [allocationDrafts, batchesQuery.data, batchesQuery.isLoading, canConfirmAllocation],
+    [warehouseMap],
   );
 
   if (!Number.isInteger(demandId) || demandId <= 0) {
@@ -703,20 +777,12 @@ export default function ShippingDemandDetailPage() {
                   <Button onClick={() => navigate('/shipping-demands')}>返回列表</Button>
                   <Button disabled={!sourceSalesOrderLink} onClick={sourceSalesOrderLink}>来源销售订单</Button>
                   {canConfirmAllocation ? (
-                    <Popconfirm
-                      title="确认分配库存？"
-                      description="系统将按当前履行类型执行库存锁定，并推进发货需求状态。"
-                      okText="确认分配"
-                      cancelText="取消"
-                      onConfirm={submitConfirmAllocation}
+                    <Button
+                      type="primary"
+                      onClick={() => setAllocationModalOpen(true)}
                     >
-                      <Button
-                        type="primary"
-                        loading={confirmAllocationMutation.isPending}
-                      >
-                        确认分配
-                      </Button>
-                    </Popconfirm>
+                      分配库存
+                    </Button>
                   ) : null}
                 </Space>
               </div>
@@ -837,7 +903,7 @@ export default function ShippingDemandDetailPage() {
               pagination={false}
               columns={columns as any}
               dataSource={items}
-              scroll={{ x: 4880 }}
+              scroll={{ x: 4200 }}
             />
           </SectionCard>
 
@@ -893,6 +959,34 @@ export default function ShippingDemandDetailPage() {
           </SectionCard>
         </div>
       </div>
+      <Modal
+        title="分配库存"
+        open={allocationModalOpen}
+        width={1180}
+        centered
+        destroyOnHidden
+        okText="确认分配"
+        cancelText="取消"
+        confirmLoading={confirmAllocationMutation.isPending}
+        onOk={submitConfirmAllocation}
+        onCancel={() => setAllocationModalOpen(false)}
+      >
+        <div className="shipping-demand-allocation-modal">
+          <div className="shipping-demand-allocation-summary">
+            <span>总 SKU {totalSkuCount}</span>
+            <span>总应发 {totalRequiredQuantity}</span>
+            <span>当前可用 {items.reduce((sum, item) => sum + sumAvailableStock(item), 0)}</span>
+          </div>
+          <Table
+            rowKey="id"
+            pagination={false}
+            columns={allocationColumns as any}
+            dataSource={items}
+            loading={batchesQuery.isLoading || warehousesQuery.isLoading}
+            scroll={{ x: 1280, y: 460 }}
+          />
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/apps/web/src/pages/shipping-demands/detail.tsx
+++ b/apps/web/src/pages/shipping-demands/detail.tsx
@@ -1,4 +1,4 @@
-import { Button, Image, Result, Skeleton, Space, Table, Tooltip } from 'antd';
+import { App, Button, Image, InputNumber, Popconfirm, Result, Select, Skeleton, Space, Table, Tooltip } from 'antd';
 import {
   BlType,
   CustomsDeclarationMethod,
@@ -24,13 +24,20 @@ import {
   FileProtectOutlined,
   FileSearchOutlined,
 } from '@ant-design/icons';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
+import type { ColumnsType } from 'antd/es/table';
 import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ActivityTimeline } from '../../components/ActivityTimeline';
-import { getShippingDemandById, type ShippingDemandItem } from '../../api/shipping-demands.api';
+import {
+  confirmShippingDemandAllocation,
+  getShippingDemandById,
+  type ConfirmShippingDemandAllocationPayload,
+  type ShippingDemandItem,
+} from '../../api/shipping-demands.api';
+import { getInventoryBatches, type InventoryBatchItem } from '../../api/inventory.api';
 import {
   AnchorNav,
   MetaItem,
@@ -53,6 +60,24 @@ const ORDER_SOURCE_LABELS: Record<string, string> = {
   [SalesOrderSource.MANUAL]: '手工录单',
   [SalesOrderSource.THIRD_PARTY]: '第三方获取',
 };
+
+const FULFILLMENT_OPTIONS = [
+  { label: '全部采购', value: FulfillmentType.FULL_PURCHASE },
+  { label: '部分采购', value: FulfillmentType.PARTIAL_PURCHASE },
+  { label: '使用现有库存', value: FulfillmentType.USE_STOCK },
+];
+
+interface AllocationDraft {
+  fulfillmentType?: FulfillmentType;
+  stockQuantity: number;
+  warehouseId?: number;
+}
+
+interface WarehouseOption {
+  label: string;
+  value: number;
+  availableQuantity: number;
+}
 
 const LABEL_MAP: Record<string, string> = {
   [DomesticTradeType.DOMESTIC]: '内销',
@@ -125,6 +150,86 @@ function sumAvailableStock(item: ShippingDemandItem) {
     (sum, row) => sum + numberValue(row.availableQuantity),
     0,
   );
+}
+
+function uniqueWarehouses(item: ShippingDemandItem): WarehouseOption[] {
+  const map = new Map<number, WarehouseOption>();
+  for (const row of item.availableStockSnapshot ?? []) {
+    const warehouseId = row.warehouseId;
+    if (!warehouseId) continue;
+    const current = map.get(warehouseId);
+    const availableQuantity = numberValue(row.availableQuantity);
+    map.set(warehouseId, {
+      label: `仓库 ${warehouseId} / 可用 ${availableQuantity + (current?.availableQuantity ?? 0)}`,
+      value: warehouseId,
+      availableQuantity: availableQuantity + (current?.availableQuantity ?? 0),
+    });
+  }
+  return [...map.values()];
+}
+
+function selectWarehouse(item: ShippingDemandItem, targetQuantity: number) {
+  const warehouses = uniqueWarehouses(item);
+  return (
+    warehouses.find((warehouse) => warehouse.availableQuantity >= targetQuantity) ??
+    [...warehouses].sort((a, b) => b.availableQuantity - a.availableQuantity)[0]
+  );
+}
+
+function getWarehouseAvailable(item: ShippingDemandItem, warehouseId?: number) {
+  if (!warehouseId) return 0;
+  return uniqueWarehouses(item).find((warehouse) => warehouse.value === warehouseId)?.availableQuantity ?? 0;
+}
+
+function getFifoPreviewBatches(
+  batches: InventoryBatchItem[],
+  item: ShippingDemandItem,
+  warehouseId?: number,
+) {
+  if (!warehouseId) return [];
+  const skuId = numberValue(item.skuId);
+  return batches
+    .filter(
+      (batch) =>
+        numberValue(batch.skuId) === skuId &&
+        numberValue(batch.warehouseId) === warehouseId &&
+        numberValue(batch.batchAvailableQuantity) > 0,
+    )
+    .sort((a, b) => {
+      const dateCompare = String(a.receiptDate ?? '').localeCompare(String(b.receiptDate ?? ''));
+      return dateCompare || numberValue(a.id) - numberValue(b.id);
+    });
+}
+
+function defaultAllocationDraft(item: ShippingDemandItem): AllocationDraft {
+  const required = numberValue(item.requiredQuantity);
+  const stockQuantity = numberValue(item.stockRequiredQuantity);
+  if (item.fulfillmentType) {
+    return {
+      fulfillmentType: item.fulfillmentType,
+      stockQuantity,
+      warehouseId: stockQuantity > 0 ? selectWarehouse(item, stockQuantity)?.value : undefined,
+    };
+  }
+  const warehouse = selectWarehouse(item, required);
+  if (warehouse && warehouse.availableQuantity >= required && required > 0) {
+    return {
+      fulfillmentType: FulfillmentType.USE_STOCK,
+      stockQuantity: required,
+      warehouseId: warehouse.value,
+    };
+  }
+  if (warehouse && warehouse.availableQuantity > 0 && required > 0) {
+    return {
+      fulfillmentType: FulfillmentType.PARTIAL_PURCHASE,
+      stockQuantity: Math.min(warehouse.availableQuantity, required - 1),
+      warehouseId: warehouse.value,
+    };
+  }
+  return {
+    fulfillmentType: FulfillmentType.FULL_PURCHASE,
+    stockQuantity: 0,
+  };
 }
 
 function InventoryIndicator({ available, required }: { available: number; required: number }) {
@@ -233,9 +338,12 @@ function SmartButton({
 
 export default function ShippingDemandDetailPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { message, notification } = App.useApp();
   const { id = '' } = useParams();
   const demandId = Number(id);
   const [activeAnchor, setActiveAnchor] = useState('basic');
+  const [allocationDrafts, setAllocationDrafts] = useState<Record<number, AllocationDraft>>({});
 
   const query = useQuery({
     queryKey: ['shipping-demand-detail', demandId],
@@ -245,6 +353,7 @@ export default function ShippingDemandDetailPage() {
 
   const data = query.data;
   const items = data?.items ?? [];
+  const canConfirmAllocation = data?.status === ShippingDemandStatus.PENDING_ALLOCATION;
   const sourceSalesOrderLink = data?.salesOrderId
     ? () => navigate(`/sales-orders/${data.salesOrderId}`)
     : undefined;
@@ -252,8 +361,135 @@ export default function ShippingDemandDetailPage() {
   const totalRequiredQuantity = items.reduce((sum, item) => sum + numberValue(item.requiredQuantity), 0);
   const totalLockedQuantity = items.reduce((sum, item) => sum + numberValue(item.lockedRemainingQuantity), 0);
   const totalShippedQuantity = items.reduce((sum, item) => sum + numberValue(item.shippedQuantity), 0);
+  const batchSkuIds = useMemo(
+    () => [...new Set(items.map((item) => numberValue(item.skuId)).filter((skuId) => skuId > 0))].sort((a, b) => a - b),
+    [items],
+  );
 
-  const columns = useMemo(
+  const batchesQuery = useQuery({
+    queryKey: ['inventory-batches', 'shipping-demand-detail', batchSkuIds],
+    queryFn: () => getInventoryBatches({ skuIds: batchSkuIds }),
+    enabled: canConfirmAllocation && batchSkuIds.length > 0,
+  });
+
+  useEffect(() => {
+    if (!data?.items?.length) {
+      setAllocationDrafts({});
+      return;
+    }
+    setAllocationDrafts(
+      Object.fromEntries(
+        data.items.map((item) => [item.id, defaultAllocationDraft(item)]),
+      ),
+    );
+  }, [data?.id, data?.status, data?.items]);
+
+  const confirmAllocationMutation = useMutation({
+    mutationFn: (payload: ConfirmShippingDemandAllocationPayload) =>
+      confirmShippingDemandAllocation(demandId, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['shipping-demand-detail', demandId] });
+      queryClient.invalidateQueries({ queryKey: ['shipping-demands'] });
+      queryClient.invalidateQueries({ queryKey: ['operation-logs', 'shipping-demands', demandId] });
+      notification.success({
+        message: '库存分配已确认',
+        description: '系统已按履行类型更新发货需求，并完成现有库存的 FIFO 锁定。',
+        duration: 5,
+      });
+    },
+    onError: (error: unknown) => {
+      const err = error as { message?: string; response?: { data?: { message?: string } } };
+      message.error(err.response?.data?.message ?? err.message ?? '确认分配失败');
+    },
+  });
+
+  const updateDraft = (itemId: number, patch: Partial<AllocationDraft>) => {
+    setAllocationDrafts((prev) => ({
+      ...prev,
+      [itemId]: {
+        ...(prev[itemId] ?? { stockQuantity: 0 }),
+        ...patch,
+      },
+    }));
+  };
+
+  const handleFulfillmentChange = (item: ShippingDemandItem, fulfillmentType: FulfillmentType) => {
+    const required = numberValue(item.requiredQuantity);
+    const warehouse = selectWarehouse(item, required);
+    if (fulfillmentType === FulfillmentType.FULL_PURCHASE) {
+      updateDraft(item.id, { fulfillmentType, stockQuantity: 0, warehouseId: undefined });
+      return;
+    }
+    if (fulfillmentType === FulfillmentType.USE_STOCK) {
+      updateDraft(item.id, { fulfillmentType, stockQuantity: required, warehouseId: warehouse?.value });
+      return;
+    }
+    updateDraft(item.id, {
+      fulfillmentType,
+      stockQuantity: warehouse ? Math.max(1, Math.min(warehouse.availableQuantity, required - 1)) : 0,
+      warehouseId: warehouse?.value,
+    });
+  };
+
+  const buildConfirmAllocationPayload = (): ConfirmShippingDemandAllocationPayload | null => {
+    if (!items.length) {
+      message.error('发货需求没有产品明细');
+      return null;
+    }
+    const payloadItems: ConfirmShippingDemandAllocationPayload['items'] = [];
+    for (const item of items) {
+      const draft = allocationDrafts[item.id];
+      const required = numberValue(item.requiredQuantity);
+      if (!draft?.fulfillmentType) {
+        message.error(`${item.skuCode} 请选择履行类型`);
+        return null;
+      }
+      const stockQuantity = numberValue(draft.stockQuantity);
+      const warehouseAvailable = getWarehouseAvailable(item, draft.warehouseId);
+      if (!Number.isInteger(stockQuantity) || stockQuantity < 0 || stockQuantity > required) {
+        message.error(`${item.skuCode} 使用库存数量必须在 0 到 ${required} 之间`);
+        return null;
+      }
+      if (draft.fulfillmentType === FulfillmentType.FULL_PURCHASE && stockQuantity !== 0) {
+        message.error(`${item.skuCode} 全部采购时使用库存数量必须为 0`);
+        return null;
+      }
+      if (draft.fulfillmentType === FulfillmentType.USE_STOCK && stockQuantity !== required) {
+        message.error(`${item.skuCode} 使用现有库存时必须覆盖全部应发数量`);
+        return null;
+      }
+      if (
+        draft.fulfillmentType === FulfillmentType.PARTIAL_PURCHASE &&
+        (stockQuantity <= 0 || stockQuantity >= required)
+      ) {
+        message.error(`${item.skuCode} 部分采购时库存数量必须大于 0 且小于应发数量`);
+        return null;
+      }
+      if (stockQuantity > 0 && !draft.warehouseId) {
+        message.error(`${item.skuCode} 使用库存时必须选择仓库`);
+        return null;
+      }
+      if (stockQuantity > 0 && stockQuantity > warehouseAvailable) {
+        message.error(`${item.skuCode} 可用库存不足，当前仓库可用 ${warehouseAvailable}`);
+        return null;
+      }
+      payloadItems.push({
+        itemId: item.id,
+        fulfillmentType: draft.fulfillmentType,
+        stockQuantity,
+        warehouseId: stockQuantity > 0 ? draft.warehouseId : undefined,
+      });
+    }
+    return { items: payloadItems };
+  };
+
+  const submitConfirmAllocation = () => {
+    const payload = buildConfirmAllocationPayload();
+    if (!payload) return;
+    confirmAllocationMutation.mutate(payload);
+  };
+
+  const columns = useMemo<ColumnsType<ShippingDemandItem>>(
     () => [
       { title: 'SKU', dataIndex: 'skuCode', key: 'skuCode', width: 140, fixed: 'left' as const },
       { title: '产品中文名', dataIndex: 'productNameCn', key: 'productNameCn', width: 180, render: displayOrDash },
@@ -266,15 +502,116 @@ export default function ShippingDemandDetailPage() {
       { title: '插头类型', dataIndex: 'plugType', key: 'plugType', width: 100, render: formatLabel },
       { title: '应发数量', dataIndex: 'requiredQuantity', key: 'requiredQuantity', width: 100 },
       { title: '可用库存', key: 'availableStock', width: 150, render: (_: unknown, record: ShippingDemandItem) => <InventoryIndicator available={sumAvailableStock(record)} required={numberValue(record.requiredQuantity)} /> },
-      { title: '履行类型', dataIndex: 'fulfillmentType', key: 'fulfillmentType', width: 130, render: formatLabel },
+      {
+        title: '履行类型',
+        dataIndex: 'fulfillmentType',
+        key: 'fulfillmentType',
+        width: 160,
+        render: (value: FulfillmentType | null, record: ShippingDemandItem) =>
+          canConfirmAllocation ? (
+            <Select<FulfillmentType>
+              className="shipping-demand-allocation-control"
+              value={allocationDrafts[record.id]?.fulfillmentType}
+              options={FULFILLMENT_OPTIONS}
+              onChange={(nextValue) => handleFulfillmentChange(record, nextValue)}
+            />
+          ) : (
+            formatLabel(value)
+          ),
+      },
+      {
+        title: '库存仓库',
+        key: 'allocationWarehouse',
+        width: 170,
+        render: (_: unknown, record: ShippingDemandItem) => {
+          const draft = allocationDrafts[record.id];
+          const options = uniqueWarehouses(record).map(({ label, value }) => ({ label, value }));
+          if (!canConfirmAllocation) {
+            return '—';
+          }
+          return (
+            <Select<number>
+              className="shipping-demand-allocation-control"
+              value={draft?.warehouseId}
+              options={options}
+              placeholder="选择仓库"
+              disabled={!draft?.fulfillmentType || draft.fulfillmentType === FulfillmentType.FULL_PURCHASE || options.length === 0}
+              onChange={(warehouseId) => updateDraft(record.id, { warehouseId })}
+            />
+          );
+        },
+      },
+      {
+        title: '本次使用库存',
+        key: 'allocationStockQuantity',
+        width: 140,
+        render: (_: unknown, record: ShippingDemandItem) => {
+          const draft = allocationDrafts[record.id];
+          if (!canConfirmAllocation) return displayOrDash(record.stockRequiredQuantity);
+          return (
+            <InputNumber
+              className="shipping-demand-allocation-control"
+              min={0}
+              max={numberValue(record.requiredQuantity)}
+              precision={0}
+              value={draft?.stockQuantity ?? 0}
+              disabled={!draft?.fulfillmentType || draft.fulfillmentType === FulfillmentType.FULL_PURCHASE || draft.fulfillmentType === FulfillmentType.USE_STOCK}
+              onChange={(value) => updateDraft(record.id, { stockQuantity: numberValue(value) })}
+            />
+          );
+        },
+      },
+      {
+        title: 'FIFO 批次预览',
+        key: 'fifoBatchPreview',
+        width: 280,
+        render: (_: unknown, record: ShippingDemandItem) => {
+          const draft = allocationDrafts[record.id];
+          if (!canConfirmAllocation || !draft?.warehouseId || numberValue(draft.stockQuantity) <= 0) {
+            return '—';
+          }
+          if (batchesQuery.isLoading) {
+            return '加载中...';
+          }
+          const batches = getFifoPreviewBatches(batchesQuery.data ?? [], record, draft.warehouseId);
+          if (!batches.length) {
+            return '—';
+          }
+          return (
+            <Space direction="vertical" size={2}>
+              {batches.map((batch) => (
+                <span key={String(batch.id)}>
+                  {formatDate(batch.receiptDate)} / {batch.sourceType} / 批次 {batch.batchQuantity} / 可用 {batch.batchAvailableQuantity}
+                </span>
+              ))}
+            </Space>
+          );
+        },
+      },
       { title: '销售单价', dataIndex: 'unitPrice', key: 'unitPrice', width: 120 },
       { title: '币种', dataIndex: 'currencyCode', key: 'currencyCode', width: 90, render: displayOrDash },
       { title: '总金额', dataIndex: 'amount', key: 'amount', width: 120 },
       { title: '单位', dataIndex: 'unitName', key: 'unitName', width: 100, render: displayOrDash },
       { title: '采购人员', dataIndex: 'purchaserName', key: 'purchaserName', width: 120, render: displayOrDash },
       { title: '是否需要采购', dataIndex: 'needsPurchase', key: 'needsPurchase', width: 120, render: formatLabel },
-      { title: '需采购数量', dataIndex: 'purchaseRequiredQuantity', key: 'purchaseRequiredQuantity', width: 120 },
-      { title: '使用现有库存数量', dataIndex: 'stockRequiredQuantity', key: 'stockRequiredQuantity', width: 150 },
+      {
+        title: '需采购数量',
+        dataIndex: 'purchaseRequiredQuantity',
+        key: 'purchaseRequiredQuantity',
+        width: 120,
+        render: (value: number, record: ShippingDemandItem) =>
+          canConfirmAllocation
+            ? Math.max(0, numberValue(record.requiredQuantity) - numberValue(allocationDrafts[record.id]?.stockQuantity))
+            : value,
+      },
+      {
+        title: '使用现有库存数量',
+        dataIndex: 'stockRequiredQuantity',
+        key: 'stockRequiredQuantity',
+        width: 150,
+        render: (value: number, record: ShippingDemandItem) =>
+          canConfirmAllocation ? numberValue(allocationDrafts[record.id]?.stockQuantity) : value,
+      },
       { title: '已锁定待发', dataIndex: 'lockedRemainingQuantity', key: 'lockedRemainingQuantity', width: 120 },
       { title: '已发货数量', dataIndex: 'shippedQuantity', key: 'shippedQuantity', width: 120 },
       { title: '采购已下单', dataIndex: 'purchaseOrderedQuantity', key: 'purchaseOrderedQuantity', width: 120 },
@@ -304,7 +641,7 @@ export default function ShippingDemandDetailPage() {
           ),
       },
     ],
-    [],
+    [allocationDrafts, batchesQuery.data, batchesQuery.isLoading, canConfirmAllocation],
   );
 
   if (!Number.isInteger(demandId) || demandId <= 0) {
@@ -365,6 +702,22 @@ export default function ShippingDemandDetailPage() {
                 <Space wrap>
                   <Button onClick={() => navigate('/shipping-demands')}>返回列表</Button>
                   <Button disabled={!sourceSalesOrderLink} onClick={sourceSalesOrderLink}>来源销售订单</Button>
+                  {canConfirmAllocation ? (
+                    <Popconfirm
+                      title="确认分配库存？"
+                      description="系统将按当前履行类型执行库存锁定，并推进发货需求状态。"
+                      okText="确认分配"
+                      cancelText="取消"
+                      onConfirm={submitConfirmAllocation}
+                    >
+                      <Button
+                        type="primary"
+                        loading={confirmAllocationMutation.isPending}
+                      >
+                        确认分配
+                      </Button>
+                    </Popconfirm>
+                  ) : null}
                 </Space>
               </div>
             </div>
@@ -478,13 +831,13 @@ export default function ShippingDemandDetailPage() {
             </div>
           </SectionCard>
 
-          <SectionCard id="items" title="产品明细" description="查看生成时继承的订单 SKU、履约数量和库存快照。" bodyClassName="master-section-table">
+          <SectionCard id="items" title="产品明细" description="查看生成时继承的订单 SKU、履约数量和库存快照。待分配状态可确认履行类型。" bodyClassName="master-section-table">
             <Table
               rowKey="id"
               pagination={false}
               columns={columns as any}
               dataSource={items}
-              scroll={{ x: 4200 }}
+              scroll={{ x: 4880 }}
             />
           </SectionCard>
 

--- a/apps/web/src/pages/shipping-demands/detail.tsx
+++ b/apps/web/src/pages/shipping-demands/detail.tsx
@@ -960,10 +960,16 @@ export default function ShippingDemandDetailPage() {
         </div>
       </div>
       <Modal
-        title="分配库存"
+        title={
+          <div className="shipping-demand-allocation-title">
+            <span>分配库存</span>
+            <small>{displayOrDash(data?.demandCode)} / {displayOrDash(data?.sourceDocumentCode)}</small>
+          </div>
+        }
         open={allocationModalOpen}
-        width={1180}
+        width="min(1440px, calc(100vw - 48px))"
         centered
+        rootClassName="shipping-demand-allocation-dialog"
         destroyOnHidden
         okText="确认分配"
         cancelText="取消"
@@ -976,6 +982,7 @@ export default function ShippingDemandDetailPage() {
             <span>总 SKU {totalSkuCount}</span>
             <span>总应发 {totalRequiredQuantity}</span>
             <span>当前可用 {items.reduce((sum, item) => sum + sumAvailableStock(item), 0)}</span>
+            <span>确认后按 FIFO 锁定库存并刷新明细</span>
           </div>
           <Table
             rowKey="id"
@@ -983,7 +990,7 @@ export default function ShippingDemandDetailPage() {
             columns={allocationColumns as any}
             dataSource={items}
             loading={batchesQuery.isLoading || warehousesQuery.isLoading}
-            scroll={{ x: 1280, y: 460 }}
+            scroll={{ x: 1280, y: 'calc(100vh - 360px)' }}
           />
         </div>
       </Modal>

--- a/packages/shared/src/enums/shipping-demand-allocation-status.enum.ts
+++ b/packages/shared/src/enums/shipping-demand-allocation-status.enum.ts
@@ -1,0 +1,8 @@
+export const ShippingDemandAllocationStatus = {
+  ACTIVE: 'active',
+  RELEASED: 'released',
+  SHIPPED: 'shipped',
+} as const;
+
+export type ShippingDemandAllocationStatus =
+  (typeof ShippingDemandAllocationStatus)[keyof typeof ShippingDemandAllocationStatus];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export * from './enums/sales-order-status.enum';
 export * from './enums/sales-order-type.enum';
 export * from './enums/sales-order-source.enum';
 export * from './enums/shipping-demand-status.enum';
+export * from './enums/shipping-demand-allocation-status.enum';
 export * from './enums/fulfillment-type.enum';
 export * from './enums/inventory-batch-source-type.enum';
 export * from './enums/inventory-change-type.enum';

--- a/packages/shared/src/types/operation-log-field-labels.ts
+++ b/packages/shared/src/types/operation-log-field-labels.ts
@@ -375,6 +375,9 @@ export const RESOURCE_OPERATION_LOG_FIELD_LABELS: Record<string, Record<string, 
     outstandingAmount: '待收款金额',
     totalAmount: '总金额',
     items: '产品明细',
+    allocation: '库存分配',
+    allocationSummary: '分配结果',
+    allocationDetails: '分配明细',
   },
 };
 


### PR DESCRIPTION
## 变更内容
- 补齐发货需求详情页销售订单相关字段、发货枢纽和产品明细字段展示。
- 增加待分配状态下的统一分配库存弹窗，确认后由后端按 FIFO 锁定库存并刷新详情/列表/操作记录。
- 增加确认分配 API、库存锁定分配表、库存流水记录和相关迁移。
- 优化仓库名称展示、FIFO 批次来源文案、分配弹窗布局。
- 优化操作记录：确认分配日志改为中文业务摘要/明细，前端兼容旧 JSON 型记录并格式化为可读文本。

## 验证
- pnpm --filter api exec jest modules/shipping-demands/tests --runInBand
- pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts common/interceptors/audit.interceptor.spec.ts --runInBand
- pnpm --filter api build
- pnpm --filter web build

说明：web build 仍有既有 Vite chunk-size warning。