### PR TITLE
feat(inventory): add inventory movement ledger

### DIFF
--- a/_bmad-output/implementation-artifacts/6-2-库存变动流水.md
+++ b/_bmad-output/implementation-artifacts/6-2-库存变动流水.md
@@ -1,0 +1,248 @@
+# Story 6.2: 库存变动流水
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a 授权用户,
+I want 系统自动记录每次库存变动流水，我可以按 SKU 或仓库查询历史变动明细,
+so that 库存变动有完整审计记录，出现差异时可以追溯。
+
+## Acceptance Criteria
+
+1. 任意库存变动操作执行成功后，系统自动写入库存变动流水记录，覆盖变动类型：期初录入、采购入库、发货出库、锁定、解锁。（FR42）
+2. 库存流水实体和 API 输出必须包含：`id`、`skuId`、`warehouseId`、`inventoryBatchId`、`changeType`、`quantityChange`、`actualQuantityDelta`、`lockedQuantityDelta`、`availableQuantityDelta`、`beforeActualQuantity`、`afterActualQuantity`、`beforeLockedQuantity`、`afterLockedQuantity`、`beforeAvailableQuantity`、`afterAvailableQuantity`、`sourceDocumentType`、`sourceDocumentId`、`sourceDocumentItemId`、`sourceActionKey`、`operatedBy`、`operatedAt`。
+3. `quantityChange` 是兼容展示字段：实际库存变化优先取 `actualQuantityDelta`，锁定/解锁类无实际库存变化时取 `lockedQuantityDelta`；不得用它替代 flow 文档要求的三类 delta 字段。
+4. 库存流水写入必须在同一个 QueryRunner 事务内完成，并使用稳定 `sourceActionKey` 保证幂等；重复确认或重复提交不得重复记账。
+5. `InventoryService.recordOpeningBalance()` 必须为期初录入写入 `changeType=initial` 流水，并记录 summary 操作前后快照。
+6. `InventoryService.increaseStockInTransaction()` 必须为采购入库类库存增加写入 `changeType=purchase_receipt` 流水；后续收货入库 Story 调用该入口时无需另建临时流水逻辑。
+7. 既有发货需求确认分配和作废流程已写入 `lock` / `unlock` 流水，本 Story 必须保留并回归验证，不得删除或改坏 5.4/5.5 的 allocation 与状态联动。
+8. 查询接口 `GET /api/inventory/transactions` 支持按 `skuId`、`warehouseId`、`changeType`、`startTime`、`endTime` 筛选，按 `operatedAt DESC, id DESC` 分页返回 `{ data, total, page, pageSize, totalPages }`。（FR43）
+9. 库存页面中，用户在 SKU+仓库库存行点击“查看变动流水”后，打开历史变动列表，默认带入该行 `skuId` 与 `warehouseId`，按时间倒序展示。
+10. 前端历史变动列表展示列：变动类型（Tag）、数量变化（+/-）、实际库存变动、锁定量变动、可用库存变动、变动前/后数量、来源单据、操作人、操作时间；支持变动类型和时间范围筛选、分页。
+11. 来源单据展示为蓝色链接或可点击文本；当前尚未落地的采购/收货/出库单据可先展示文案和 ID，不允许硬编码不存在的路由。
+12. 后端定向单测覆盖期初流水、采购入库流水、锁定/解锁流水回归、流水查询筛选分页、`sourceActionKey` 幂等/重复键边界；前端至少覆盖 API 参数封装或以构建验证保证类型正确。
+
+## Tasks / Subtasks
+
+- [x] 后端流水查询 DTO、Repository 与 API（AC: 2, 3, 8）
+  - [x] 新增 `QueryInventoryTransactionDto`，支持 `skuId`、`warehouseId`、`changeType`、`startTime`、`endTime`、`page`、`pageSize`，校验非法枚举和非法日期。
+  - [x] 在 `InventoryRepository` 增加 `findTransactions()`，使用 QueryBuilder 组合筛选条件，排序固定为 `operatedAt DESC, id DESC`。
+  - [x] 在 `InventoryController` 增加 `GET /inventory/transactions`，返回项目统一分页结构。
+  - [x] API 输出将 snake_case Entity 字段映射为 camelCase，并补充 `quantityChange` 展示字段。
+- [x] 后端库存动作统一写流水（AC: 1, 4, 5, 6）
+  - [x] 在 `InventoryService` 内新增内部流水创建方法，入参包含事务 `QueryRunner`、变动类型、summary 前后快照、batch/source 信息和 operator。
+  - [x] `recordOpeningBalanceInTransaction()` 保存 summary 前记录 before 快照，summary 刷新后写 `initial` 流水。
+  - [x] `increaseStockInTransaction()` 保存 summary 前记录 before 快照，summary 刷新后写 `purchase_receipt` 流水。
+  - [x] 保持 `lockStockInTransaction()`、`unlockStockInTransaction()`、`deductLockedStockInTransaction()` 可被发货需求、收货、出库领域服务继续复用；本 Story 不把上游单据状态推进塞进 InventoryService。
+  - [x] 处理 `sourceActionKey` 唯一键冲突：同一动作重复进入不得创建重复流水，应返回可识别的并发/幂等结果或保持现有动作的单次确认语义。
+- [x] 保留并回归发货需求库存流水（AC: 7）
+  - [x] 检查 `ShippingDemandsService.confirmFulfillment()` 仍为 `lock` 写入库存流水，且 source/action key 稳定。
+  - [x] 检查 `ShippingDemandsService.voidDemand()` 仍为 `unlock` 写入库存流水，且不会重复释放或重复写流水。
+  - [x] 若查询 DTO/API 需要来源字段展示，复用现有 `InventoryTransaction` 字段，不修改发货需求 allocation 结构。
+- [x] 前端 API 与库存页面交互（AC: 9, 10, 11）
+  - [x] 在 `apps/web/src/api/inventory.api.ts` 增加 `getInventoryTransactions()` 和类型定义。
+  - [x] 在 `apps/web/src/pages/inventory/index.tsx` 的库存汇总表增加“查看变动流水”行操作。
+  - [x] 增加 Drawer 或同页明细区展示流水列表，默认继承所选 SKU+仓库筛选条件。
+  - [x] 增加变动类型筛选、时间范围筛选和分页；筛选参数必须通过 API 层传递，不在组件内直接 axios。
+  - [x] 使用 `InventoryChangeType` 的中文映射和 Tag 色彩，不新增前后端重复枚举。
+- [x] 测试与验证（AC: 1-12）
+  - [x] 扩展 `apps/api/src/modules/inventory/tests/inventory.service.spec.ts`，覆盖期初和采购入库流水写入。
+  - [x] 新增或扩展库存查询相关 spec，覆盖筛选、分页、时间范围、`quantityChange` 映射。
+  - [x] 回归 `apps/api/src/modules/shipping-demands/tests/shipping-demands.service.spec.ts` 中 lock/unlock 流水断言。
+  - [x] 运行定向库存测试、发货需求相关测试、API build、Web build，并在 Dev Agent Record 记录结果。
+- [x] Story 记录更新（AC: 1-12）
+  - [x] 更新 Dev Agent Record、Completion Notes、File List、Change Log。
+  - [x] 全部 AC 满足、验证和 code review 修复完成后，将任务复选框全部标记完成，并把 Status 改为 done。
+
+### Review Findings
+
+- [x] [Review][Patch] `sourceActionKey` 不能依赖新建批次 ID [apps/api/src/modules/inventory/inventory.service.ts] — 已改为基于期初 SKU+仓库、采购来源单据/行项或调用方显式 action key 的稳定键，并补充重复键冲突测试。
+- [x] [Review][Patch] 出库扣减入口缺少 `outbound` 库存流水 [apps/api/src/modules/inventory/inventory.service.ts] — 已在 `deductLockedStockInTransaction()` 的同一 QueryRunner 事务内写入出库流水，并支持来源单据元数据。
+- [x] [Review][Patch] 日期筛选的纯日期边界不应落到 UTC 日界 [apps/api/src/modules/inventory/inventory.repository.ts] — 已将 `YYYY-MM-DD` 转为本地日开始/结束字符串，避免漏查当天记录。
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守以下三份 flow 文档：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic 或旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、`shipping_demand_inventory_allocations` 和 `inventory_transactions`，不是销售订单、采购订单或页面缓存字段。
+- 库存流水必须表达实际库存变化、锁定库存变化、可用库存变化，并保留 before/after 快照与 `sourceActionKey`。
+- 库存写操作必须在领域动作服务的 QueryRunner 事务内执行；禁止前端直接提交目标状态，禁止通用 PATCH 修改状态字段。
+- 禁止新增临时库存 API、临时库存表、重复枚举或硬编码库存快照；所有枚举继续从 `packages/shared` 引用。
+- 后续收货入库、发货出库 Story 需要复用本 Story 的流水结构和 `InventoryService` 内部能力，不应在各模块复制一套流水字段逻辑。
+
+### Source Context
+
+- Epic 6 明确库存双层数据模型、期初录入和可用库存查询接口已在 Story 5.0 前置落地，6.2 聚焦历史变动流水查询。[Source: `_bmad-output/planning-artifacts/epics.md#Story 6.2`]
+- PRD FR42/FR43 要求自动记录库存变动流水，并允许授权用户按 SKU 或仓库查询当前库存及历史变动流水。[Source: `_bmad-output/planning-artifacts/prd.md#9. 库存管理`]
+- `flow-quantity-data-lineage.md` 要求 `inventory_transactions` 记录 `actual_quantity_delta`、`locked_quantity_delta`、`available_quantity_delta`、before/after 快照和 `source_action_key`。[Source: `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md#2.4 库存流水记录实际量与锁定量的变化`]
+- Story 5.0 已创建正式 `InventoryModule`、`inventory_summary`、`inventory_batch`、库存基础页和可用库存查询；6.2 不应重建这些能力。[Source: `_bmad-output/implementation-artifacts/5-0-库存双层结构查询接口与期初录入.md`]
+- Story 5.4/5.5 已提前落地 `inventory_transactions` 表、`InventoryTransaction` Entity、发货需求锁定/解锁流水和 allocation 表；6.2 应扩展查询和补齐库存动作流水，不应回滚这些实现。[Source: `_bmad-output/implementation-artifacts/5-4-发货需求枢纽详情页.md`, `_bmad-output/implementation-artifacts/5-5-发货需求下游入口与完整作废逻辑.md`]
+
+### Existing Code Map
+
+- 后端库存模块：`apps/api/src/modules/inventory/`
+  - `entities/inventory-transaction.entity.ts` 已存在，字段已经接近 flow 目标。
+  - `inventory.service.ts` 已有 `recordOpeningBalance()`、`increaseStock()`、`lockStock()`、`unlockStock()`、`deductLockedStock()` 和对应 `*InTransaction()` 方法。
+  - 当前 `recordOpeningBalanceInTransaction()` 与 `increaseStockInTransaction()` 只更新 batch/summary，尚未统一写 `inventory_transactions`。
+  - `inventory.repository.ts` 当前只有 summary/batch 查询与加锁方法，需要增加流水查询。
+- 发货需求模块：`apps/api/src/modules/shipping-demands/shipping-demands.service.ts`
+  - `confirmFulfillment()` 已保存 `InventoryChangeType.LOCK` 流水。
+  - `voidDemand()` 已保存 `InventoryChangeType.UNLOCK` 流水。
+  - 这些逻辑依赖 `InventoryService.lockStockInTransaction()` 和 `unlockStockInTransaction()`，本 Story 改动要保持兼容。
+- 前端库存页面：`apps/web/src/pages/inventory/index.tsx`
+  - 已有期初库存录入、可用库存汇总表、批次库存明细。
+  - 适合在汇总表行操作中加入“查看变动流水”，并用 Drawer/同页区域展示流水。
+- Shared 枚举：`packages/shared/src/enums/inventory-change-type.enum.ts` 已定义 `initial`、`purchase_receipt`、`outbound`、`lock`、`unlock`。
+
+### API Contract
+
+建议后端接口：
+
+- `GET /api/inventory/transactions`
+  - query: `skuId?: number`
+  - query: `warehouseId?: number`
+  - query: `changeType?: InventoryChangeType`
+  - query: `startTime?: string`，ISO 日期时间或 `YYYY-MM-DD`
+  - query: `endTime?: string`，ISO 日期时间或 `YYYY-MM-DD`
+  - query: `page?: number = 1`
+  - query: `pageSize?: number = 20`
+  - response: `{ data: InventoryTransactionItem[], total, page, pageSize, totalPages }`
+
+`InventoryTransactionItem` 建议字段：
+
+- `id`
+- `skuId`
+- `warehouseId`
+- `inventoryBatchId`
+- `changeType`
+- `quantityChange`
+- `actualQuantityDelta`
+- `lockedQuantityDelta`
+- `availableQuantityDelta`
+- `beforeActualQuantity`
+- `afterActualQuantity`
+- `beforeLockedQuantity`
+- `afterLockedQuantity`
+- `beforeAvailableQuantity`
+- `afterAvailableQuantity`
+- `sourceDocumentType`
+- `sourceDocumentId`
+- `sourceDocumentItemId`
+- `sourceActionKey`
+- `operatedBy`
+- `operatedAt`
+
+### Field List and UI Candidate Fields
+
+字段来源说明：`docs/系统模块对应字段清单.md` 未提供独立“库存流水”旧表单；候选字段按 PRD FR42/FR43、Epic 6.2、flow 文档和现有 `InventoryTransaction` Entity 整理。
+
+建议搜索/筛选字段：
+
+- SKU
+- 仓库
+- 变动类型
+- 操作时间范围
+
+建议列表展示字段：
+
+- 变动类型（Tag）
+- SKU
+- 仓库
+- 数量变化（+/-）
+- 实际库存变动
+- 锁定量变动
+- 可用库存变动
+- 变动前/后数量
+- 来源单据
+- 操作人
+- 操作时间
+
+### Testing Requirements
+
+- 后端定向测试优先覆盖库存服务和查询接口，不依赖真实数据库。
+- 流水写入测试必须断言同一个 QueryRunner manager 保存 `InventoryTransaction`，避免事务外写入。
+- 期初录入测试需覆盖 before summary 不存在和已存在两类快照。
+- 采购入库测试需覆盖 `sourceType=InventoryBatchSourceType.PURCHASE_RECEIPT`、`sourceDocumentId`、`sourceActionKey`。
+- 发货需求测试需回归 lock/unlock 现有流水断言，防止本 Story 把 `sourceActionKey` 或 delta 口径改坏。
+- 推荐验证命令：
+  - `pnpm --filter api exec jest modules/inventory/tests --runInBand`
+  - `pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand`
+  - `pnpm --filter api build`
+  - `pnpm --filter web build`
+
+### Implementation Boundaries
+
+- 不实现采购订单、收货入库单、物流单、发货出库单的新业务流程；这些属于 Story 6.3-6.6 和 Epic 7。
+- 不新增新的库存基础表；`inventory_transactions` 已存在，优先扩展现有实体、Repository、Service 与页面。
+- 不把 `InventoryService` 改造成上游状态机服务；状态推进继续由发货需求、采购、收货、出库等领域动作服务负责。
+- 不在前端硬编码尚不存在的单据详情路由；来源单据跳转应只对已存在路由启用。
+- 不把中文文案持久化到数据库；数据库和 API 使用 shared 枚举英文值，中文只在 UI 映射层处理。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/.codex/worktrees/e310/worktrees/codex-story-6-2-inventory-movement-ledger`
+- Branch: `codex/story-6-2-inventory-movement-ledger`
+- WORKTREE_MODE: `true`
+
+### Completion Notes List
+
+- Story file created by context engine with Epic 5-7 mandatory flow context.
+- 已确认 Story 5.0 提供库存基础能力，Story 5.4/5.5 已提前落地部分库存流水和 allocation；本 Story 规格聚焦查询与补齐自动写流水。
+- 2026-04-29：进入实现阶段，已加载 Story、项目上下文和 Epic 5-7 三份强制 flow 文档。
+- 已新增库存流水查询 DTO、Repository 查询、`GET /api/inventory/transactions` 和服务层 camelCase/`quantityChange` 映射。
+- 已在 `recordOpeningBalanceInTransaction()` 与 `increaseStockInTransaction()` 中写入 `initial` / `purchase_receipt` 库存流水，保留 summary before/after 快照与稳定 `sourceActionKey`。
+- 已保留发货需求确认分配/作废已有的 `lock` / `unlock` 库存流水逻辑，并通过定向回归测试验证。
+- 已在库存页面新增“查看变动流水”行操作和 Drawer 列表，支持变动类型、操作时间范围筛选和分页。
+- 按用户确认补充独立菜单入口：`库存管理 > 库存变动流水`，新增 `/inventory/transactions` 独立流水列表页，并保留库存查询页快捷抽屉。
+- Code review 修复：库存流水幂等键不再依赖新建批次 ID；`deductLockedStockInTransaction()` 已补 `outbound` 流水；日期筛选纯日期使用本地日边界。
+- 定向库存测试通过：`pnpm --filter api exec jest modules/inventory/tests --runInBand`，4 个测试文件，25 个用例。
+- 发货需求回归测试通过：`pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand`，25 个用例。
+- Build verification 通过：`pnpm --filter api build`、`pnpm --filter web build`。Web build 仍有 Vite chunk size 警告。
+- `git diff --check` 通过。
+- 全量 API Jest 已运行：`pnpm --filter api test --runInBand`，失败项为既有的 contract-templates、skus、product-categories 测试问题，与本 Story 改动无关；其余 34 个测试套件、298 个用例通过。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/6-2-库存变动流水.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `apps/api/src/modules/inventory/dto/query-inventory-transaction.dto.ts`
+- `apps/api/src/modules/inventory/inventory.controller.ts`
+- `apps/api/src/modules/inventory/inventory.repository.ts`
+- `apps/api/src/modules/inventory/inventory.service.ts`
+- `apps/api/src/modules/inventory/tests/inventory.repository.spec.ts`
+- `apps/api/src/modules/inventory/tests/inventory.service.spec.ts`
+- `apps/api/src/modules/inventory/tests/query-inventory-transaction.dto.spec.ts`
+- `apps/web/src/App.tsx`
+- `apps/web/src/api/inventory.api.ts`
+- `apps/web/src/components/layout/AppLayout.tsx`
+- `apps/web/src/components/layout/Sidebar.tsx`
+- `apps/web/src/pages/inventory/index.tsx`
+- `apps/web/src/pages/inventory/inventory.css`
+- `apps/web/src/pages/inventory/transactions.tsx`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-04-29 | 0.1 | 创建 Story 6.2 开发上下文，加入 Epic 5-7 强制 flow 约束、现有库存流水复用说明和列表字段候选 | GPT-5 Codex |
+| 2026-04-29 | 0.2 | 开始 Story 6.2 实现，状态更新为 in-progress | GPT-5 Codex |
+| 2026-04-29 | 1.0 | 完成库存流水查询、期初/采购入库流水写入、前端流水 Drawer 与定向测试，状态更新为 review | GPT-5 Codex |
+| 2026-04-29 | 1.1 | 按用户反馈补充库存变动流水独立菜单和列表页 | GPT-5 Codex |
+| 2026-04-29 | 1.2 | Code review 后修复幂等键稳定性、出库流水和日期筛选边界，状态更新为 done | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-29 (story-5.6-done)
+# last_updated: 2026-04-29 (story-6.2-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-04-29 (story-5.6-done)
+last_updated: 2026-04-29 (story-6.2-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -119,8 +119,8 @@ development_status:
   # ─────────────────────────────────────────────────
   # Epic 6: 采购订单与收货入库
   # ─────────────────────────────────────────────────
-  epic-6: backlog
-  6-2-库存变动流水: backlog
+  epic-6: in-progress
+  6-2-库存变动流水: done
   6-3-采购订单创建与确认: backlog
   6-4-采购订单列表与详情: backlog
   6-5-收货入库单创建与确认: backlog

--- a/apps/api/src/modules/inventory/dto/query-inventory-transaction.dto.ts
+++ b/apps/api/src/modules/inventory/dto/query-inventory-transaction.dto.ts
@@ -1,0 +1,38 @@
+import { Transform, Type } from 'class-transformer';
+import { IsDateString, IsIn, IsInt, IsOptional, Min } from 'class-validator';
+import { InventoryChangeType } from '@infitek/shared';
+import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+
+function normalizeOptionalString(value: unknown) {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+export class QueryInventoryTransactionDto extends BaseQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  skuId?: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  warehouseId?: number;
+
+  @IsOptional()
+  @IsIn(Object.values(InventoryChangeType))
+  changeType?: InventoryChangeType;
+
+  @Transform(({ value }) => normalizeOptionalString(value))
+  @IsOptional()
+  @IsDateString()
+  startTime?: string;
+
+  @Transform(({ value }) => normalizeOptionalString(value))
+  @IsOptional()
+  @IsDateString()
+  endTime?: string;
+}

--- a/apps/api/src/modules/inventory/inventory.controller.ts
+++ b/apps/api/src/modules/inventory/inventory.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { CreateOpeningInventoryDto } from './dto/create-opening-inventory.dto';
 import { QueryAvailableInventoryDto } from './dto/query-available-inventory.dto';
+import { QueryInventoryTransactionDto } from './dto/query-inventory-transaction.dto';
 import { InventoryService } from './inventory.service';
 
 @Controller('inventory')
@@ -16,6 +17,11 @@ export class InventoryController {
   @Get('batches')
   findBatches(@Query() query: QueryAvailableInventoryDto) {
     return this.inventoryService.findBatches(query);
+  }
+
+  @Get('transactions')
+  findTransactions(@Query() query: QueryInventoryTransactionDto) {
+    return this.inventoryService.findTransactions(query);
   }
 
   @Post('opening-balances')

--- a/apps/api/src/modules/inventory/inventory.repository.ts
+++ b/apps/api/src/modules/inventory/inventory.repository.ts
@@ -1,8 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, EntityManager, In, Repository } from 'typeorm';
+import { QueryInventoryTransactionDto } from './dto/query-inventory-transaction.dto';
 import { InventoryBatch } from './entities/inventory-batch.entity';
 import { InventorySummary } from './entities/inventory-summary.entity';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
 
 @Injectable()
 export class InventoryRepository {
@@ -10,6 +12,8 @@ export class InventoryRepository {
     private readonly dataSource: DataSource,
     @InjectRepository(InventorySummary)
     private readonly summaryRepo: Repository<InventorySummary>,
+    @InjectRepository(InventoryTransaction)
+    private readonly transactionRepo: Repository<InventoryTransaction>,
   ) {}
 
   createQueryRunner() {
@@ -62,6 +66,58 @@ export class InventoryRepository {
         id: 'ASC',
       },
     });
+  }
+
+  async findTransactions(query: QueryInventoryTransactionDto): Promise<{
+    data: InventoryTransaction[];
+    total: number;
+    page: number;
+    pageSize: number;
+    totalPages: number;
+  }> {
+    const { page = 1, pageSize = 20 } = query;
+    const qb = this.transactionRepo.createQueryBuilder('inventoryTransaction');
+
+    if (query.skuId !== undefined) {
+      qb.andWhere('inventoryTransaction.sku_id = :skuId', {
+        skuId: query.skuId,
+      });
+    }
+    if (query.warehouseId !== undefined) {
+      qb.andWhere('inventoryTransaction.warehouse_id = :warehouseId', {
+        warehouseId: query.warehouseId,
+      });
+    }
+    if (query.changeType !== undefined) {
+      qb.andWhere('inventoryTransaction.change_type = :changeType', {
+        changeType: query.changeType,
+      });
+    }
+    if (query.startTime !== undefined) {
+      qb.andWhere('inventoryTransaction.operated_at >= :startTime', {
+        startTime: this.toRangeStart(query.startTime),
+      });
+    }
+    if (query.endTime !== undefined) {
+      qb.andWhere('inventoryTransaction.operated_at <= :endTime', {
+        endTime: this.toRangeEnd(query.endTime),
+      });
+    }
+
+    const [data, total] = await qb
+      .orderBy('inventoryTransaction.operated_at', 'DESC')
+      .addOrderBy('inventoryTransaction.id', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
   }
 
   findSummaryForUpdate(
@@ -137,5 +193,19 @@ export class InventoryRepository {
       actualQuantity: Number(result?.actualQuantity ?? 0),
       lockedQuantity: Number(result?.lockedQuantity ?? 0),
     };
+  }
+
+  private toRangeStart(value: string): Date | string {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return `${value} 00:00:00.000`;
+    }
+    return new Date(value);
+  }
+
+  private toRangeEnd(value: string): Date | string {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return `${value} 23:59:59.999`;
+    }
+    return new Date(value);
   }
 }

--- a/apps/api/src/modules/inventory/inventory.service.ts
+++ b/apps/api/src/modules/inventory/inventory.service.ts
@@ -3,15 +3,17 @@ import {
   ConflictException,
   Injectable,
 } from '@nestjs/common';
-import { InventoryBatchSourceType } from '@infitek/shared';
-import { randomUUID } from 'node:crypto';
+import { InventoryBatchSourceType, InventoryChangeType } from '@infitek/shared';
+import { createHash, randomUUID } from 'node:crypto';
 import { QueryRunner } from 'typeorm';
 import { SkusService } from '../master-data/skus/skus.service';
 import { WarehousesService } from '../master-data/warehouses/warehouses.service';
 import { CreateOpeningInventoryDto } from './dto/create-opening-inventory.dto';
 import { QueryAvailableInventoryDto } from './dto/query-available-inventory.dto';
+import { QueryInventoryTransactionDto } from './dto/query-inventory-transaction.dto';
 import { InventoryBatch } from './entities/inventory-batch.entity';
 import { InventorySummary } from './entities/inventory-summary.entity';
+import { InventoryTransaction } from './entities/inventory-transaction.entity';
 import { InventoryRepository } from './inventory.repository';
 
 const MAX_DEADLOCK_RETRIES = 3;
@@ -51,6 +53,8 @@ export interface IncreaseStockCommand {
   quantity: number;
   sourceType: InventoryBatchSourceType;
   sourceDocumentId?: number | null;
+  sourceDocumentItemId?: number | null;
+  sourceActionKey?: string;
   receiptDate?: string;
   operator?: string;
 }
@@ -66,6 +70,10 @@ export interface AllocatedStockCommand {
   skuId: number;
   warehouseId: number;
   allocations: InventoryBatchQuantity[];
+  sourceDocumentType?: string;
+  sourceDocumentId?: number | null;
+  sourceDocumentItemId?: number | null;
+  sourceActionKey?: string;
   operator?: string;
 }
 
@@ -73,6 +81,36 @@ export interface InventoryMutationResult {
   summary: InventorySummary;
   batches: InventoryBatch[];
   allocations?: InventoryBatchQuantity[];
+}
+
+export interface InventoryTransactionItem {
+  id: number;
+  skuId: number;
+  warehouseId: number;
+  inventoryBatchId: number | null;
+  changeType: InventoryChangeType;
+  quantityChange: number;
+  actualQuantityDelta: number;
+  lockedQuantityDelta: number;
+  availableQuantityDelta: number;
+  beforeActualQuantity: number;
+  afterActualQuantity: number;
+  beforeLockedQuantity: number;
+  afterLockedQuantity: number;
+  beforeAvailableQuantity: number;
+  afterAvailableQuantity: number;
+  sourceDocumentType: string;
+  sourceDocumentId: number;
+  sourceDocumentItemId: number | null;
+  sourceActionKey: string;
+  operatedBy: string | null;
+  operatedAt: Date;
+}
+
+interface InventorySummarySnapshot {
+  actualQuantity: number;
+  lockedQuantity: number;
+  availableQuantity: number;
 }
 
 @Injectable()
@@ -137,6 +175,22 @@ export class InventoryService {
       query.warehouseId,
     );
     return batches.map((batch) => this.toBatchItem(batch));
+  }
+
+  async findTransactions(query: QueryInventoryTransactionDto): Promise<{
+    data: InventoryTransactionItem[];
+    total: number;
+    page: number;
+    pageSize: number;
+    totalPages: number;
+  }> {
+    const result = await this.inventoryRepository.findTransactions(query);
+    return {
+      ...result,
+      data: result.data.map((transaction) =>
+        this.toTransactionItem(transaction),
+      ),
+    };
   }
 
   async recordOpeningBalance(
@@ -209,6 +263,7 @@ export class InventoryService {
       dto.warehouseId,
       operator,
     );
+    const beforeSummary = this.toSummarySnapshot(summary);
 
     const batch = batchRepo.create({
       batchNo: this.buildPendingBatchNo(),
@@ -236,6 +291,19 @@ export class InventoryService {
       dto.warehouseId,
       operator,
     );
+    await this.writeInventoryTransaction(queryRunner, {
+      skuId: dto.skuId,
+      warehouseId: dto.warehouseId,
+      inventoryBatchId: Number(finalizedBatch.id),
+      changeType: InventoryChangeType.INITIAL,
+      beforeSummary,
+      afterSummary: this.toSummarySnapshot(savedSummary),
+      sourceDocumentType: 'opening_inventory',
+      sourceDocumentId: Number(finalizedBatch.id),
+      sourceDocumentItemId: null,
+      sourceActionKey: this.buildOpeningInventoryActionKey(dto),
+      operatedBy: operator,
+    });
 
     return { summary: savedSummary, batch: finalizedBatch };
   }
@@ -261,6 +329,7 @@ export class InventoryService {
       command.warehouseId,
       command.operator,
     );
+    const beforeSummary = this.toSummarySnapshot(summary);
 
     const batch = batchRepo.create({
       batchNo: this.buildPendingBatchNo(),
@@ -288,6 +357,22 @@ export class InventoryService {
       command.warehouseId,
       command.operator,
     );
+    await this.writeInventoryTransaction(queryRunner, {
+      skuId: command.skuId,
+      warehouseId: command.warehouseId,
+      inventoryBatchId: Number(finalizedBatch.id),
+      changeType: InventoryChangeType.PURCHASE_RECEIPT,
+      beforeSummary,
+      afterSummary: this.toSummarySnapshot(savedSummary),
+      sourceDocumentType: this.toSourceDocumentType(command.sourceType),
+      sourceDocumentId: command.sourceDocumentId ?? Number(finalizedBatch.id),
+      sourceDocumentItemId: command.sourceDocumentItemId ?? null,
+      sourceActionKey: this.buildIncreaseStockActionKey(
+        command,
+        finalizedBatch,
+      ),
+      operatedBy: command.operator,
+    });
 
     return { summary: savedSummary, batches: [finalizedBatch] };
   }
@@ -387,6 +472,7 @@ export class InventoryService {
     if (!summary) {
       throw this.createStockInsufficientException(0);
     }
+    const beforeSummary = this.toSummarySnapshot(summary);
 
     const batches = await this.inventoryRepository.findBatchesForUpdate(
       manager,
@@ -430,6 +516,26 @@ export class InventoryService {
       command.warehouseId,
       command.operator,
     );
+    if (changeType === 'deduct') {
+      await this.writeInventoryTransaction(queryRunner, {
+        skuId: command.skuId,
+        warehouseId: command.warehouseId,
+        inventoryBatchId:
+          normalized.batchIds.length === 1 ? normalized.batchIds[0] : null,
+        changeType: InventoryChangeType.OUTBOUND,
+        beforeSummary,
+        afterSummary: this.toSummarySnapshot(savedSummary),
+        sourceDocumentType: command.sourceDocumentType ?? 'outbound_order',
+        sourceDocumentId:
+          command.sourceDocumentId ?? normalized.batchIds[0] ?? 0,
+        sourceDocumentItemId: command.sourceDocumentItemId ?? null,
+        sourceActionKey: this.buildDeductLockedStockActionKey(
+          command,
+          normalized,
+        ),
+        operatedBy: command.operator,
+      });
+    }
 
     return { summary: savedSummary, batches: touchedBatches };
   }
@@ -628,6 +734,162 @@ export class InventoryService {
       receiptDate: batch.receiptDate,
       updatedAt: batch.updatedAt,
     };
+  }
+
+  private toTransactionItem(
+    transaction: InventoryTransaction,
+  ): InventoryTransactionItem {
+    const actualQuantityDelta = Number(transaction.actualQuantityDelta ?? 0);
+    const lockedQuantityDelta = Number(transaction.lockedQuantityDelta ?? 0);
+    return {
+      id: Number(transaction.id),
+      skuId: Number(transaction.skuId),
+      warehouseId: Number(transaction.warehouseId),
+      inventoryBatchId:
+        transaction.inventoryBatchId === null
+          ? null
+          : Number(transaction.inventoryBatchId),
+      changeType: transaction.changeType,
+      quantityChange:
+        actualQuantityDelta !== 0 ? actualQuantityDelta : lockedQuantityDelta,
+      actualQuantityDelta,
+      lockedQuantityDelta,
+      availableQuantityDelta: Number(transaction.availableQuantityDelta ?? 0),
+      beforeActualQuantity: Number(transaction.beforeActualQuantity ?? 0),
+      afterActualQuantity: Number(transaction.afterActualQuantity ?? 0),
+      beforeLockedQuantity: Number(transaction.beforeLockedQuantity ?? 0),
+      afterLockedQuantity: Number(transaction.afterLockedQuantity ?? 0),
+      beforeAvailableQuantity: Number(
+        transaction.beforeAvailableQuantity ?? 0,
+      ),
+      afterAvailableQuantity: Number(transaction.afterAvailableQuantity ?? 0),
+      sourceDocumentType: transaction.sourceDocumentType,
+      sourceDocumentId: Number(transaction.sourceDocumentId),
+      sourceDocumentItemId:
+        transaction.sourceDocumentItemId === null
+          ? null
+          : Number(transaction.sourceDocumentItemId),
+      sourceActionKey: transaction.sourceActionKey,
+      operatedBy: transaction.operatedBy,
+      operatedAt: transaction.operatedAt,
+    };
+  }
+
+  private async writeInventoryTransaction(
+    queryRunner: QueryRunner,
+    input: {
+      skuId: number;
+      warehouseId: number;
+      inventoryBatchId: number | null;
+      changeType: InventoryChangeType;
+      beforeSummary: InventorySummarySnapshot;
+      afterSummary: InventorySummarySnapshot;
+      sourceDocumentType: string;
+      sourceDocumentId: number;
+      sourceDocumentItemId: number | null;
+      sourceActionKey: string;
+      operatedBy?: string;
+    },
+  ): Promise<void> {
+    const repo = queryRunner.manager.getRepository(InventoryTransaction);
+    await repo.save(
+      repo.create({
+        skuId: input.skuId,
+        warehouseId: input.warehouseId,
+        inventoryBatchId: input.inventoryBatchId,
+        changeType: input.changeType,
+        actualQuantityDelta:
+          input.afterSummary.actualQuantity - input.beforeSummary.actualQuantity,
+        lockedQuantityDelta:
+          input.afterSummary.lockedQuantity - input.beforeSummary.lockedQuantity,
+        availableQuantityDelta:
+          input.afterSummary.availableQuantity -
+          input.beforeSummary.availableQuantity,
+        beforeActualQuantity: input.beforeSummary.actualQuantity,
+        afterActualQuantity: input.afterSummary.actualQuantity,
+        beforeLockedQuantity: input.beforeSummary.lockedQuantity,
+        afterLockedQuantity: input.afterSummary.lockedQuantity,
+        beforeAvailableQuantity: input.beforeSummary.availableQuantity,
+        afterAvailableQuantity: input.afterSummary.availableQuantity,
+        sourceDocumentType: input.sourceDocumentType,
+        sourceDocumentId: input.sourceDocumentId,
+        sourceDocumentItemId: input.sourceDocumentItemId,
+        sourceActionKey: input.sourceActionKey,
+        operatedBy: input.operatedBy ?? 'system',
+      }),
+    );
+  }
+
+  private toSummarySnapshot(summary: InventorySummary): InventorySummarySnapshot {
+    const actualQuantity = Number(summary.actualQuantity ?? 0);
+    const lockedQuantity = Number(summary.lockedQuantity ?? 0);
+    const rawAvailableQuantity = summary.availableQuantity;
+    return {
+      actualQuantity,
+      lockedQuantity,
+      availableQuantity:
+        rawAvailableQuantity === undefined || rawAvailableQuantity === null
+          ? actualQuantity - lockedQuantity
+          : Number(rawAvailableQuantity),
+    };
+  }
+
+  private toSourceDocumentType(sourceType: InventoryBatchSourceType): string {
+    if (sourceType === InventoryBatchSourceType.PURCHASE_RECEIPT) {
+      return 'receipt_order';
+    }
+    return sourceType;
+  }
+
+  private buildOpeningInventoryActionKey(
+    dto: CreateOpeningInventoryDto,
+  ): string {
+    return `inventory:initial:sku:${dto.skuId}:warehouse:${dto.warehouseId}:record`;
+  }
+
+  private buildIncreaseStockActionKey(
+    command: IncreaseStockCommand,
+    batch: InventoryBatch,
+  ): string {
+    if (command.sourceActionKey) return command.sourceActionKey;
+
+    if (command.sourceDocumentId !== undefined && command.sourceDocumentId !== null) {
+      const itemKey =
+        command.sourceDocumentItemId !== undefined &&
+        command.sourceDocumentItemId !== null
+          ? `item:${command.sourceDocumentItemId}`
+          : `sku:${command.skuId}:warehouse:${command.warehouseId}`;
+      return `inventory:${command.sourceType}:doc:${command.sourceDocumentId}:${itemKey}:increase`;
+    }
+
+    return `inventory:${command.sourceType}:batch:${Number(batch.id)}:increase`;
+  }
+
+  private buildDeductLockedStockActionKey(
+    command: AllocatedStockCommand,
+    normalized: {
+      batchIds: number[];
+      quantityByBatchId: Map<number, number>;
+    },
+  ): string {
+    if (command.sourceActionKey) return command.sourceActionKey;
+
+    const allocationSignature = normalized.batchIds
+      .map(
+        (batchId) =>
+          `${batchId}:${normalized.quantityByBatchId.get(batchId) ?? 0}`,
+      )
+      .join(',');
+    const allocationHash = this.hashActionPart(allocationSignature);
+    const sourceKey =
+      command.sourceDocumentId !== undefined && command.sourceDocumentId !== null
+        ? `doc:${command.sourceDocumentId}:item:${command.sourceDocumentItemId ?? 'none'}`
+        : `sku:${command.skuId}:warehouse:${command.warehouseId}`;
+    return `inventory:outbound:${sourceKey}:deduct:${allocationHash}`;
+  }
+
+  private hashActionPart(value: string): string {
+    return createHash('sha256').update(value).digest('hex').slice(0, 16);
   }
 
   private buildInitialBatchNo(receiptDate: string, batchId: number): string {

--- a/apps/api/src/modules/inventory/tests/inventory.repository.spec.ts
+++ b/apps/api/src/modules/inventory/tests/inventory.repository.spec.ts
@@ -1,0 +1,93 @@
+import { InventoryChangeType } from '@infitek/shared';
+import { InventoryRepository } from '../inventory.repository';
+
+describe('InventoryRepository', () => {
+  const dataSource = {
+    createQueryRunner: jest.fn(),
+    getRepository: jest.fn(),
+  };
+  const summaryRepo = {
+    find: jest.fn(),
+  };
+  const transactionRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+
+  const qb = {
+    andWhere: jest.fn(),
+    orderBy: jest.fn(),
+    addOrderBy: jest.fn(),
+    skip: jest.fn(),
+    take: jest.fn(),
+    getManyAndCount: jest.fn(),
+  };
+
+  let repository: InventoryRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const method of ['andWhere', 'orderBy', 'addOrderBy', 'skip', 'take'] as const) {
+      qb[method].mockReturnValue(qb);
+    }
+    qb.getManyAndCount.mockResolvedValue([[{ id: 1 }], 1]);
+    transactionRepo.createQueryBuilder.mockReturnValue(qb);
+    repository = new InventoryRepository(
+      dataSource as any,
+      summaryRepo as any,
+      transactionRepo as any,
+    );
+  });
+
+  it('findTransactions applies filters, date range, sorting and pagination', async () => {
+    const result = await repository.findTransactions({
+      skuId: 11,
+      warehouseId: 22,
+      changeType: InventoryChangeType.PURCHASE_RECEIPT,
+      startTime: '2026-04-01',
+      endTime: '2026-04-29',
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(transactionRepo.createQueryBuilder).toHaveBeenCalledWith(
+      'inventoryTransaction',
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'inventoryTransaction.sku_id = :skuId',
+      { skuId: 11 },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'inventoryTransaction.warehouse_id = :warehouseId',
+      { warehouseId: 22 },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'inventoryTransaction.change_type = :changeType',
+      { changeType: InventoryChangeType.PURCHASE_RECEIPT },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'inventoryTransaction.operated_at >= :startTime',
+      { startTime: '2026-04-01 00:00:00.000' },
+    );
+    expect(qb.andWhere).toHaveBeenCalledWith(
+      'inventoryTransaction.operated_at <= :endTime',
+      { endTime: '2026-04-29 23:59:59.999' },
+    );
+    expect(qb.orderBy).toHaveBeenCalledWith(
+      'inventoryTransaction.operated_at',
+      'DESC',
+    );
+    expect(qb.addOrderBy).toHaveBeenCalledWith(
+      'inventoryTransaction.id',
+      'DESC',
+    );
+    expect(qb.skip).toHaveBeenCalledWith(10);
+    expect(qb.take).toHaveBeenCalledWith(10);
+    expect(result).toEqual({
+      data: [{ id: 1 }],
+      total: 1,
+      page: 2,
+      pageSize: 10,
+      totalPages: 1,
+    });
+  });
+});

--- a/apps/api/src/modules/inventory/tests/inventory.service.spec.ts
+++ b/apps/api/src/modules/inventory/tests/inventory.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, ConflictException } from '@nestjs/common';
-import { InventoryBatchSourceType } from '@infitek/shared';
+import { InventoryBatchSourceType, InventoryChangeType } from '@infitek/shared';
+import { InventoryTransaction } from '../entities/inventory-transaction.entity';
 import { InventoryService } from '../inventory.service';
 
 describe('InventoryService', () => {
@@ -11,6 +12,7 @@ describe('InventoryService', () => {
     findAvailableBatchesForUpdate: jest.fn(),
     findBatchesForUpdate: jest.fn(),
     sumBatchQuantities: jest.fn(),
+    findTransactions: jest.fn(),
   };
   const skusService = { findById: jest.fn() };
   const warehousesService = { findById: jest.fn() };
@@ -23,6 +25,10 @@ describe('InventoryService', () => {
     create: jest.fn((data) => ({ id: undefined, ...data })),
     save: jest.fn(async (data) => ({ ...data, id: data.id ?? 2 })),
   };
+  const transactionRepo = {
+    create: jest.fn((data) => ({ id: undefined, ...data })),
+    save: jest.fn(async (data) => ({ ...data, id: data.id ?? 3 })),
+  };
 
   const makeQueryRunner = () => ({
     connect: jest.fn().mockResolvedValue(undefined),
@@ -34,6 +40,7 @@ describe('InventoryService', () => {
       getRepository: jest.fn((entity) => {
         if (entity.name === 'InventorySummary') return summaryRepo;
         if (entity.name === 'InventoryBatch') return batchRepo;
+        if (entity.name === 'InventoryTransaction') return transactionRepo;
         throw new Error(`Unexpected repository: ${entity.name}`);
       }),
     },
@@ -43,6 +50,24 @@ describe('InventoryService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    summaryRepo.create.mockImplementation((data) => ({ id: undefined, ...data }));
+    summaryRepo.save.mockImplementation(async (data) => ({
+      id: data.id ?? 1,
+      ...data,
+    }));
+    batchRepo.create.mockImplementation((data) => ({ id: undefined, ...data }));
+    batchRepo.save.mockImplementation(async (data) => ({
+      ...data,
+      id: data.id ?? 2,
+    }));
+    transactionRepo.create.mockImplementation((data) => ({
+      id: undefined,
+      ...data,
+    }));
+    transactionRepo.save.mockImplementation(async (data) => ({
+      ...data,
+      id: data.id ?? 3,
+    }));
     jest.spyOn(global, 'setTimeout').mockImplementation((callback: any) => {
       callback();
       return 0 as any;
@@ -257,6 +282,77 @@ describe('InventoryService', () => {
     ]);
   });
 
+  it('findTransactions maps delta fields and fallback quantityChange', async () => {
+    const operatedAt = new Date('2026-04-29T08:00:00Z');
+    inventoryRepository.findTransactions.mockResolvedValue({
+      data: [
+        {
+          id: '31',
+          skuId: '11',
+          warehouseId: '22',
+          inventoryBatchId: null,
+          changeType: InventoryChangeType.LOCK,
+          actualQuantityDelta: '0',
+          lockedQuantityDelta: '5',
+          availableQuantityDelta: '-5',
+          beforeActualQuantity: '10',
+          afterActualQuantity: '10',
+          beforeLockedQuantity: '0',
+          afterLockedQuantity: '5',
+          beforeAvailableQuantity: '10',
+          afterAvailableQuantity: '5',
+          sourceDocumentType: 'shipping_demand',
+          sourceDocumentId: '500',
+          sourceDocumentItemId: '700',
+          sourceActionKey: 'shipping-demand:500:item:700:lock',
+          operatedBy: 'admin',
+          operatedAt,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    });
+
+    const result = await service.findTransactions({
+      skuId: 11,
+      warehouseId: 22,
+      changeType: InventoryChangeType.LOCK,
+    });
+
+    expect(inventoryRepository.findTransactions).toHaveBeenCalledWith({
+      skuId: 11,
+      warehouseId: 22,
+      changeType: InventoryChangeType.LOCK,
+    });
+    expect(result.data).toEqual([
+      {
+        id: 31,
+        skuId: 11,
+        warehouseId: 22,
+        inventoryBatchId: null,
+        changeType: InventoryChangeType.LOCK,
+        quantityChange: 5,
+        actualQuantityDelta: 0,
+        lockedQuantityDelta: 5,
+        availableQuantityDelta: -5,
+        beforeActualQuantity: 10,
+        afterActualQuantity: 10,
+        beforeLockedQuantity: 0,
+        afterLockedQuantity: 5,
+        beforeAvailableQuantity: 10,
+        afterAvailableQuantity: 5,
+        sourceDocumentType: 'shipping_demand',
+        sourceDocumentId: 500,
+        sourceDocumentItemId: 700,
+        sourceActionKey: 'shipping-demand:500:item:700:lock',
+        operatedBy: 'admin',
+        operatedAt,
+      },
+    ]);
+  });
+
   it('recordOpeningBalance creates initial batch and summary inside a transaction', async () => {
     const queryRunner = makeQueryRunner();
     inventoryRepository.createQueryRunner.mockReturnValue(queryRunner);
@@ -293,6 +389,28 @@ describe('InventoryService', () => {
         actualQuantity: 10,
         lockedQuantity: 0,
         availableQuantity: 10,
+      }),
+    );
+    expect(transactionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 22,
+        inventoryBatchId: 2,
+        changeType: InventoryChangeType.INITIAL,
+        actualQuantityDelta: 10,
+        lockedQuantityDelta: 0,
+        availableQuantityDelta: 10,
+        beforeActualQuantity: 0,
+        afterActualQuantity: 10,
+        beforeLockedQuantity: 0,
+        afterLockedQuantity: 0,
+        beforeAvailableQuantity: 0,
+        afterAvailableQuantity: 10,
+        sourceDocumentType: 'opening_inventory',
+        sourceDocumentId: 2,
+        sourceDocumentItemId: null,
+        sourceActionKey: 'inventory:initial:sku:11:warehouse:22:record',
+        operatedBy: 'admin',
       }),
     );
     expect(queryRunner.commitTransaction).toHaveBeenCalled();
@@ -343,6 +461,20 @@ describe('InventoryService', () => {
     expect(result.batch.batchNo).toBe('INV-INIT-20260402-000002');
     expect(result.summary.actualQuantity).toBe(19);
     expect(result.summary.availableQuantity).toBe(18);
+    expect(transactionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeType: InventoryChangeType.INITIAL,
+        actualQuantityDelta: 12,
+        lockedQuantityDelta: 0,
+        availableQuantityDelta: 12,
+        beforeActualQuantity: 7,
+        afterActualQuantity: 19,
+        beforeLockedQuantity: 1,
+        afterLockedQuantity: 1,
+        beforeAvailableQuantity: 6,
+        afterAvailableQuantity: 18,
+      }),
+    );
   });
 
   it('recordOpeningBalance creates separate initial batches for the same SKU in different warehouses', async () => {
@@ -396,6 +528,7 @@ describe('InventoryService', () => {
       quantity: 8,
       sourceType: InventoryBatchSourceType.PURCHASE_RECEIPT,
       sourceDocumentId: 9001,
+      sourceDocumentItemId: 9101,
       receiptDate: '2026-04-03',
       operator: 'admin',
     });
@@ -420,6 +553,29 @@ describe('InventoryService', () => {
     expect(result.batches[0].batchNo).toBe('INV-REC-20260403-000002');
     expect(result.summary.actualQuantity).toBe(18);
     expect(result.summary.availableQuantity).toBe(16);
+    expect(transactionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 22,
+        inventoryBatchId: 2,
+        changeType: InventoryChangeType.PURCHASE_RECEIPT,
+        actualQuantityDelta: 18,
+        lockedQuantityDelta: 2,
+        availableQuantityDelta: 16,
+        beforeActualQuantity: 0,
+        afterActualQuantity: 18,
+        beforeLockedQuantity: 0,
+        afterLockedQuantity: 2,
+        beforeAvailableQuantity: 0,
+        afterAvailableQuantity: 16,
+        sourceDocumentType: 'receipt_order',
+        sourceDocumentId: 9001,
+        sourceDocumentItemId: 9101,
+        sourceActionKey:
+          'inventory:purchase_receipt:doc:9001:item:9101:increase',
+        operatedBy: 'admin',
+      }),
+    );
   });
 
   it('lockStock locks FIFO batches and refreshes summary quantities', async () => {
@@ -581,6 +737,10 @@ describe('InventoryService', () => {
       skuId: 11,
       warehouseId: 22,
       allocations: [{ batchId: 100, quantity: 2 }],
+      sourceDocumentType: 'outbound_order',
+      sourceDocumentId: 7001,
+      sourceDocumentItemId: 8001,
+      sourceActionKey: 'outbound:7001:confirm:item:8001',
       operator: 'admin',
     });
 
@@ -591,7 +751,62 @@ describe('InventoryService', () => {
         batchLockedQuantity: 1,
       }),
     );
+    expect(transactionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 22,
+        inventoryBatchId: 100,
+        changeType: InventoryChangeType.OUTBOUND,
+        actualQuantityDelta: -2,
+        lockedQuantityDelta: -2,
+        availableQuantityDelta: 0,
+        beforeActualQuantity: 5,
+        afterActualQuantity: 3,
+        beforeLockedQuantity: 3,
+        afterLockedQuantity: 1,
+        beforeAvailableQuantity: 2,
+        afterAvailableQuantity: 2,
+        sourceDocumentType: 'outbound_order',
+        sourceDocumentId: 7001,
+        sourceDocumentItemId: 8001,
+        sourceActionKey: 'outbound:7001:confirm:item:8001',
+        operatedBy: 'admin',
+      }),
+    );
     expect(result.summary.availableQuantity).toBe(2);
+  });
+
+  it('increaseStock reports conflict when the source action key already exists', async () => {
+    inventoryRepository.createQueryRunner
+      .mockReturnValueOnce(makeQueryRunner())
+      .mockReturnValueOnce(makeQueryRunner())
+      .mockReturnValueOnce(makeQueryRunner())
+      .mockReturnValueOnce(makeQueryRunner());
+    transactionRepo.save.mockRejectedValue({
+      code: 'ER_DUP_ENTRY',
+      errno: 1062,
+    });
+
+    await expect(
+      service.increaseStock({
+        skuId: 11,
+        warehouseId: 22,
+        quantity: 8,
+        sourceType: InventoryBatchSourceType.PURCHASE_RECEIPT,
+        sourceDocumentId: 9001,
+        sourceDocumentItemId: 9101,
+        receiptDate: '2026-04-03',
+        operator: 'admin',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(inventoryRepository.createQueryRunner).toHaveBeenCalledTimes(4);
+    expect(transactionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceActionKey:
+          'inventory:purchase_receipt:doc:9001:item:9101:increase',
+      }),
+    );
   });
 
   it('recordOpeningBalance retries deadlocks and then succeeds', async () => {

--- a/apps/api/src/modules/inventory/tests/query-inventory-transaction.dto.spec.ts
+++ b/apps/api/src/modules/inventory/tests/query-inventory-transaction.dto.spec.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { InventoryChangeType } from '@infitek/shared';
+import { QueryInventoryTransactionDto } from '../dto/query-inventory-transaction.dto';
+
+describe('QueryInventoryTransactionDto', () => {
+  async function validateQuery(input: Record<string, unknown>) {
+    const dto = plainToInstance(QueryInventoryTransactionDto, input);
+    const errors = await validate(dto);
+    return { dto, errors };
+  }
+
+  it('normalizes IDs, dates and pagination values', async () => {
+    const { dto, errors } = await validateQuery({
+      skuId: '11',
+      warehouseId: '22',
+      changeType: InventoryChangeType.PURCHASE_RECEIPT,
+      startTime: '2026-04-01',
+      endTime: '2026-04-29',
+      page: '2',
+      pageSize: '10',
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(dto).toEqual(
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 22,
+        changeType: InventoryChangeType.PURCHASE_RECEIPT,
+        startTime: '2026-04-01',
+        endTime: '2026-04-29',
+        page: 2,
+        pageSize: 10,
+      }),
+    );
+  });
+
+  it('rejects invalid change type and date values', async () => {
+    const { errors } = await validateQuery({
+      changeType: 'adjustment',
+      startTime: 'bad-date',
+    });
+
+    expect(errors.map((error) => error.property).sort()).toEqual([
+      'changeType',
+      'startTime',
+    ]);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -63,6 +63,7 @@ import ShippingDemandDetailPage from "./pages/shipping-demands/detail";
 import ShippingDemandFormPage from "./pages/shipping-demands/form";
 import LogisticsOrderFormPage from "./pages/logistics-orders/form";
 import InventoryPage from "./pages/inventory/index";
+import InventoryTransactionsPage from "./pages/inventory/transactions";
 import HomePage from "./pages/home/index";
 import "./App.css";
 
@@ -453,6 +454,10 @@ function App() {
                   <Route
                     path="/logistics-orders/create"
                     element={<LogisticsOrderFormPage />}
+                  />
+                  <Route
+                    path="/inventory/transactions"
+                    element={<InventoryTransactionsPage />}
                   />
                   <Route path="/inventory" element={<InventoryPage />} />
                   <Route path="/inventory/*" element={<InventoryPage />} />

--- a/apps/web/src/api/inventory.api.ts
+++ b/apps/web/src/api/inventory.api.ts
@@ -1,4 +1,5 @@
 import request from './request';
+import type { InventoryChangeType } from '@infitek/shared';
 
 export interface AvailableInventoryItem {
   skuId: number | string;
@@ -23,9 +24,51 @@ export interface InventoryBatchItem {
   updatedAt?: string;
 }
 
+export interface InventoryTransactionItem {
+  id: number | string;
+  skuId: number | string;
+  warehouseId: number | string;
+  inventoryBatchId: number | string | null;
+  changeType: InventoryChangeType;
+  quantityChange: number;
+  actualQuantityDelta: number;
+  lockedQuantityDelta: number;
+  availableQuantityDelta: number;
+  beforeActualQuantity: number;
+  afterActualQuantity: number;
+  beforeLockedQuantity: number;
+  afterLockedQuantity: number;
+  beforeAvailableQuantity: number;
+  afterAvailableQuantity: number;
+  sourceDocumentType: string;
+  sourceDocumentId: number | string;
+  sourceDocumentItemId: number | string | null;
+  sourceActionKey: string;
+  operatedBy: string | null;
+  operatedAt: string;
+}
+
+export interface InventoryTransactionsPage {
+  data: InventoryTransactionItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
 export interface QueryAvailableInventoryParams {
   skuIds?: number[];
   warehouseId?: number;
+}
+
+export interface QueryInventoryTransactionParams {
+  skuId?: number;
+  warehouseId?: number;
+  changeType?: InventoryChangeType;
+  startTime?: string;
+  endTime?: string;
+  page?: number;
+  pageSize?: number;
 }
 
 export interface CreateOpeningInventoryPayload {
@@ -75,6 +118,15 @@ export const getInventoryBatches = (
         skuIds: params.skuIds?.length ? params.skuIds.join(',') : undefined,
         warehouseId: params.warehouseId,
       },
+    })
+    .catch(normalizeApiError);
+
+export const getInventoryTransactions = (
+  params: QueryInventoryTransactionParams,
+): Promise<InventoryTransactionsPage> =>
+  request
+    .get<unknown, InventoryTransactionsPage>('/inventory/transactions', {
+      params,
     })
     .catch(normalizeApiError);
 

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -122,6 +122,12 @@ const BREADCRUMB_ROUTES: BreadcrumbRoute[] = [
     listLabel: '库存查询',
   }),
   ...createCrudBreadcrumbRoutes({
+    basePath: '/inventory/transactions',
+    sectionLabel: '库存管理',
+    sectionPath: INVENTORY_SECTION_PATH,
+    listLabel: '库存变动流水',
+  }),
+  ...createCrudBreadcrumbRoutes({
     basePath: '/master-data/units',
     sectionLabel: '基础数据',
     sectionPath: BASIC_DATA_SECTION_PATH,

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -91,7 +91,10 @@ const menuItems = [
         <rect x="5.5" y="10" width="5" height="4.5" rx=".5" stroke="currentColor" strokeWidth="1.1"/>
       </svg>
     ),
-    children: [{ key: '/inventory', label: '库存查询' }],
+    children: [
+      { key: '/inventory', label: '库存查询', exact: true },
+      { key: '/inventory/transactions', label: '库存变动流水' },
+    ],
   },
   {
     section: SECTION_SYSTEM,
@@ -151,8 +154,22 @@ function getInitials(name: string) {
   return name ? name.slice(0, 2).toUpperCase() : 'U';
 }
 
-function isChildRouteActive(currentPath: string, childPath: string): boolean {
+function isChildRouteActive(
+  currentPath: string,
+  childPath: string,
+  exact?: boolean,
+): boolean {
+  if (exact) return currentPath === childPath;
   return currentPath === childPath || currentPath.startsWith(`${childPath}/`);
+}
+
+function isExactChild(child: unknown): boolean {
+  return (
+    typeof child === 'object' &&
+    child !== null &&
+    'exact' in child &&
+    child.exact === true
+  );
 }
 
 export default function Sidebar() {
@@ -161,7 +178,7 @@ export default function Sidebar() {
   const { user, logout } = useAuthStore();
 
   const defaultOpen = menuItems
-    .filter((item) => item.children.some((c) => isChildRouteActive(location.pathname, c.key)))
+    .filter((item) => item.children.some((c) => isChildRouteActive(location.pathname, c.key, isExactChild(c))))
     .map((item) => item.key);
   const [openKeys, setOpenKeys] = useState<string[]>(defaultOpen);
   const [hoveredFooterBtn, setHoveredFooterBtn] = useState<string | null>(null);
@@ -232,7 +249,11 @@ export default function Sidebar() {
         >
           <div style={{ padding: '3px 0 6px 0' }}>
             {item.children.map((child) => {
-              const isActive = isChildRouteActive(location.pathname, child.key);
+              const isActive = isChildRouteActive(
+                location.pathname,
+                child.key,
+                isExactChild(child),
+              );
               return (
                 <ChildItem
                   key={child.key}

--- a/apps/web/src/pages/inventory/index.tsx
+++ b/apps/web/src/pages/inventory/index.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useRef, useState } from 'react';
-import { Button, Empty, Result, Select, Skeleton, Tag, message } from 'antd';
+import { Button, DatePicker, Drawer, Empty, Result, Select, Skeleton, Tag, message } from 'antd';
 import { ProForm, ProFormDatePicker, ProFormDigit, ProFormSelect, ProTable, type ProFormInstance } from '@ant-design/pro-components';
 import type { ProColumns } from '@ant-design/pro-components';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import dayjs, { type Dayjs } from 'dayjs';
-import { createOpeningInventory, getAvailableInventory, getInventoryBatches, type AvailableInventoryItem, type CreateOpeningInventoryPayload, type InventoryBatchItem } from '../../api/inventory.api';
+import { InventoryChangeType } from '@infitek/shared';
+import { createOpeningInventory, getAvailableInventory, getInventoryBatches, getInventoryTransactions, type AvailableInventoryItem, type CreateOpeningInventoryPayload, type InventoryBatchItem, type InventoryTransactionItem } from '../../api/inventory.api';
 import { getSkus, type Sku } from '../../api/skus.api';
 import { getWarehouses, type Warehouse } from '../../api/warehouses.api';
 import { SectionCard } from '../master-data/components/page-scaffold';
@@ -31,6 +33,27 @@ interface InventoryBatchRow extends InventoryBatchItem {
   warehouseName?: string | null;
 }
 
+interface InventoryTransactionRow extends InventoryTransactionItem {
+  key: string;
+  id: number;
+  skuId: number;
+  warehouseId: number;
+  inventoryBatchId: number | null;
+  sourceDocumentId: number;
+  sourceDocumentItemId: number | null;
+  skuCode?: string;
+  skuName?: string | null;
+  warehouseName?: string | null;
+}
+
+interface TransactionContext {
+  skuId: number;
+  warehouseId: number | null;
+  skuCode?: string;
+  skuName?: string | null;
+  warehouseName?: string | null;
+}
+
 interface OpeningInventoryFormValues {
   skuId: number;
   warehouseId: number;
@@ -47,6 +70,39 @@ function sourceTypeLabel(value: string) {
   if (value === 'initial') return '期初录入';
   if (value === 'purchase_receipt') return '采购入库';
   return value;
+}
+
+const inventoryChangeTypeOptions = [
+  { label: '期初录入', value: InventoryChangeType.INITIAL },
+  { label: '采购入库', value: InventoryChangeType.PURCHASE_RECEIPT },
+  { label: '发货出库', value: InventoryChangeType.OUTBOUND },
+  { label: '锁定', value: InventoryChangeType.LOCK },
+  { label: '解锁', value: InventoryChangeType.UNLOCK },
+];
+
+const inventoryChangeTypeColor: Record<string, string> = {
+  [InventoryChangeType.INITIAL]: 'blue',
+  [InventoryChangeType.PURCHASE_RECEIPT]: 'green',
+  [InventoryChangeType.OUTBOUND]: 'red',
+  [InventoryChangeType.LOCK]: 'gold',
+  [InventoryChangeType.UNLOCK]: 'purple',
+};
+
+function changeTypeLabel(value: string) {
+  return inventoryChangeTypeOptions.find((item) => item.value === value)?.label ?? value;
+}
+
+function signedNumber(value: number) {
+  if (value > 0) return `+${value}`;
+  return String(value);
+}
+
+function sourceDocumentNode(record: InventoryTransactionRow) {
+  const text = `${record.sourceDocumentType} #${record.sourceDocumentId}`;
+  if (record.sourceDocumentType === 'shipping_demand') {
+    return <Link to={`/shipping-demands/${record.sourceDocumentId}`}>{text}</Link>;
+  }
+  return <span className="inventory-source-text">{text}</span>;
 }
 
 function toNumberId(value: number | string | null | undefined) {
@@ -77,6 +133,11 @@ export default function InventoryPage() {
   const formRef = useRef<ProFormInstance<OpeningInventoryFormValues>>(undefined);
   const [selectedSkuIds, setSelectedSkuIds] = useState<number[]>([]);
   const [selectedWarehouseId, setSelectedWarehouseId] = useState<number | undefined>();
+  const [transactionContext, setTransactionContext] = useState<TransactionContext | null>(null);
+  const [transactionChangeType, setTransactionChangeType] = useState<InventoryChangeType | undefined>();
+  const [transactionDateRange, setTransactionDateRange] = useState<[Dayjs | null, Dayjs | null] | null>(null);
+  const [transactionPage, setTransactionPage] = useState(1);
+  const [transactionPageSize, setTransactionPageSize] = useState(20);
 
   const skusQuery = useQuery({
     queryKey: ['inventory-skus'],
@@ -107,6 +168,31 @@ export default function InventoryPage() {
         warehouseId: selectedWarehouseId,
       }),
     enabled: canQuery,
+  });
+  const transactionStartTime = transactionDateRange?.[0]?.format('YYYY-MM-DD');
+  const transactionEndTime = transactionDateRange?.[1]?.format('YYYY-MM-DD');
+  const transactionsQuery = useQuery({
+    queryKey: [
+      'inventory-transactions',
+      transactionContext?.skuId,
+      transactionContext?.warehouseId,
+      transactionChangeType,
+      transactionStartTime,
+      transactionEndTime,
+      transactionPage,
+      transactionPageSize,
+    ],
+    queryFn: () =>
+      getInventoryTransactions({
+        skuId: transactionContext?.skuId,
+        warehouseId: transactionContext?.warehouseId ?? undefined,
+        changeType: transactionChangeType,
+        startTime: transactionStartTime,
+        endTime: transactionEndTime,
+        page: transactionPage,
+        pageSize: transactionPageSize,
+      }),
+    enabled: transactionContext !== null,
   });
 
   const skuMap = useMemo(() => {
@@ -210,6 +296,34 @@ export default function InventoryPage() {
     [rows],
   );
 
+  const transactionRows: InventoryTransactionRow[] = useMemo(
+    () =>
+      (transactionsQuery.data?.data ?? []).map((item) => {
+        const id = toNumberId(item.id) ?? 0;
+        const skuId = toNumberId(item.skuId) ?? 0;
+        const warehouseId = toNumberId(item.warehouseId) ?? 0;
+        const inventoryBatchId = toNumberId(item.inventoryBatchId);
+        const sourceDocumentId = toNumberId(item.sourceDocumentId) ?? 0;
+        const sourceDocumentItemId = toNumberId(item.sourceDocumentItemId);
+        const sku = skuMap.get(skuId);
+        const warehouse = warehouseMap.get(warehouseId);
+        return {
+          ...item,
+          key: `${id}`,
+          id,
+          skuId,
+          warehouseId,
+          inventoryBatchId,
+          sourceDocumentId,
+          sourceDocumentItemId,
+          skuCode: sku?.skuCode,
+          skuName: sku?.nameCn ?? sku?.nameEn ?? sku?.specification,
+          warehouseName: warehouse?.name ?? `仓库 #${warehouseId}`,
+        };
+      }),
+    [transactionsQuery.data, skuMap, warehouseMap],
+  );
+
   const createMutation = useMutation({
     mutationFn: (payload: CreateOpeningInventoryPayload) => createOpeningInventory(payload),
     onSuccess: (_, payload) => {
@@ -218,9 +332,24 @@ export default function InventoryPage() {
       setSelectedWarehouseId(payload.warehouseId);
       queryClient.invalidateQueries({ queryKey: ['inventory-available'] });
       queryClient.invalidateQueries({ queryKey: ['inventory-batches'] });
+      queryClient.invalidateQueries({ queryKey: ['inventory-transactions'] });
       formRef.current?.resetFields();
     },
   });
+
+  const openTransactions = (record: InventoryRow) => {
+    setTransactionContext({
+      skuId: record.skuId,
+      warehouseId: record.warehouseId,
+      skuCode: record.skuCode,
+      skuName: record.skuName,
+      warehouseName: record.warehouseName,
+    });
+    setTransactionChangeType(undefined);
+    setTransactionDateRange(null);
+    setTransactionPage(1);
+    setTransactionPageSize(20);
+  };
 
   const columns: ProColumns<InventoryRow>[] = [
     {
@@ -264,6 +393,22 @@ export default function InventoryPage() {
       dataIndex: 'updatedAt',
       width: 145,
       render: (_, record) => (record.updatedAt ? dayjs(record.updatedAt).format('YYYY-MM-DD HH:mm') : '-'),
+    },
+    {
+      title: '操作',
+      valueType: 'option',
+      width: 120,
+      fixed: 'right',
+      render: (_, record) => [
+        <Button
+          key="transactions"
+          type="link"
+          size="small"
+          onClick={() => openTransactions(record)}
+        >
+          查看变动流水
+        </Button>,
+      ],
     },
   ];
 
@@ -320,6 +465,97 @@ export default function InventoryPage() {
       width: 115,
       align: 'right',
       render: (_, record) => inventoryTag(record.batchAvailableQuantity),
+    },
+  ];
+
+  const transactionColumns: ProColumns<InventoryTransactionRow>[] = [
+    {
+      title: '变动类型',
+      dataIndex: 'changeType',
+      width: 105,
+      render: (_, record) => (
+        <Tag color={inventoryChangeTypeColor[record.changeType]}>
+          {changeTypeLabel(record.changeType)}
+        </Tag>
+      ),
+    },
+    {
+      title: 'SKU',
+      dataIndex: 'skuCode',
+      width: 170,
+      render: (_, record) => (
+        <div className="inventory-sku-cell">
+          <div className="inventory-sku-code">{record.skuCode ?? `SKU #${record.skuId}`}</div>
+          <div className="inventory-sku-name">{record.skuName ?? '-'}</div>
+        </div>
+      ),
+    },
+    {
+      title: '仓库',
+      dataIndex: 'warehouseName',
+      width: 130,
+    },
+    {
+      title: '数量变化',
+      dataIndex: 'quantityChange',
+      width: 100,
+      align: 'right',
+      render: (_, record) => (
+        <span className={record.quantityChange >= 0 ? 'inventory-delta positive' : 'inventory-delta negative'}>
+          {signedNumber(record.quantityChange)}
+        </span>
+      ),
+    },
+    {
+      title: '实际库存',
+      dataIndex: 'actualQuantityDelta',
+      width: 105,
+      align: 'right',
+      render: (_, record) => signedNumber(record.actualQuantityDelta),
+    },
+    {
+      title: '锁定量',
+      dataIndex: 'lockedQuantityDelta',
+      width: 95,
+      align: 'right',
+      render: (_, record) => signedNumber(record.lockedQuantityDelta),
+    },
+    {
+      title: '可用库存',
+      dataIndex: 'availableQuantityDelta',
+      width: 105,
+      align: 'right',
+      render: (_, record) => signedNumber(record.availableQuantityDelta),
+    },
+    {
+      title: '变动前/后',
+      dataIndex: 'beforeAfter',
+      width: 150,
+      render: (_, record) => (
+        <div className="inventory-before-after">
+          <span>实 {record.beforeActualQuantity} / {record.afterActualQuantity}</span>
+          <span>锁 {record.beforeLockedQuantity} / {record.afterLockedQuantity}</span>
+          <span>可 {record.beforeAvailableQuantity} / {record.afterAvailableQuantity}</span>
+        </div>
+      ),
+    },
+    {
+      title: '来源单据',
+      dataIndex: 'sourceDocumentType',
+      width: 180,
+      render: (_, record) => sourceDocumentNode(record),
+    },
+    {
+      title: '操作人',
+      dataIndex: 'operatedBy',
+      width: 105,
+      render: (_, record) => record.operatedBy ?? 'system',
+    },
+    {
+      title: '操作时间',
+      dataIndex: 'operatedAt',
+      width: 150,
+      render: (_, record) => (record.operatedAt ? dayjs(record.operatedAt).format('YYYY-MM-DD HH:mm') : '-'),
     },
   ];
 
@@ -485,7 +721,7 @@ export default function InventoryPage() {
                 locale={{
                   emptyText: canQuery ? <Empty description="暂无库存记录" /> : <Empty description="SKU 加载中" />,
                 }}
-                scroll={{ x: 830 }}
+                scroll={{ x: 950 }}
               />
             </div>
 
@@ -515,6 +751,94 @@ export default function InventoryPage() {
           </SectionCard>
         </div>
       )}
+      <Drawer
+        title="库存变动流水"
+        width={1100}
+        open={transactionContext !== null}
+        onClose={() => setTransactionContext(null)}
+        destroyOnHidden
+      >
+        {transactionContext ? (
+          <div className="inventory-ledger-drawer">
+            <div className="inventory-ledger-summary">
+              <div>
+                <div className="inventory-ledger-title">
+                  {transactionContext.skuCode ?? `SKU #${transactionContext.skuId}`}
+                </div>
+                <div className="inventory-ledger-subtitle">
+                  {transactionContext.skuName ?? '-'} · {transactionContext.warehouseName ?? '全部仓库'}
+                </div>
+              </div>
+              <span className="inventory-section-badge">
+                共 {transactionsQuery.data?.total ?? 0} 条
+              </span>
+            </div>
+
+            <div className="inventory-ledger-toolbar">
+              <label className="inventory-query-field">
+                <span className="inventory-query-label">变动类型</span>
+                <Select<InventoryChangeType>
+                  allowClear
+                  placeholder="全部类型"
+                  options={inventoryChangeTypeOptions}
+                  value={transactionChangeType}
+                  onChange={(value) => {
+                    setTransactionChangeType(value);
+                    setTransactionPage(1);
+                  }}
+                  style={{ width: '100%' }}
+                />
+              </label>
+              <label className="inventory-query-field">
+                <span className="inventory-query-label">操作时间</span>
+                <DatePicker.RangePicker
+                  value={transactionDateRange}
+                  onChange={(values) => {
+                    setTransactionDateRange(values ? [values[0], values[1]] : null);
+                    setTransactionPage(1);
+                  }}
+                  style={{ width: '100%' }}
+                />
+              </label>
+              <Button
+                className="inventory-query-button"
+                onClick={() => {
+                  setTransactionChangeType(undefined);
+                  setTransactionDateRange(null);
+                  setTransactionPage(1);
+                }}
+              >
+                清除筛选
+              </Button>
+            </div>
+
+            <ProTable<InventoryTransactionRow>
+              rowKey="key"
+              columns={transactionColumns}
+              dataSource={transactionRows}
+              loading={transactionsQuery.isFetching}
+              search={false}
+              options={false}
+              pagination={{
+                current: transactionPage,
+                pageSize: transactionPageSize,
+                total: transactionsQuery.data?.total ?? 0,
+                showSizeChanger: true,
+                pageSizeOptions: [10, 20, 50],
+                showTotal: (total) => `共 ${total} 条记录`,
+                onChange: (page, pageSize) => {
+                  setTransactionPage(page);
+                  setTransactionPageSize(pageSize);
+                },
+              }}
+              locale={{
+                emptyText: <Empty description="暂无变动流水" />,
+              }}
+              scroll={{ x: 1395 }}
+            />
+          </div>
+        ) : null}
+      </Drawer>
     </div>
   );
 }

--- a/apps/web/src/pages/inventory/inventory.css
+++ b/apps/web/src/pages/inventory/inventory.css
@@ -242,6 +242,81 @@
   background: #fef2f2;
 }
 
+.inventory-delta {
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.inventory-delta.positive {
+  color: #047857;
+}
+
+.inventory-delta.negative {
+  color: #b91c1c;
+}
+
+.inventory-before-after {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: #475569;
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+}
+
+.inventory-source-text {
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.inventory-ledger-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.inventory-ledger-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #eef2f7;
+}
+
+.inventory-ledger-title {
+  color: #0f172a;
+  font-size: 16px;
+  line-height: 1.4;
+  font-weight: 800;
+}
+
+.inventory-ledger-subtitle {
+  margin-top: 2px;
+  color: #64748b;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.inventory-ledger-toolbar {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.6fr) minmax(280px, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.inventory-ledger-page-toolbar {
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) minmax(170px, 0.8fr) minmax(160px, 0.75fr) minmax(250px, 1.1fr) auto;
+  gap: 12px;
+  align-items: end;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #fff;
+}
+
 @media (max-width: 1200px) {
   .inventory-opening-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -256,6 +331,14 @@
   .inventory-query-button {
     grid-column: 1 / -1;
     width: fit-content;
+  }
+
+  .inventory-ledger-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .inventory-ledger-page-toolbar {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/apps/web/src/pages/inventory/transactions.tsx
+++ b/apps/web/src/pages/inventory/transactions.tsx
@@ -1,0 +1,395 @@
+import { useMemo, useState } from 'react';
+import { Button, DatePicker, Empty, Select, Tag } from 'antd';
+import { ProTable } from '@ant-design/pro-components';
+import type { ProColumns } from '@ant-design/pro-components';
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+import dayjs, { type Dayjs } from 'dayjs';
+import { InventoryChangeType } from '@infitek/shared';
+import {
+  getInventoryTransactions,
+  type InventoryTransactionItem,
+} from '../../api/inventory.api';
+import { getSkus, type Sku } from '../../api/skus.api';
+import { getWarehouses, type Warehouse } from '../../api/warehouses.api';
+import '../master-data/master-page.css';
+import './inventory.css';
+
+interface InventoryTransactionRow extends InventoryTransactionItem {
+  key: string;
+  id: number;
+  skuId: number;
+  warehouseId: number;
+  inventoryBatchId: number | null;
+  sourceDocumentId: number;
+  sourceDocumentItemId: number | null;
+  skuCode?: string;
+  skuName?: string | null;
+  warehouseName?: string | null;
+}
+
+const inventoryChangeTypeOptions = [
+  { label: '期初录入', value: InventoryChangeType.INITIAL },
+  { label: '采购入库', value: InventoryChangeType.PURCHASE_RECEIPT },
+  { label: '发货出库', value: InventoryChangeType.OUTBOUND },
+  { label: '锁定', value: InventoryChangeType.LOCK },
+  { label: '解锁', value: InventoryChangeType.UNLOCK },
+];
+
+const inventoryChangeTypeColor: Record<string, string> = {
+  [InventoryChangeType.INITIAL]: 'blue',
+  [InventoryChangeType.PURCHASE_RECEIPT]: 'green',
+  [InventoryChangeType.OUTBOUND]: 'red',
+  [InventoryChangeType.LOCK]: 'gold',
+  [InventoryChangeType.UNLOCK]: 'purple',
+};
+
+function toNumberId(value: number | string | null | undefined) {
+  if (value === null || value === undefined) return null;
+  const id = Number(value);
+  return Number.isFinite(id) ? id : null;
+}
+
+function changeTypeLabel(value: string) {
+  return inventoryChangeTypeOptions.find((item) => item.value === value)?.label ?? value;
+}
+
+function signedNumber(value: number) {
+  if (value > 0) return `+${value}`;
+  return String(value);
+}
+
+function sourceDocumentNode(record: InventoryTransactionRow) {
+  const text = `${record.sourceDocumentType} #${record.sourceDocumentId}`;
+  if (record.sourceDocumentType === 'shipping_demand') {
+    return <Link to={`/shipping-demands/${record.sourceDocumentId}`}>{text}</Link>;
+  }
+  return <span className="inventory-source-text">{text}</span>;
+}
+
+export default function InventoryTransactionsPage() {
+  const [selectedSkuId, setSelectedSkuId] = useState<number | undefined>();
+  const [selectedWarehouseId, setSelectedWarehouseId] = useState<number | undefined>();
+  const [selectedChangeType, setSelectedChangeType] = useState<InventoryChangeType | undefined>();
+  const [dateRange, setDateRange] = useState<[Dayjs | null, Dayjs | null] | null>(null);
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const skusQuery = useQuery({
+    queryKey: ['inventory-ledger-skus'],
+    queryFn: () => getSkus({ page: 1, pageSize: 200 }),
+  });
+  const warehousesQuery = useQuery({
+    queryKey: ['inventory-ledger-warehouses'],
+    queryFn: () => getWarehouses({ page: 1, pageSize: 200 }),
+  });
+
+  const startTime = dateRange?.[0]?.format('YYYY-MM-DD');
+  const endTime = dateRange?.[1]?.format('YYYY-MM-DD');
+  const transactionsQuery = useQuery({
+    queryKey: [
+      'inventory-transactions-page',
+      selectedSkuId,
+      selectedWarehouseId,
+      selectedChangeType,
+      startTime,
+      endTime,
+      page,
+      pageSize,
+    ],
+    queryFn: () =>
+      getInventoryTransactions({
+        skuId: selectedSkuId,
+        warehouseId: selectedWarehouseId,
+        changeType: selectedChangeType,
+        startTime,
+        endTime,
+        page,
+        pageSize,
+      }),
+  });
+
+  const skuMap = useMemo(() => {
+    const map = new Map<number, Sku>();
+    skusQuery.data?.list.forEach((sku) => {
+      const skuId = toNumberId(sku.id);
+      if (skuId !== null) map.set(skuId, sku);
+    });
+    return map;
+  }, [skusQuery.data]);
+
+  const warehouseMap = useMemo(() => {
+    const map = new Map<number, Warehouse>();
+    warehousesQuery.data?.list.forEach((warehouse) => {
+      const warehouseId = toNumberId(warehouse.id);
+      if (warehouseId !== null) map.set(warehouseId, warehouse);
+    });
+    return map;
+  }, [warehousesQuery.data]);
+
+  const skuOptions = useMemo(
+    () =>
+      (skusQuery.data?.list ?? []).flatMap((sku) => {
+        const skuId = toNumberId(sku.id);
+        if (skuId === null) return [];
+        return [{
+          label: `${sku.skuCode} ${sku.nameCn ?? sku.specification ?? ''}`,
+          value: skuId,
+        }];
+      }),
+    [skusQuery.data],
+  );
+
+  const warehouseOptions = useMemo(
+    () =>
+      (warehousesQuery.data?.list ?? []).flatMap((warehouse) => {
+        const warehouseId = toNumberId(warehouse.id);
+        if (warehouseId === null) return [];
+        return [{
+          label: warehouse.name,
+          value: warehouseId,
+        }];
+      }),
+    [warehousesQuery.data],
+  );
+
+  const rows: InventoryTransactionRow[] = useMemo(
+    () =>
+      (transactionsQuery.data?.data ?? []).map((item) => {
+        const id = toNumberId(item.id) ?? 0;
+        const skuId = toNumberId(item.skuId) ?? 0;
+        const warehouseId = toNumberId(item.warehouseId) ?? 0;
+        const inventoryBatchId = toNumberId(item.inventoryBatchId);
+        const sourceDocumentId = toNumberId(item.sourceDocumentId) ?? 0;
+        const sourceDocumentItemId = toNumberId(item.sourceDocumentItemId);
+        const sku = skuMap.get(skuId);
+        const warehouse = warehouseMap.get(warehouseId);
+        return {
+          ...item,
+          key: `${id}`,
+          id,
+          skuId,
+          warehouseId,
+          inventoryBatchId,
+          sourceDocumentId,
+          sourceDocumentItemId,
+          skuCode: sku?.skuCode,
+          skuName: sku?.nameCn ?? sku?.nameEn ?? sku?.specification,
+          warehouseName: warehouse?.name ?? `仓库 #${warehouseId}`,
+        };
+      }),
+    [transactionsQuery.data, skuMap, warehouseMap],
+  );
+
+  const resetFilters = () => {
+    setSelectedSkuId(undefined);
+    setSelectedWarehouseId(undefined);
+    setSelectedChangeType(undefined);
+    setDateRange(null);
+    setPage(1);
+  };
+
+  const columns: ProColumns<InventoryTransactionRow>[] = [
+    {
+      title: '变动类型',
+      dataIndex: 'changeType',
+      width: 105,
+      render: (_, record) => (
+        <Tag color={inventoryChangeTypeColor[record.changeType]}>
+          {changeTypeLabel(record.changeType)}
+        </Tag>
+      ),
+    },
+    {
+      title: 'SKU',
+      dataIndex: 'skuCode',
+      width: 190,
+      render: (_, record) => (
+        <div className="inventory-sku-cell">
+          <div className="inventory-sku-code">{record.skuCode ?? `SKU #${record.skuId}`}</div>
+          <div className="inventory-sku-name">{record.skuName ?? '-'}</div>
+        </div>
+      ),
+    },
+    {
+      title: '仓库',
+      dataIndex: 'warehouseName',
+      width: 140,
+    },
+    {
+      title: '数量变化',
+      dataIndex: 'quantityChange',
+      width: 100,
+      align: 'right',
+      render: (_, record) => (
+        <span className={record.quantityChange >= 0 ? 'inventory-delta positive' : 'inventory-delta negative'}>
+          {signedNumber(record.quantityChange)}
+        </span>
+      ),
+    },
+    {
+      title: '实际库存',
+      dataIndex: 'actualQuantityDelta',
+      width: 105,
+      align: 'right',
+      render: (_, record) => signedNumber(record.actualQuantityDelta),
+    },
+    {
+      title: '锁定量',
+      dataIndex: 'lockedQuantityDelta',
+      width: 95,
+      align: 'right',
+      render: (_, record) => signedNumber(record.lockedQuantityDelta),
+    },
+    {
+      title: '可用库存',
+      dataIndex: 'availableQuantityDelta',
+      width: 105,
+      align: 'right',
+      render: (_, record) => signedNumber(record.availableQuantityDelta),
+    },
+    {
+      title: '变动前/后',
+      dataIndex: 'beforeAfter',
+      width: 155,
+      render: (_, record) => (
+        <div className="inventory-before-after">
+          <span>实 {record.beforeActualQuantity} / {record.afterActualQuantity}</span>
+          <span>锁 {record.beforeLockedQuantity} / {record.afterLockedQuantity}</span>
+          <span>可 {record.beforeAvailableQuantity} / {record.afterAvailableQuantity}</span>
+        </div>
+      ),
+    },
+    {
+      title: '来源单据',
+      dataIndex: 'sourceDocumentType',
+      width: 180,
+      render: (_, record) => sourceDocumentNode(record),
+    },
+    {
+      title: '操作人',
+      dataIndex: 'operatedBy',
+      width: 105,
+      render: (_, record) => record.operatedBy ?? 'system',
+    },
+    {
+      title: '操作时间',
+      dataIndex: 'operatedAt',
+      width: 150,
+      render: (_, record) => (record.operatedAt ? dayjs(record.operatedAt).format('YYYY-MM-DD HH:mm') : '-'),
+    },
+  ];
+
+  return (
+    <div className="master-page inventory-page">
+      <div className="master-page-shell">
+        <div className="master-page-header inventory-page-header">
+          <div className="master-page-heading">
+            <div className="master-page-title">库存变动流水</div>
+            <div className="master-page-description">按 SKU、仓库、变动类型和操作时间追溯库存实际量、锁定量和可用量变化。</div>
+          </div>
+          <div className="inventory-header-summary" aria-label="库存流水筛选基础数据">
+            <div className="inventory-header-count">
+              <span>SKU</span>
+              <strong>{skuOptions.length}</strong>
+            </div>
+            <div className="inventory-header-count">
+              <span>仓库</span>
+              <strong>{warehouseOptions.length}</strong>
+            </div>
+          </div>
+        </div>
+
+        <div className="inventory-ledger-page-toolbar">
+          <label className="inventory-query-field">
+            <span className="inventory-query-label">SKU</span>
+            <Select<number>
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              placeholder="全部 SKU"
+              options={skuOptions}
+              value={selectedSkuId}
+              onChange={(value) => {
+                setSelectedSkuId(value);
+                setPage(1);
+              }}
+              style={{ width: '100%' }}
+            />
+          </label>
+          <label className="inventory-query-field">
+            <span className="inventory-query-label">仓库</span>
+            <Select<number>
+              allowClear
+              showSearch
+              optionFilterProp="label"
+              placeholder="全部仓库"
+              options={warehouseOptions}
+              value={selectedWarehouseId}
+              onChange={(value) => {
+                setSelectedWarehouseId(value);
+                setPage(1);
+              }}
+              style={{ width: '100%' }}
+            />
+          </label>
+          <label className="inventory-query-field">
+            <span className="inventory-query-label">变动类型</span>
+            <Select<InventoryChangeType>
+              allowClear
+              placeholder="全部类型"
+              options={inventoryChangeTypeOptions}
+              value={selectedChangeType}
+              onChange={(value) => {
+                setSelectedChangeType(value);
+                setPage(1);
+              }}
+              style={{ width: '100%' }}
+            />
+          </label>
+          <label className="inventory-query-field">
+            <span className="inventory-query-label">操作时间</span>
+            <DatePicker.RangePicker
+              value={dateRange}
+              onChange={(values) => {
+                setDateRange(values ? [values[0], values[1]] : null);
+                setPage(1);
+              }}
+              style={{ width: '100%' }}
+            />
+          </label>
+          <Button className="inventory-query-button" onClick={resetFilters}>
+            清除筛选
+          </Button>
+        </div>
+
+        <div className="master-table-shell">
+          <ProTable<InventoryTransactionRow>
+            rowKey="key"
+            columns={columns}
+            dataSource={rows}
+            loading={transactionsQuery.isFetching}
+            search={false}
+            options={false}
+            pagination={{
+              current: page,
+              pageSize,
+              total: transactionsQuery.data?.total ?? 0,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50],
+              showTotal: (total) => `共 ${total} 条记录`,
+              onChange: (nextPage, nextPageSize) => {
+                setPage(nextPage);
+                setPageSize(nextPageSize);
+              },
+            }}
+            locale={{
+              emptyText: <Empty description="暂无变动流水" />,
+            }}
+            scroll={{ x: 1425 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add inventory transaction query DTO/repository/service/controller API and camelCase quantityChange response mapping
- Record initial, purchase receipt, and outbound inventory transactions in QueryRunner transactions with stable sourceActionKey support
- Add inventory ledger drawer and standalone Inventory Management > Inventory Movement Ledger page
- Update Story 6.2 and sprint status to done after code review fixes

## Test plan
- pnpm --filter api exec jest modules/inventory/tests --runInBand
- pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand
- pnpm --filter api build
- pnpm --filter web build
- git diff --check

## Notes
- Full API Jest was run with `pnpm --filter api test --runInBand`; it still fails in existing unrelated contract-templates, product-categories, and skus specs. Inventory and shipping-demand targeted suites pass.
