### PR TITLE
feat(receipt-orders): implement purchase receipt confirmation

### DIFF
--- a/_bmad-output/implementation-artifacts/6-5-收货入库单创建与确认.md
+++ b/_bmad-output/implementation-artifacts/6-5-收货入库单创建与确认.md
@@ -1,0 +1,251 @@
+# Story 6.5: 收货入库单创建与确认
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a 仓管,
+I want 创建收货入库单并关联可收货的采购订单，逐行填写实际收货数量和目标仓库，确认后自动落库存批次与库存流水,
+so that 收货过程有审计记录，库存数量能够实时、准确地更新。
+
+## Acceptance Criteria
+
+1. 仓管进入 `/receipt-orders/new` 后，可通过可搜索的关联单据选择器选择采购订单；候选订单必须满足存在可收货剩余数量，且状态为 `pending_receipt` 或 `partially_received`。选中后自动预填采购订单行项信息：SKU 编码、SKU 名称、产品规格、采购数量、已收货数量、剩余可收货数量（只读），并为每行提供可编辑字段：实际收货数量（必填，正整数，且不得超过该行剩余可收货数量）、目标仓库（必填）。
+2. 表单确认入口使用 `Popconfirm` 二次确认；前端 API 必须通过 `apps/web/src/api/` 层调用，组件内不得直接 axios，请求完成后在 3 秒内返回结果或清晰错误信息。（NFR-P5）
+3. 确认收货成功后，后端在同一个 `QueryRunner` 事务内完成：创建收货入库单主表、收货入库明细、为每行调用现有 `InventoryService` 创建采购入库批次记录、更新 `inventory_summary.actual_quantity` / `available_quantity`、写入 `inventory_transactions`（`change_type = purchase_receipt`）以及操作审计日志。
+4. 收货入库明细必须至少包含：`id`、`receiptOrderId`、`purchaseOrderId`、`purchaseOrderItemId`、`shippingDemandItemId`（请购型继承，可空）、`skuId`、`warehouseId`、`receivedQuantity`、`inventoryBatchId`、`createdAt`、`updatedAt`；主表必须至少包含：`id`、`receiptCode`、`purchaseOrderId`、`status`、`remark`、`createdAt`、`updatedAt`、`createdBy`、`updatedBy`。
+5. 允许部分收货，也允许同一采购订单多次创建收货入库单；每次确认只回填本次实收数量。若某行 `0 < receivedQuantity < quantity`，采购订单状态按权威 flow 文档聚合为 `partially_received`；当所有行 `receivedQuantity >= quantity` 时聚合为 `received`。原 Epic 文本中“部分收货仍直接更新为已收货”的旧口径不作为实现依据。
+6. 采购订单的已收货数量、入库状态和详情页“收货入库单”区域必须能读取到本 Story 的结果；至少在采购订单详情页提供“创建收货入库单”入口和已创建收货单的基本链接/数量反馈，替换 Story 6.4 的占位说明。
+7. 本 Story 只实现采购入库、采购订单收货数量回填和采购订单收货状态聚合；请购型收货后的 FIFO 自动锁定、发货需求 `prepared` 推进以及销售订单状态联动，仍由 Story 6.6 负责，不在本 Story 预支。
+8. 后端测试覆盖：可收货采购订单筛选、剩余可收货数量校验、重复确认幂等、库存批次与流水写入、采购订单 `receivedQuantity`/状态聚合；前端至少通过类型检查或构建验证，并补齐 API 层类型。
+
+## Tasks / Subtasks
+
+- [x] Story 规格确认与字段清单落地（AC: 1-8）
+  - [x] 使用 `docs/系统模块对应字段清单.md#入库单-管理` 作为旧系统字段参考，`收货通知单` 仅作为历史上下游背景，不作为本次 MVP 必建模块。
+  - [x] 在 Dev Agent Record 记录本 Story 的冲突裁决：采购订单状态遵守 flow 文档；请购型自动锁定与发货需求推进保留给 Story 6.6。
+  - [x] 确认本 Story 不实现收货入库列表页/详情页完整浏览体验，如需后续扩展可在后续 Story 补齐。
+- [x] Shared 枚举、实体与迁移（AC: 3-5）
+  - [x] 如现有 shared 中缺少收货入库单状态枚举，则在 `packages/shared` 新增并导出统一枚举；不得在前后端本地重复定义。
+  - [x] 新增 `receipt-orders` 模块对应 Entity、DTO、Repository、Service、Controller、Tests 目录结构，实体继承 `BaseEntity` 并显式声明 snake_case 列名。
+  - [x] 新增 TypeORM migration 创建 `receipt_orders`、`receipt_order_items` 及必要索引/外键，保证与采购订单、采购订单明细、SKU、仓库、库存批次的关联完整。
+- [x] 后端收货确认事务（AC: 1, 3-5, 7-8）
+  - [x] 提供采购订单候选查询/预填能力，只返回存在剩余可收货数量且状态为 `pending_receipt` 或 `partially_received` 的订单。
+  - [x] 实现收货入库创建/确认接口，在事务内锁定采购订单、采购订单行、相关库存汇总与批次写入路径，校验每行实收数量不得超过剩余可收货数量。
+  - [x] 为每个收货明细调用现有 `InventoryService.increaseStock()` 或等效事务内能力，使用 `InventoryBatchSourceType.PURCHASE_RECEIPT`、稳定 `sourceActionKey` 和 `receipt_order` 来源类型写库存批次与流水。
+  - [x] 回填 `purchase_order_items.received_quantity`、采购订单 `receiptStatus` 与 `status` 聚合结果，并写入操作日志。
+  - [x] 实现幂等保护：同一收货入库单确认只能生效一次，重复提交不得重复创建批次或重复累计库存。
+- [x] 前端 API 与创建页（AC: 1-2, 6, 8）
+  - [x] 新增 `apps/web/src/api/receipt-orders.api.ts`，封装候选采购订单查询、预填读取和确认收货接口及类型。
+  - [x] 新增 `apps/web/src/pages/receipt-orders/form.tsx`，采用现有 ProForm / master-page 布局模式，完成采购订单选择、行项展示、仓库选择、备注和确认收货交互。
+  - [x] 在 `apps/web/src/App.tsx` 注册 `/receipt-orders/new` 路由，并支持从采购订单详情页携带 `purchaseOrderId` 上下文进入。
+  - [x] 更新采购订单详情页，在合法状态显示“创建收货入库单”入口，并把已有收货入库结果从占位文案改为真实反馈。
+- [x] 测试与验证（AC: 1-8）
+  - [x] 新增或更新后端单测，覆盖候选过滤、数量校验、事务幂等、库存批次/流水写入、状态聚合。
+  - [x] 运行 `pnpm --filter api exec jest modules/receipt-orders/tests --runInBand`（若目录命名不同则用实际模块路径）。
+  - [x] 运行采购订单与库存相关回归测试。
+  - [x] 运行 `pnpm --filter api build`。
+  - [x] 运行 `pnpm --filter web build`。
+  - [x] 运行 `git diff --check`。
+  - [x] 更新 Dev Agent Record、Completion Notes、File List、Change Log，并在满足全部 AC 后把 Status 改为 done。
+
+### Review Findings
+
+- [x] [Review][Patch] 收货确认未回填发货需求明细的收货缓存 [apps/api/src/modules/receipt-orders/receipt-orders.service.ts:344]
+- [x] [Review][Patch] 收货页把历史已收货数量当成本次入库数量复用 [apps/web/src/pages/receipt-orders/form.tsx:115]
+- [x] [Review][Patch] 收货确认入口缺少 Popconfirm 二次确认 [apps/web/src/pages/receipt-orders/form.tsx:636]
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守以下三份 flow 文档：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic 或旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 采购订单可收货状态以 `pending_receipt` / `partially_received` 为准，收货后聚合到 `partially_received` 或 `received`，不能回退到旧的“confirmed”口径。
+- 收货数量权威来源是 `receipt_order_items.received_quantity`；采购订单明细 `received_quantity` 是事务内回填缓存。
+- 库存写入只能通过现有 `InventoryService` 与事务行锁能力完成，不允许直接更新 `inventory_summary` / `inventory_batch` 绕过领域服务。
+- 采购入库库存流水必须带稳定 `sourceActionKey`，避免重复确认导致数量重复累加。
+- 本 Story 创建的收货单与明细必须保留 `purchaseOrderItemId`、`shippingDemandItemId`、`inventoryBatchId` 等链路，为 Story 6.6 自动锁定保留数据基础。
+
+### Conflict Resolution
+
+- `flow-state-machine.md` 与 `flow-quantity-data-lineage.md` 明确部分收货应聚合为 `partially_received`，因此覆盖 Epic 原文中“部分收货仍直接更新为已收货”的旧描述。
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-29.md` 说明请购型收货后的 FIFO 自动锁定、发货需求 `prepared` 推进仍归 Story 6.6；本 Story 只负责采购入库、数量回填和采购订单状态聚合。
+
+### Source Context
+
+- Epic 6 Story 6.5 原始目标是“关联采购订单创建收货入库单，确认后创建批次并更新库存”。[Source: `_bmad-output/planning-artifacts/epics.md#Story 6.5`]
+- 数量权威文档定义了收货入库明细的最小字段集，以及收货确认时库存、采购订单状态和幂等规则。[Source: `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md#3.4`, `#4.6`, `#5.3`]
+- Story 5.0 与 Story 6.2 已经落地库存双层结构、库存批次、库存汇总和库存流水，本 Story 必须复用同一 `InventoryModule`。[Source: `_bmad-output/planning-artifacts/epics.md#Epic 6`, `_bmad-output/implementation-artifacts/6-2-库存变动流水.md`]
+- Story 6.4 已完成采购订单详情页，并明确“收货入库将在 Story 6.5 接入”；本 Story 应补齐该入口与展示反馈。[Source: `_bmad-output/implementation-artifacts/6-4-采购订单列表与详情.md`]
+
+### Previous Story Intelligence
+
+- Story 6.3 已建立采购订单主从表、状态动作、`shippingDemandItemId` 链路和 `receivedQuantity` 字段，为本 Story 的收货回填提供了落点。
+- Story 6.4 已把采购订单状态与入库状态的前端展示口径统一到了 shared 枚举，并在详情页预留了“收货入库”区块。
+- 现有采购订单前端和后端都已经识别 `pending_receipt`、`partially_received`、`received`；本 Story 不能再引入另一套收货状态文案。
+
+### Existing Code Map
+
+- 后端采购订单模块：`apps/api/src/modules/purchase-orders/`
+  - `PurchaseOrder` / `PurchaseOrderItem` 已有 `receivedQuantity`、`receiptStatus`、`shippingDemandItemId` 等字段。
+  - `PurchaseOrdersService.confirmSupplier()` 已把供应商确认后的订单推进到 `pending_receipt`。
+- 后端库存模块：`apps/api/src/modules/inventory/`
+  - `InventoryService.increaseStock()` 已支持 `InventoryBatchSourceType.PURCHASE_RECEIPT`、批次创建、汇总重算、流水写入和幂等动作键。
+  - `inventory.service.ts` 已将 `purchase_receipt` 映射到 `receipt_order` 来源文档类型，可直接复用。
+- 前端采购订单详情页：`apps/web/src/pages/purchase-orders/detail.tsx`
+  - 目前“收货入库单”区域仍是 Story 6.5 占位说明，需要替换成真实入口/反馈。
+- 前端采购订单 API：`apps/web/src/api/purchase-orders.api.ts`
+  - 已有采购订单状态、入库状态和详情类型，可复用扩展。
+
+### Field List Reference
+
+字段参考优先使用：`docs/系统模块对应字段清单.md#入库单-管理`，并以用户 2026-04-30 确认的以下字段为准。
+
+#### 主表字段
+
+| 中文名 | 类型 | 对应的值 |
+|---|---|---|
+| 入库单号 | 系统流水号 | 自动生成，规则：`RKDH` + `yyyyMMdd` + `autoCount(4位)` |
+| 入库类型 | 下拉单选 | 枚举：采购入库 / 销售退货入库 / 销售换货入库 / 期初入库 / 供应商受赠入库 / 调拨入库 / 盘盈入库 / 其他 |
+| 入库仓库 | 下拉单选 | 仓库列表 |
+| 入库日期 | 日期 | — |
+| 入库员 | 下拉单选 | 用户列表 |
+| 发货需求 | 下拉单选 | 发货需求列表 |
+| 入库总数量 | 数字 | 精度 2 位，明细中的入库数量之和 |
+| 入库总金额 | 数字 | 精度 2 位，明细中的入库数量乘以采购单价之和 |
+| 备注 | 多行文本 | — |
+| 发货需求编号 | 文本框 | — |
+| 采购订单号 | 文本框 | 点击可以跳转到详情 |
+| 采购主体 | 下拉单选 | 公司主体列表 |
+| 库存说明 | 文本框 | — |
+
+#### 子表：入库明细
+
+| 中文名 | 类型 | 对应的值 |
+|---|---|---|
+| SKU | 下拉单选 | SKU 列表 |
+| 产品名称 | 文本框 | — |
+| 入库数量 | 数字 | 精度 0 位 |
+| 质检图片 | 附件 | — |
+| 产品分类 | 文本框 | — |
+| 采购单价 | 数字 | 精度 2 位 |
+
+实现裁剪说明：
+
+- Story AC 仍要求每行有目标仓库，因此主表“入库仓库”将作为默认仓库，同时保留行级仓库可编辑能力。
+- `发货需求`、`发货需求编号`、`采购主体` 等字段优先由关联采购订单及其来源数据自动回填；若 PO 无对应来源，则允许为空。
+- 以下旧系统字段本 Story 暂不实现：收货通知单、质检单、质检整改单号、调拨唯一值、审批状态。
+
+### Candidate Search And Display Fields
+
+本 Story 不包含正式列表页，因此“搜索字段/列表展示字段”确认不适用。
+
+### UI / UX Guidance
+
+- 创建页延续现有 `master-page` / `SectionCard` / `AnchorNav` 表单布局，不额外发明新页面骨架。
+- 采购订单选择器需要支持关键字搜索，候选项至少展示：采购订单号、供应商名称、状态、剩余可收货总量。
+- 行项表格或表单区需要清晰区分只读采购信息与本次录入字段；`实际收货数量`、`目标仓库` 为重点输入项。
+- 成功反馈优先使用 `notification.success`，文案需包含收货入库单号与关联采购订单号。
+
+### Testing Requirements
+
+- 后端单测至少覆盖：
+  - 候选采购订单只返回 `pending_receipt` / `partially_received` 且存在剩余可收货数量的订单。
+  - 单行或多行实收数量超过剩余可收货数量时报业务错误。
+  - 收货确认创建库存批次、更新汇总层、写入采购入库流水。
+  - 同一确认请求重复提交时不重复入库。
+  - 采购订单状态按行项 `receivedQuantity` 聚合为 `partially_received` / `received`。
+- 前端验证至少覆盖：
+  - `pnpm --filter web build` 通过。
+  - API 类型与页面表单数据结构一致。
+  - 从采购订单详情页进入创建收货页的路由参数可正常预填。
+- 统一验证命令：
+  - `pnpm --filter api exec jest modules/receipt-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/purchase-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`
+  - `pnpm --filter api build`
+  - `pnpm --filter web build`
+  - `git diff --check`
+
+### Implementation Boundaries
+
+- 不实现请购型收货后的 FIFO 自动锁定、发货需求 `prepared` 推进或销售订单状态联动；这是 Story 6.6。
+- 不实现收货入库列表页、详情页或复杂质检流程；本 Story 先完成创建与确认闭环。
+- 不实现超过采购剩余数量的超收逻辑；MVP 默认禁止超收。
+- 不新增绕过 shared 的本地枚举，不新增绕过 `InventoryService` 的临时库存写接口。
+- 不通过通用 PATCH 修改采购订单状态。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/ai_study/worktrees/story/6-5-receipt-create-confirmation`
+- Branch: `story/6-5-receipt-create-confirmation`
+- WORKTREE_MODE: `true`
+- 2026-04-30：创建 Story 6.5 开发上下文，已加载 Epic 5-7 三份强制 flow 文档、Story 6.3、Story 6.4、字段清单与库存/采购订单现有代码。
+- 2026-04-30：已记录关键冲突裁决：采购订单部分收货状态按 flow 文档聚合；自动锁定与发货需求推进保留给 Story 6.6。
+- 2026-04-30：用户已确认主表字段与入库明细字段，采用 `docs/系统模块对应字段清单.md#入库单-管理` 作为字段参考，Story 进入实现阶段。
+- 2026-04-30：`pnpm --filter api test -- --runInBand modules/receipt-orders/tests/receipt-orders.service.spec.ts` 通过（5 tests）。
+- 2026-04-30：`pnpm --filter api test -- --runInBand modules/purchase-orders/tests/purchase-orders.service.spec.ts modules/inventory/tests/inventory.service.spec.ts` 通过（32 tests）。
+- 2026-04-30：`pnpm --filter api build` 通过。
+- 2026-04-30：`pnpm --filter web build` 通过；仅保留 Vite chunk size warning。
+- 2026-04-30：`git diff --check` 通过。
+- 2026-04-30：code review 完成并已修复 3 条 patch finding：发货需求收货缓存回填、收货页历史数量显示、确认收货 Popconfirm。
+
+### Completion Notes List
+
+- Story file created by context engine with Epic 5-7 mandatory flow context.
+- 已新增 shared 收货入库单状态/类型枚举，并在前后端共用。
+- 已实现 `receipt-orders` 后端模块、主从表迁移、候选采购订单查询、预填接口和收货确认事务。
+- 收货确认已复用 `InventoryService.increaseStockInTransaction()` 创建采购入库批次与库存流水，并回填采购订单及发货需求明细收货缓存。
+- 已新增收货入库创建页、前端 API、采购订单详情入口和收货记录展示。
+- 所有 code review patch 已修复，无剩余未决 review finding。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/6-5-收货入库单创建与确认.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `packages/shared/src/enums/receipt-order-status.enum.ts`
+- `packages/shared/src/enums/receipt-order-type.enum.ts`
+- `packages/shared/src/index.ts`
+- `apps/api/src/__mocks__/infitek-shared.ts`
+- `apps/api/src/app.module.ts`
+- `apps/api/src/migrations/20260430000200-create-receipt-orders.ts`
+- `apps/api/src/modules/purchase-orders/entities/purchase-order.entity.ts`
+- `apps/api/src/modules/purchase-orders/purchase-orders.repository.ts`
+- `apps/api/src/modules/receipt-orders/dto/create-receipt-order.dto.ts`
+- `apps/api/src/modules/receipt-orders/dto/query-receipt-purchase-order.dto.ts`
+- `apps/api/src/modules/receipt-orders/entities/receipt-order.entity.ts`
+- `apps/api/src/modules/receipt-orders/entities/receipt-order-item.entity.ts`
+- `apps/api/src/modules/receipt-orders/receipt-orders.controller.ts`
+- `apps/api/src/modules/receipt-orders/receipt-orders.module.ts`
+- `apps/api/src/modules/receipt-orders/receipt-orders.repository.ts`
+- `apps/api/src/modules/receipt-orders/receipt-orders.service.ts`
+- `apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts`
+- `apps/web/src/App.tsx`
+- `apps/web/src/api/purchase-orders.api.ts`
+- `apps/web/src/api/receipt-orders.api.ts`
+- `apps/web/src/components/layout/AppLayout.tsx`
+- `apps/web/src/pages/purchase-orders/detail.tsx`
+- `apps/web/src/pages/receipt-orders/form.tsx`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-04-30 | 0.1 | 创建 Story 6.5 开发上下文，加入 Epic 5-7 强制 flow 约束、字段清单参考和收货状态冲突裁决 | GPT-5 Codex |
+| 2026-04-30 | 0.2 | 用户确认主表与入库明细字段，Story 状态更新为 in-progress | GPT-5 Codex |
+| 2026-04-30 | 1.0 | 完成收货入库单创建与确认实现、验证和 code review 修复，状态更新为 done | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-30 (story-6.4-done)
+# last_updated: 2026-04-30 (story-6.5-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-04-30 (story-6.4-done)
+last_updated: 2026-04-30 (story-6.5-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -123,7 +123,7 @@ development_status:
   6-2-库存变动流水: done
   6-3-采购订单创建与确认: done
   6-4-采购订单列表与详情: done
-  6-5-收货入库单创建与确认: backlog
+  6-5-收货入库单创建与确认: done
   6-6-收货后自动触发: backlog
   epic-6-retrospective: optional
 

--- a/apps/api/src/__mocks__/infitek-shared.ts
+++ b/apps/api/src/__mocks__/infitek-shared.ts
@@ -176,6 +176,25 @@ export const InventoryChangeType = {
 export type InventoryChangeType =
   (typeof InventoryChangeType)[keyof typeof InventoryChangeType];
 
+export const ReceiptOrderStatus = {
+  CONFIRMED: 'confirmed',
+} as const;
+export type ReceiptOrderStatus =
+  (typeof ReceiptOrderStatus)[keyof typeof ReceiptOrderStatus];
+
+export const ReceiptOrderType = {
+  PURCHASE_RECEIPT: 'purchase_receipt',
+  SALES_RETURN_RECEIPT: 'sales_return_receipt',
+  SALES_EXCHANGE_RECEIPT: 'sales_exchange_receipt',
+  OPENING_RECEIPT: 'opening_receipt',
+  SUPPLIER_GIFT_RECEIPT: 'supplier_gift_receipt',
+  TRANSFER_RECEIPT: 'transfer_receipt',
+  INVENTORY_GAIN_RECEIPT: 'inventory_gain_receipt',
+  OTHER: 'other',
+} as const;
+export type ReceiptOrderType =
+  (typeof ReceiptOrderType)[keyof typeof ReceiptOrderType];
+
 export const CurrencyStatus = {
   ACTIVE: 'active',
   INACTIVE: 'inactive',

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -35,6 +35,7 @@ import { SalesOrdersModule } from './modules/sales-orders/sales-orders.module';
 import { ShippingDemandsModule } from './modules/shipping-demands/shipping-demands.module';
 import { LogisticsOrdersModule } from './modules/logistics-orders/logistics-orders.module';
 import { PurchaseOrdersModule } from './modules/purchase-orders/purchase-orders.module';
+import { ReceiptOrdersModule } from './modules/receipt-orders/receipt-orders.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
 import { OperationLogsModule } from './modules/operation-logs/operation-logs.module';
 import databaseConfig from './config/database.config';
@@ -70,6 +71,7 @@ import { createLoggerConfig } from './config/logger.config';
     ShippingDemandsModule,
     LogisticsOrdersModule,
     PurchaseOrdersModule,
+    ReceiptOrdersModule,
     InventoryModule,
     ProductCategoriesModule,
     SuppliersModule,

--- a/apps/api/src/migrations/20260430000200-create-receipt-orders.ts
+++ b/apps/api/src/migrations/20260430000200-create-receipt-orders.ts
@@ -1,0 +1,313 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateReceiptOrders20260430000200
+  implements MigrationInterface
+{
+  name = 'CreateReceiptOrders20260430000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'receipt_orders',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'receipt_code', type: 'varchar', length: '40' },
+          { name: 'purchase_order_id', type: 'bigint', unsigned: true },
+          { name: 'purchase_order_code', type: 'varchar', length: '40' },
+          { name: 'receipt_type', type: 'varchar', length: '40' },
+          { name: 'status', type: 'varchar', length: '20' },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_name', type: 'varchar', length: '200' },
+          { name: 'receipt_date', type: 'date' },
+          { name: 'receiver_id', type: 'bigint', unsigned: true },
+          { name: 'receiver_name', type: 'varchar', length: '100' },
+          {
+            name: 'shipping_demand_id',
+            type: 'bigint',
+            unsigned: true,
+            isNullable: true,
+          },
+          {
+            name: 'shipping_demand_code',
+            type: 'varchar',
+            length: '40',
+            isNullable: true,
+          },
+          {
+            name: 'purchase_company_id',
+            type: 'bigint',
+            unsigned: true,
+            isNullable: true,
+          },
+          {
+            name: 'purchase_company_name',
+            type: 'varchar',
+            length: '200',
+            isNullable: true,
+          },
+          { name: 'total_quantity', type: 'int', default: 0 },
+          {
+            name: 'total_amount',
+            type: 'decimal',
+            precision: 18,
+            scale: 2,
+            default: 0,
+          },
+          { name: 'remark', type: 'text', isNullable: true },
+          {
+            name: 'inventory_note',
+            type: 'varchar',
+            length: '500',
+            isNullable: true,
+          },
+          {
+            name: 'source_action_key',
+            type: 'varchar',
+            length: '160',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'created_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'updated_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('receipt_orders', [
+      new TableIndex({
+        name: 'uq_receipt_orders_receipt_code',
+        columnNames: ['receipt_code'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'idx_receipt_orders_purchase_order_id',
+        columnNames: ['purchase_order_id'],
+      }),
+      new TableIndex({
+        name: 'idx_receipt_orders_receipt_date',
+        columnNames: ['receipt_date'],
+      }),
+      new TableIndex({
+        name: 'idx_receipt_orders_source_action_key',
+        columnNames: ['source_action_key'],
+        isUnique: true,
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('receipt_orders', [
+      new TableForeignKey({
+        columnNames: ['purchase_order_id'],
+        referencedTableName: 'purchase_orders',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['warehouse_id'],
+        referencedTableName: 'warehouses',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['receiver_id'],
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['shipping_demand_id'],
+        referencedTableName: 'shipping_demands',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+      new TableForeignKey({
+        columnNames: ['purchase_company_id'],
+        referencedTableName: 'companies',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    ]);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'receipt_order_items',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'receipt_order_id', type: 'bigint', unsigned: true },
+          { name: 'purchase_order_id', type: 'bigint', unsigned: true },
+          { name: 'purchase_order_item_id', type: 'bigint', unsigned: true },
+          {
+            name: 'shipping_demand_item_id',
+            type: 'bigint',
+            unsigned: true,
+            isNullable: true,
+          },
+          { name: 'sku_id', type: 'bigint', unsigned: true },
+          { name: 'sku_code', type: 'varchar', length: '100' },
+          {
+            name: 'product_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'product_category_name',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          { name: 'received_quantity', type: 'int', default: 0 },
+          { name: 'qc_image_keys', type: 'json', isNullable: true },
+          {
+            name: 'unit_price',
+            type: 'decimal',
+            precision: 18,
+            scale: 2,
+            default: 0,
+          },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_name', type: 'varchar', length: '200' },
+          {
+            name: 'inventory_batch_id',
+            type: 'bigint',
+            unsigned: true,
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'datetime',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'created_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'updated_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('receipt_order_items', [
+      new TableIndex({
+        name: 'idx_receipt_order_items_receipt_order_id',
+        columnNames: ['receipt_order_id'],
+      }),
+      new TableIndex({
+        name: 'idx_receipt_order_items_purchase_order_item_id',
+        columnNames: ['purchase_order_item_id'],
+      }),
+      new TableIndex({
+        name: 'idx_receipt_order_items_sku_id',
+        columnNames: ['sku_id'],
+      }),
+      new TableIndex({
+        name: 'idx_receipt_order_items_warehouse_id',
+        columnNames: ['warehouse_id'],
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('receipt_order_items', [
+      new TableForeignKey({
+        columnNames: ['receipt_order_id'],
+        referencedTableName: 'receipt_orders',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        columnNames: ['purchase_order_id'],
+        referencedTableName: 'purchase_orders',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['purchase_order_item_id'],
+        referencedTableName: 'purchase_order_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['shipping_demand_item_id'],
+        referencedTableName: 'shipping_demand_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+      new TableForeignKey({
+        columnNames: ['sku_id'],
+        referencedTableName: 'skus',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['warehouse_id'],
+        referencedTableName: 'warehouses',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        columnNames: ['inventory_batch_id'],
+        referencedTableName: 'inventory_batch',
+        referencedColumnNames: ['id'],
+        onDelete: 'SET NULL',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('receipt_order_items');
+    await queryRunner.dropTable('receipt_orders');
+  }
+}

--- a/apps/api/src/modules/purchase-orders/entities/purchase-order.entity.ts
+++ b/apps/api/src/modules/purchase-orders/entities/purchase-order.entity.ts
@@ -20,6 +20,7 @@ import {
 } from '@infitek/shared';
 import { BaseEntity } from '../../../common/entities/base.entity';
 import { ContractTemplate } from '../../master-data/contract-templates/entities/contract-template.entity';
+import { ReceiptOrder } from '../../receipt-orders/entities/receipt-order.entity';
 import { Supplier } from '../../master-data/suppliers/entities/supplier.entity';
 import { ShippingDemand } from '../../shipping-demands/entities/shipping-demand.entity';
 import { PurchaseOrderItem } from './purchase-order-item.entity';
@@ -480,4 +481,10 @@ export class PurchaseOrder extends BaseEntity {
   })
   @Expose()
   items?: PurchaseOrderItem[];
+
+  @OneToMany(() => ReceiptOrder, (receiptOrder) => receiptOrder.purchaseOrder, {
+    cascade: false,
+  })
+  @Expose()
+  receiptOrders?: ReceiptOrder[];
 }

--- a/apps/api/src/modules/purchase-orders/purchase-orders.repository.ts
+++ b/apps/api/src/modules/purchase-orders/purchase-orders.repository.ts
@@ -27,8 +27,11 @@ export class PurchaseOrdersRepository {
   findById(id: number): Promise<PurchaseOrder | null> {
     return this.purchaseOrderRepo.findOne({
       where: { id },
-      relations: { items: true },
-      order: { items: { id: 'ASC' } },
+      relations: { items: true, receiptOrders: true },
+      order: {
+        items: { id: 'ASC' },
+        receiptOrders: { createdAt: 'DESC', id: 'DESC' },
+      },
     });
   }
 

--- a/apps/api/src/modules/receipt-orders/dto/create-receipt-order.dto.ts
+++ b/apps/api/src/modules/receipt-orders/dto/create-receipt-order.dto.ts
@@ -1,0 +1,87 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { ReceiptOrderType } from '@infitek/shared';
+
+export class CreateReceiptOrderItemDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  purchaseOrderItemId: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  receivedQuantity: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  warehouseId?: number;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  qcImageKeys?: string[];
+}
+
+export class CreateReceiptOrderDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  purchaseOrderId: number;
+
+  @IsString()
+  @MaxLength(160)
+  requestKey: string;
+
+  @IsIn(Object.values(ReceiptOrderType))
+  @IsOptional()
+  receiptType?: ReceiptOrderType;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  warehouseId: number;
+
+  @IsDateString()
+  receiptDate: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  receiverId: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  purchaseCompanyId?: number;
+
+  @IsString()
+  @MaxLength(1000)
+  @IsOptional()
+  remark?: string;
+
+  @IsString()
+  @MaxLength(500)
+  @IsOptional()
+  inventoryNote?: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateReceiptOrderItemDto)
+  items: CreateReceiptOrderItemDto[];
+}

--- a/apps/api/src/modules/receipt-orders/dto/query-receipt-purchase-order.dto.ts
+++ b/apps/api/src/modules/receipt-orders/dto/query-receipt-purchase-order.dto.ts
@@ -1,0 +1,3 @@
+import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+
+export class QueryReceiptPurchaseOrderDto extends BaseQueryDto {}

--- a/apps/api/src/modules/receipt-orders/entities/receipt-order-item.entity.ts
+++ b/apps/api/src/modules/receipt-orders/entities/receipt-order-item.entity.ts
@@ -1,0 +1,114 @@
+import { Expose } from 'class-transformer';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { PurchaseOrder } from '../../purchase-orders/entities/purchase-order.entity';
+import { PurchaseOrderItem } from '../../purchase-orders/entities/purchase-order-item.entity';
+import { ShippingDemandItem } from '../../shipping-demands/entities/shipping-demand-item.entity';
+import { ReceiptOrder } from './receipt-order.entity';
+
+@Entity('receipt_order_items')
+@Index('idx_receipt_order_items_receipt_order_id', ['receiptOrderId'])
+@Index('idx_receipt_order_items_purchase_order_item_id', ['purchaseOrderItemId'])
+@Index('idx_receipt_order_items_sku_id', ['skuId'])
+@Index('idx_receipt_order_items_warehouse_id', ['warehouseId'])
+export class ReceiptOrderItem extends BaseEntity {
+  @Column({ name: 'receipt_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  receiptOrderId: number;
+
+  @ManyToOne(() => ReceiptOrder, (receiptOrder) => receiptOrder.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'receipt_order_id' })
+  receiptOrder?: ReceiptOrder;
+
+  @Column({ name: 'purchase_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  purchaseOrderId: number;
+
+  @ManyToOne(() => PurchaseOrder, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'purchase_order_id' })
+  purchaseOrder?: PurchaseOrder;
+
+  @Column({ name: 'purchase_order_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  purchaseOrderItemId: number;
+
+  @ManyToOne(() => PurchaseOrderItem, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'purchase_order_item_id' })
+  purchaseOrderItem?: PurchaseOrderItem;
+
+  @Column({
+    name: 'shipping_demand_item_id',
+    type: 'bigint',
+    unsigned: true,
+    nullable: true,
+  })
+  @Expose()
+  shippingDemandItemId: number | null;
+
+  @ManyToOne(() => ShippingDemandItem, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'shipping_demand_item_id' })
+  shippingDemandItem?: ShippingDemandItem;
+
+  @Column({ name: 'sku_id', type: 'bigint', unsigned: true })
+  @Expose()
+  skuId: number;
+
+  @Column({ name: 'sku_code', type: 'varchar', length: 100 })
+  @Expose()
+  skuCode: string;
+
+  @Column({
+    name: 'product_name',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  @Expose()
+  productName: string | null;
+
+  @Column({
+    name: 'product_category_name',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  @Expose()
+  productCategoryName: string | null;
+
+  @Column({ name: 'received_quantity', type: 'int', default: 0 })
+  @Expose()
+  receivedQuantity: number;
+
+  @Column({ name: 'qc_image_keys', type: 'json', nullable: true })
+  @Expose()
+  qcImageKeys: string[] | null;
+
+  @Column({
+    name: 'unit_price',
+    type: 'decimal',
+    precision: 18,
+    scale: 2,
+    default: 0,
+  })
+  @Expose()
+  unitPrice: string;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'warehouse_name', type: 'varchar', length: 200 })
+  @Expose()
+  warehouseName: string;
+
+  @Column({
+    name: 'inventory_batch_id',
+    type: 'bigint',
+    unsigned: true,
+    nullable: true,
+  })
+  @Expose()
+  inventoryBatchId: number | null;
+}

--- a/apps/api/src/modules/receipt-orders/entities/receipt-order.entity.ts
+++ b/apps/api/src/modules/receipt-orders/entities/receipt-order.entity.ts
@@ -1,0 +1,147 @@
+import { Expose } from 'class-transformer';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
+import { ReceiptOrderStatus, ReceiptOrderType } from '@infitek/shared';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { PurchaseOrder } from '../../purchase-orders/entities/purchase-order.entity';
+import { ReceiptOrderItem } from './receipt-order-item.entity';
+
+@Entity('receipt_orders')
+@Unique('uq_receipt_orders_receipt_code', ['receiptCode'])
+@Index('idx_receipt_orders_purchase_order_id', ['purchaseOrderId'])
+@Index('idx_receipt_orders_receipt_date', ['receiptDate'])
+@Index('idx_receipt_orders_source_action_key', ['sourceActionKey'], {
+  unique: true,
+})
+export class ReceiptOrder extends BaseEntity {
+  @Column({ name: 'receipt_code', type: 'varchar', length: 40 })
+  @Expose()
+  receiptCode: string;
+
+  @Column({ name: 'purchase_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  purchaseOrderId: number;
+
+  @ManyToOne(() => PurchaseOrder, (purchaseOrder) => purchaseOrder.receiptOrders, {
+    onDelete: 'RESTRICT',
+  })
+  @JoinColumn({ name: 'purchase_order_id' })
+  purchaseOrder?: PurchaseOrder;
+
+  @Column({ name: 'purchase_order_code', type: 'varchar', length: 40 })
+  @Expose()
+  purchaseOrderCode: string;
+
+  @Column({ name: 'receipt_type', type: 'varchar', length: 40 })
+  @Expose()
+  receiptType: ReceiptOrderType;
+
+  @Column({ name: 'status', type: 'varchar', length: 20 })
+  @Expose()
+  status: ReceiptOrderStatus;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'warehouse_name', type: 'varchar', length: 200 })
+  @Expose()
+  warehouseName: string;
+
+  @Column({ name: 'receipt_date', type: 'date' })
+  @Expose()
+  receiptDate: string;
+
+  @Column({ name: 'receiver_id', type: 'bigint', unsigned: true })
+  @Expose()
+  receiverId: number;
+
+  @Column({ name: 'receiver_name', type: 'varchar', length: 100 })
+  @Expose()
+  receiverName: string;
+
+  @Column({
+    name: 'shipping_demand_id',
+    type: 'bigint',
+    unsigned: true,
+    nullable: true,
+  })
+  @Expose()
+  shippingDemandId: number | null;
+
+  @Column({
+    name: 'shipping_demand_code',
+    type: 'varchar',
+    length: 40,
+    nullable: true,
+  })
+  @Expose()
+  shippingDemandCode: string | null;
+
+  @Column({
+    name: 'purchase_company_id',
+    type: 'bigint',
+    unsigned: true,
+    nullable: true,
+  })
+  @Expose()
+  purchaseCompanyId: number | null;
+
+  @Column({
+    name: 'purchase_company_name',
+    type: 'varchar',
+    length: 200,
+    nullable: true,
+  })
+  @Expose()
+  purchaseCompanyName: string | null;
+
+  @Column({ name: 'total_quantity', type: 'int', default: 0 })
+  @Expose()
+  totalQuantity: number;
+
+  @Column({
+    name: 'total_amount',
+    type: 'decimal',
+    precision: 18,
+    scale: 2,
+    default: 0,
+  })
+  @Expose()
+  totalAmount: string;
+
+  @Column({ name: 'remark', type: 'text', nullable: true })
+  @Expose()
+  remark: string | null;
+
+  @Column({
+    name: 'inventory_note',
+    type: 'varchar',
+    length: 500,
+    nullable: true,
+  })
+  @Expose()
+  inventoryNote: string | null;
+
+  @Column({
+    name: 'source_action_key',
+    type: 'varchar',
+    length: 160,
+    nullable: true,
+  })
+  @Expose()
+  sourceActionKey: string | null;
+
+  @OneToMany(() => ReceiptOrderItem, (item) => item.receiptOrder, {
+    cascade: false,
+  })
+  @Expose()
+  items?: ReceiptOrderItem[];
+}

--- a/apps/api/src/modules/receipt-orders/receipt-orders.controller.ts
+++ b/apps/api/src/modules/receipt-orders/receipt-orders.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { CreateReceiptOrderDto } from './dto/create-receipt-order.dto';
+import { QueryReceiptPurchaseOrderDto } from './dto/query-receipt-purchase-order.dto';
+import { ReceiptOrdersService } from './receipt-orders.service';
+
+@Controller('receipt-orders')
+export class ReceiptOrdersController {
+  constructor(private readonly receiptOrdersService: ReceiptOrdersService) {}
+
+  @Get('purchase-order-options')
+  getPurchaseOrderOptions(@Query() query: QueryReceiptPurchaseOrderDto) {
+    return this.receiptOrdersService.getPurchaseOrderOptions(query);
+  }
+
+  @Get('create-prefill')
+  getCreatePrefill(
+    @Query('purchaseOrderId', ParseIntPipe) purchaseOrderId: number,
+  ) {
+    return this.receiptOrdersService.getCreatePrefill(purchaseOrderId);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.receiptOrdersService.findById(id);
+  }
+
+  @Post()
+  create(
+    @Body() dto: CreateReceiptOrderDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.receiptOrdersService.create(dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/receipt-orders/receipt-orders.module.ts
+++ b/apps/api/src/modules/receipt-orders/receipt-orders.module.ts
@@ -1,0 +1,34 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InventoryModule } from '../inventory/inventory.module';
+import { Company } from '../master-data/companies/entities/company.entity';
+import { Warehouse } from '../master-data/warehouses/entities/warehouse.entity';
+import { PurchaseOrderItem } from '../purchase-orders/entities/purchase-order-item.entity';
+import { PurchaseOrder } from '../purchase-orders/entities/purchase-order.entity';
+import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
+import { User } from '../users/entities/user.entity';
+import { ReceiptOrderItem } from './entities/receipt-order-item.entity';
+import { ReceiptOrder } from './entities/receipt-order.entity';
+import { ReceiptOrdersController } from './receipt-orders.controller';
+import { ReceiptOrdersRepository } from './receipt-orders.repository';
+import { ReceiptOrdersService } from './receipt-orders.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      ReceiptOrder,
+      ReceiptOrderItem,
+      PurchaseOrder,
+      PurchaseOrderItem,
+      ShippingDemandItem,
+      Warehouse,
+      User,
+      Company,
+    ]),
+    InventoryModule,
+  ],
+  controllers: [ReceiptOrdersController],
+  providers: [ReceiptOrdersRepository, ReceiptOrdersService],
+  exports: [ReceiptOrdersService],
+})
+export class ReceiptOrdersModule {}

--- a/apps/api/src/modules/receipt-orders/receipt-orders.repository.ts
+++ b/apps/api/src/modules/receipt-orders/receipt-orders.repository.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { PurchaseOrderStatus } from '@infitek/shared';
+import { PurchaseOrder } from '../purchase-orders/entities/purchase-order.entity';
+import { QueryReceiptPurchaseOrderDto } from './dto/query-receipt-purchase-order.dto';
+import { ReceiptOrder } from './entities/receipt-order.entity';
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+@Injectable()
+export class ReceiptOrdersRepository {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    @InjectRepository(ReceiptOrder)
+    private readonly receiptOrderRepo: Repository<ReceiptOrder>,
+  ) {}
+
+  createQueryRunner() {
+    return this.dataSource.createQueryRunner();
+  }
+
+  findById(id: number): Promise<ReceiptOrder | null> {
+    return this.receiptOrderRepo.findOne({
+      where: { id },
+      relations: { items: true },
+      order: { items: { id: 'ASC' } },
+    });
+  }
+
+  findBySourceActionKey(sourceActionKey: string): Promise<ReceiptOrder | null> {
+    return this.receiptOrderRepo.findOne({
+      where: { sourceActionKey },
+      relations: { items: true },
+      order: { items: { id: 'ASC' } },
+    });
+  }
+
+  findByPurchaseOrderId(purchaseOrderId: number): Promise<ReceiptOrder[]> {
+    return this.receiptOrderRepo.find({
+      where: { purchaseOrderId },
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+  }
+
+  async findPurchaseOrderOptions(query: QueryReceiptPurchaseOrderDto) {
+    const qb = this.dataSource
+      .getRepository(PurchaseOrder)
+      .createQueryBuilder('purchaseOrder')
+      .innerJoin('purchase_order_items', 'item', 'item.purchase_order_id = purchaseOrder.id')
+      .select('purchaseOrder.id', 'id')
+      .addSelect('purchaseOrder.po_code', 'poCode')
+      .addSelect('purchaseOrder.supplier_name', 'supplierName')
+      .addSelect('purchaseOrder.status', 'status')
+      .addSelect('purchaseOrder.receipt_status', 'receiptStatus')
+      .addSelect('purchaseOrder.shipping_demand_id', 'shippingDemandId')
+      .addSelect('purchaseOrder.shipping_demand_code', 'shippingDemandCode')
+      .addSelect(
+        'SUM(GREATEST(item.quantity - item.received_quantity, 0))',
+        'remainingTotalQuantity',
+      )
+      .where('purchaseOrder.status IN (:...statuses)', {
+        statuses: [
+          PurchaseOrderStatus.PENDING_RECEIPT,
+          PurchaseOrderStatus.PARTIALLY_RECEIVED,
+        ],
+      })
+      .groupBy('purchaseOrder.id')
+      .having('SUM(GREATEST(item.quantity - item.received_quantity, 0)) > 0')
+      .orderBy('purchaseOrder.updated_at', 'DESC')
+      .addOrderBy('purchaseOrder.id', 'DESC')
+      .take(query.pageSize ?? 20);
+
+    const normalizedKeyword = query.keyword?.trim();
+    if (normalizedKeyword) {
+      qb.andWhere(
+        '(purchaseOrder.po_code LIKE :kw OR purchaseOrder.supplier_name LIKE :kw OR purchaseOrder.shipping_demand_code LIKE :kw OR purchaseOrder.sales_order_code LIKE :kw)',
+        { kw: `%${escapeLike(normalizedKeyword)}%` },
+      );
+    }
+
+    return qb.getRawMany<{
+      id: string;
+      poCode: string;
+      supplierName: string;
+      status: string;
+      receiptStatus: string;
+      shippingDemandId: string | null;
+      shippingDemandCode: string | null;
+      remainingTotalQuantity: string;
+    }>();
+  }
+}

--- a/apps/api/src/modules/receipt-orders/receipt-orders.service.ts
+++ b/apps/api/src/modules/receipt-orders/receipt-orders.service.ts
@@ -1,0 +1,785 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  InventoryBatchSourceType,
+  PurchaseOrderReceiptStatus,
+  PurchaseOrderStatus,
+  PurchaseOrderType,
+  ReceiptOrderStatus,
+  ReceiptOrderType,
+  YesNo,
+} from '@infitek/shared';
+import { In, QueryRunner } from 'typeorm';
+import { InventoryService } from '../inventory/inventory.service';
+import {
+  OperationLog,
+  OperationLogAction,
+} from '../operation-logs/entities/operation-log.entity';
+import { Company } from '../master-data/companies/entities/company.entity';
+import { Warehouse } from '../master-data/warehouses/entities/warehouse.entity';
+import { PurchaseOrderItem } from '../purchase-orders/entities/purchase-order-item.entity';
+import { PurchaseOrder } from '../purchase-orders/entities/purchase-order.entity';
+import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
+import { User } from '../users/entities/user.entity';
+import { CreateReceiptOrderDto } from './dto/create-receipt-order.dto';
+import { QueryReceiptPurchaseOrderDto } from './dto/query-receipt-purchase-order.dto';
+import { ReceiptOrderItem } from './entities/receipt-order-item.entity';
+import { ReceiptOrder } from './entities/receipt-order.entity';
+import { ReceiptOrdersRepository } from './receipt-orders.repository';
+
+const MAX_RECEIPT_ORDER_CODE_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 25;
+
+interface ReceiptWarehouseSnapshot {
+  id: number;
+  name: string;
+}
+
+@Injectable()
+export class ReceiptOrdersService {
+  constructor(
+    private readonly receiptOrdersRepository: ReceiptOrdersRepository,
+    private readonly inventoryService: InventoryService,
+  ) {}
+
+  async findById(id: number): Promise<ReceiptOrder> {
+    const receiptOrder = await this.receiptOrdersRepository.findById(id);
+    if (!receiptOrder) {
+      throw new NotFoundException('收货入库单不存在');
+    }
+    return receiptOrder;
+  }
+
+  async getPurchaseOrderOptions(query: QueryReceiptPurchaseOrderDto) {
+    const rows =
+      await this.receiptOrdersRepository.findPurchaseOrderOptions(query);
+    return rows.map((row) => ({
+      id: Number(row.id),
+      poCode: row.poCode,
+      supplierName: row.supplierName,
+      status: row.status as PurchaseOrderStatus,
+      receiptStatus: row.receiptStatus as PurchaseOrderReceiptStatus,
+      shippingDemandId:
+        row.shippingDemandId == null ? null : Number(row.shippingDemandId),
+      shippingDemandCode: row.shippingDemandCode,
+      remainingTotalQuantity: Number(row.remainingTotalQuantity ?? 0),
+    }));
+  }
+
+  async getCreatePrefill(purchaseOrderId: number) {
+    const queryRunner = this.receiptOrdersRepository.createQueryRunner();
+    try {
+      await queryRunner.connect();
+      const purchaseOrder = await this.findPurchaseOrderForReceipt(
+        queryRunner,
+        purchaseOrderId,
+      );
+      return {
+        purchaseOrder: {
+          id: Number(purchaseOrder.id),
+          poCode: purchaseOrder.poCode,
+          status: purchaseOrder.status,
+          receiptStatus: purchaseOrder.receiptStatus,
+          supplierId: Number(purchaseOrder.supplierId),
+          supplierName: purchaseOrder.supplierName,
+          shippingDemandId:
+            purchaseOrder.shippingDemandId == null
+              ? null
+              : Number(purchaseOrder.shippingDemandId),
+          shippingDemandCode: purchaseOrder.shippingDemandCode,
+          purchaseCompanyId:
+            purchaseOrder.purchaseCompanyId == null
+              ? null
+              : Number(purchaseOrder.purchaseCompanyId),
+          purchaseCompanyName: purchaseOrder.purchaseCompanyName,
+          totalQuantity: Number(purchaseOrder.totalQuantity ?? 0),
+          receivedTotalQuantity: Number(
+            purchaseOrder.receivedTotalQuantity ?? 0,
+          ),
+          remainingTotalQuantity: this.sumRemainingQuantity(purchaseOrder.items ?? []),
+        },
+        items: this.buildPrefillItems(purchaseOrder.items ?? []),
+      };
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async create(dto: CreateReceiptOrderDto, operator?: string) {
+    const existing = await this.receiptOrdersRepository.findBySourceActionKey(
+      dto.requestKey,
+    );
+    if (existing) {
+      return this.findById(Number(existing.id));
+    }
+
+    const receiptOrderId = await this.executeWithReceiptOrderCodeRetry(
+      async (queryRunner) => {
+        const existingInTx =
+          await queryRunner.manager.getRepository(ReceiptOrder).findOne({
+            where: { sourceActionKey: dto.requestKey },
+          });
+        if (existingInTx) {
+          return Number(existingInTx.id);
+        }
+
+        const receiptOrder = await this.createInTransaction(
+          queryRunner,
+          dto,
+          operator,
+        );
+        return Number(receiptOrder.id);
+      },
+    );
+
+    return this.findById(receiptOrderId);
+  }
+
+  private async createInTransaction(
+    queryRunner: QueryRunner,
+    dto: CreateReceiptOrderDto,
+    operator?: string,
+  ): Promise<ReceiptOrder> {
+    const purchaseOrder = await this.findPurchaseOrderForReceipt(
+      queryRunner,
+      dto.purchaseOrderId,
+      true,
+    );
+    const receiptOrderRepo = queryRunner.manager.getRepository(ReceiptOrder);
+    const receiptOrderItemRepo = queryRunner.manager.getRepository(ReceiptOrderItem);
+
+    const oldStatus = purchaseOrder.status;
+    const oldReceiptStatus = purchaseOrder.receiptStatus;
+    const oldReceivedTotalQuantity = Number(
+      purchaseOrder.receivedTotalQuantity ?? 0,
+    );
+
+    const receiptLines = dto.items.filter(
+      (item) => Number(item.receivedQuantity ?? 0) > 0,
+    );
+    if (!receiptLines.length) {
+      throw new BadRequestException({
+        code: 'RECEIPT_ORDER_ITEMS_EMPTY',
+        message: '至少需要录入一条入库数量大于 0 的明细',
+      });
+    }
+
+    const purchaseOrderItemById = new Map(
+      (purchaseOrder.items ?? []).map((item) => [Number(item.id), item]),
+    );
+    const warehouseIds = [
+      ...new Set(
+        receiptLines.map((item) =>
+          Number(item.warehouseId ?? dto.warehouseId),
+        ),
+      ),
+    ];
+    const warehouseSnapshots = await this.resolveWarehouses(
+      queryRunner,
+      warehouseIds,
+    );
+    const receiver = await this.resolveReceiver(queryRunner, dto.receiverId);
+    const purchaseCompany = await this.resolvePurchaseCompany(
+      queryRunner,
+      dto.purchaseCompanyId ?? purchaseOrder.purchaseCompanyId ?? undefined,
+    );
+    const defaultWarehouse = warehouseSnapshots.get(Number(dto.warehouseId));
+
+    if (!defaultWarehouse) {
+      throw new BadRequestException({
+        code: 'RECEIPT_ORDER_WAREHOUSE_NOT_FOUND',
+        message: '默认入库仓库不存在',
+      });
+    }
+
+    const preparedItems = receiptLines.map((item) => {
+      const purchaseOrderItem = purchaseOrderItemById.get(
+        Number(item.purchaseOrderItemId),
+      );
+      if (!purchaseOrderItem) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_ITEM_NOT_IN_PURCHASE_ORDER',
+          message: '收货明细必须来自当前采购订单',
+        });
+      }
+
+      const remainingQuantity =
+        Number(purchaseOrderItem.quantity ?? 0) -
+        Number(purchaseOrderItem.receivedQuantity ?? 0);
+      if (remainingQuantity <= 0) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_ITEM_FULLY_RECEIVED',
+          message: `${purchaseOrderItem.skuCode} 已经全部收货`,
+        });
+      }
+
+      if (!Number.isInteger(item.receivedQuantity) || item.receivedQuantity < 0) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_QUANTITY_INVALID',
+          message: `${purchaseOrderItem.skuCode} 的入库数量必须为 0 或正整数`,
+        });
+      }
+      if (item.receivedQuantity > remainingQuantity) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_QUANTITY_EXCEEDS_REMAINING',
+          message: `${purchaseOrderItem.skuCode} 本次入库数量不能超过剩余可收货数量 ${remainingQuantity}`,
+        });
+      }
+
+      const warehouseId = Number(item.warehouseId ?? dto.warehouseId);
+      const warehouse = warehouseSnapshots.get(warehouseId);
+      if (!warehouse) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_WAREHOUSE_NOT_FOUND',
+          message: `${purchaseOrderItem.skuCode} 的目标仓库不存在`,
+        });
+      }
+
+      return {
+        purchaseOrderItem,
+        warehouse,
+        receivedQuantity: item.receivedQuantity,
+        qcImageKeys: item.qcImageKeys ?? [],
+      };
+    });
+
+    const receiptCode = await this.generateReceiptCode(queryRunner);
+    const totalQuantity = preparedItems.reduce(
+      (sum, item) => sum + item.receivedQuantity,
+      0,
+    );
+    const totalAmount = preparedItems.reduce(
+      (sum, item) =>
+        sum +
+        item.receivedQuantity * Number(item.purchaseOrderItem.unitPrice ?? 0),
+      0,
+    );
+
+    const receiptOrder = await receiptOrderRepo.save(
+      receiptOrderRepo.create({
+        receiptCode,
+        purchaseOrderId: Number(purchaseOrder.id),
+        purchaseOrderCode: purchaseOrder.poCode,
+        receiptType: dto.receiptType ?? ReceiptOrderType.PURCHASE_RECEIPT,
+        status: ReceiptOrderStatus.CONFIRMED,
+        warehouseId: Number(defaultWarehouse.id),
+        warehouseName: defaultWarehouse.name,
+        receiptDate: dto.receiptDate,
+        receiverId: Number(receiver.id),
+        receiverName: receiver.name,
+        shippingDemandId:
+          purchaseOrder.shippingDemandId == null
+            ? null
+            : Number(purchaseOrder.shippingDemandId),
+        shippingDemandCode: purchaseOrder.shippingDemandCode,
+        purchaseCompanyId:
+          purchaseCompany == null ? null : Number(purchaseCompany.id),
+        purchaseCompanyName: purchaseCompany?.nameCn ?? null,
+        totalQuantity,
+        totalAmount: this.decimal(totalAmount),
+        remark: dto.remark?.trim() || null,
+        inventoryNote: dto.inventoryNote?.trim() || null,
+        sourceActionKey: dto.requestKey,
+        createdBy: operator,
+        updatedBy: operator,
+      }),
+    );
+
+    const savedReceiptItems: ReceiptOrderItem[] = [];
+    for (const preparedItem of preparedItems) {
+      const savedReceiptItem = await receiptOrderItemRepo.save(
+        receiptOrderItemRepo.create({
+          receiptOrderId: Number(receiptOrder.id),
+          purchaseOrderId: Number(purchaseOrder.id),
+          purchaseOrderItemId: Number(preparedItem.purchaseOrderItem.id),
+          shippingDemandItemId:
+            preparedItem.purchaseOrderItem.shippingDemandItemId == null
+              ? null
+              : Number(preparedItem.purchaseOrderItem.shippingDemandItemId),
+          skuId: Number(preparedItem.purchaseOrderItem.skuId),
+          skuCode: preparedItem.purchaseOrderItem.skuCode,
+          productName:
+            preparedItem.purchaseOrderItem.productNameCn ??
+            preparedItem.purchaseOrderItem.productNameEn,
+          productCategoryName:
+            preparedItem.purchaseOrderItem.productType ??
+            preparedItem.purchaseOrderItem.spuName,
+          receivedQuantity: preparedItem.receivedQuantity,
+          qcImageKeys:
+            preparedItem.qcImageKeys.length > 0 ? preparedItem.qcImageKeys : null,
+          unitPrice: preparedItem.purchaseOrderItem.unitPrice,
+          warehouseId: Number(preparedItem.warehouse.id),
+          warehouseName: preparedItem.warehouse.name,
+          inventoryBatchId: null,
+          createdBy: operator,
+          updatedBy: operator,
+        }),
+      );
+
+      const inventoryResult = await this.inventoryService.increaseStockInTransaction(
+        queryRunner,
+        {
+          skuId: Number(preparedItem.purchaseOrderItem.skuId),
+          warehouseId: Number(preparedItem.warehouse.id),
+          quantity: preparedItem.receivedQuantity,
+          sourceType: InventoryBatchSourceType.PURCHASE_RECEIPT,
+          sourceDocumentId: Number(receiptOrder.id),
+          sourceDocumentItemId: Number(savedReceiptItem.id),
+          sourceActionKey: `receipt:${dto.requestKey}:item:${savedReceiptItem.id}`,
+          receiptDate: dto.receiptDate,
+          operator,
+        },
+      );
+
+      savedReceiptItem.inventoryBatchId = Number(
+        inventoryResult.batches[0]?.id ?? 0,
+      );
+      if (operator !== undefined) {
+        savedReceiptItem.updatedBy = operator;
+      }
+      savedReceiptItems.push(await receiptOrderItemRepo.save(savedReceiptItem));
+
+      preparedItem.purchaseOrderItem.receivedQuantity =
+        Number(preparedItem.purchaseOrderItem.receivedQuantity ?? 0) +
+        preparedItem.receivedQuantity;
+      preparedItem.purchaseOrderItem.isFullyReceived =
+        preparedItem.purchaseOrderItem.receivedQuantity >=
+        Number(preparedItem.purchaseOrderItem.quantity ?? 0)
+          ? YesNo.YES
+          : YesNo.NO;
+      if (operator !== undefined) {
+        preparedItem.purchaseOrderItem.updatedBy = operator;
+      }
+    }
+
+    const purchaseOrderItemRepo =
+      queryRunner.manager.getRepository(PurchaseOrderItem);
+    purchaseOrder.items = await purchaseOrderItemRepo.save(purchaseOrder.items ?? []);
+    await this.refreshShippingDemandReceivedQuantity(
+      queryRunner,
+      (purchaseOrder.items ?? [])
+        .map((item) =>
+          item.shippingDemandItemId == null
+            ? null
+            : Number(item.shippingDemandItemId),
+        )
+        .filter((itemId): itemId is number => itemId != null),
+      operator,
+    );
+
+    const aggregated = this.aggregatePurchaseOrderReceipt(
+      purchaseOrder.items ?? [],
+    );
+    purchaseOrder.receivedTotalQuantity = aggregated.receivedTotalQuantity;
+    purchaseOrder.receiptStatus = aggregated.receiptStatus;
+    purchaseOrder.status = aggregated.status;
+    if (operator !== undefined) {
+      purchaseOrder.updatedBy = operator;
+    }
+    await queryRunner.manager.getRepository(PurchaseOrder).save(purchaseOrder);
+
+    await this.writeOperationLogs(
+      queryRunner,
+      receiptOrder,
+      purchaseOrder,
+      savedReceiptItems,
+      {
+        oldStatus,
+        oldReceiptStatus,
+        oldReceivedTotalQuantity,
+      },
+      operator,
+    );
+
+    receiptOrder.items = savedReceiptItems;
+    return receiptOrder;
+  }
+
+  private async findPurchaseOrderForReceipt(
+    queryRunner: QueryRunner,
+    purchaseOrderId: number,
+    lock = false,
+  ): Promise<PurchaseOrder> {
+    const qb = queryRunner.manager
+      .getRepository(PurchaseOrder)
+      .createQueryBuilder('purchaseOrder')
+      .leftJoinAndSelect('purchaseOrder.items', 'items')
+      .leftJoinAndSelect('purchaseOrder.receiptOrders', 'receiptOrders')
+      .where('purchaseOrder.id = :purchaseOrderId', { purchaseOrderId })
+      .orderBy('items.id', 'ASC')
+      .addOrderBy('receiptOrders.created_at', 'DESC')
+      .addOrderBy('receiptOrders.id', 'DESC');
+
+    if (lock) {
+      qb.setLock('pessimistic_write');
+    }
+
+    const purchaseOrder = await qb.getOne();
+    if (!purchaseOrder) {
+      throw new NotFoundException('采购订单不存在');
+    }
+    if (
+      purchaseOrder.status !== PurchaseOrderStatus.PENDING_RECEIPT &&
+      purchaseOrder.status !== PurchaseOrderStatus.PARTIALLY_RECEIVED
+    ) {
+      throw new BadRequestException({
+        code: 'PURCHASE_ORDER_RECEIPT_STATUS_INVALID',
+        message: '只有待收货或部分收货的采购订单可以创建收货入库单',
+      });
+    }
+    if (!this.buildPrefillItems(purchaseOrder.items ?? []).length) {
+      throw new BadRequestException({
+        code: 'PURCHASE_ORDER_NO_REMAINING_RECEIPT_QUANTITY',
+        message: '当前采购订单没有可收货的剩余数量',
+      });
+    }
+    return purchaseOrder;
+  }
+
+  private buildPrefillItems(items: PurchaseOrderItem[]) {
+    return items
+      .map((item) => {
+        const quantity = Number(item.quantity ?? 0);
+        const receivedQuantity = Number(item.receivedQuantity ?? 0);
+        const remainingQuantity = Math.max(0, quantity - receivedQuantity);
+        return {
+          purchaseOrderItemId: Number(item.id),
+          shippingDemandItemId:
+            item.shippingDemandItemId == null
+              ? null
+              : Number(item.shippingDemandItemId),
+          skuId: Number(item.skuId),
+          skuCode: item.skuCode,
+          productName:
+            item.productNameCn ?? item.productNameEn ?? item.skuCode,
+          productCategoryName: item.productType ?? item.spuName,
+          quantity,
+          receivedQuantity,
+          remainingQuantity,
+          unitPrice: Number(item.unitPrice ?? 0),
+          qcImageKeys: [] as string[],
+        };
+      })
+      .filter((item) => item.remainingQuantity > 0);
+  }
+
+  private sumRemainingQuantity(items: PurchaseOrderItem[]) {
+    return items.reduce(
+      (sum, item) =>
+        sum +
+        Math.max(
+          0,
+          Number(item.quantity ?? 0) - Number(item.receivedQuantity ?? 0),
+        ),
+      0,
+    );
+  }
+
+  private async resolveWarehouses(
+    queryRunner: QueryRunner,
+    warehouseIds: number[],
+  ): Promise<Map<number, ReceiptWarehouseSnapshot>> {
+    const warehouses = await queryRunner.manager.getRepository(Warehouse).find({
+      where: { id: In(warehouseIds) },
+    });
+    return new Map(
+      warehouses.map((warehouse) => [
+        Number(warehouse.id),
+        {
+          id: Number(warehouse.id),
+          name: warehouse.name,
+        },
+      ]),
+    );
+  }
+
+  private async resolveReceiver(queryRunner: QueryRunner, receiverId: number) {
+    const receiver = await queryRunner.manager.getRepository(User).findOne({
+      where: { id: receiverId },
+    });
+    if (!receiver) {
+      throw new BadRequestException({
+        code: 'RECEIPT_ORDER_RECEIVER_NOT_FOUND',
+        message: '入库员不存在',
+      });
+    }
+    return receiver;
+  }
+
+  private async resolvePurchaseCompany(
+    queryRunner: QueryRunner,
+    purchaseCompanyId?: number,
+  ): Promise<Company | null> {
+    if (!purchaseCompanyId) return null;
+    const company = await queryRunner.manager.getRepository(Company).findOne({
+      where: { id: purchaseCompanyId },
+    });
+    if (!company) {
+      throw new BadRequestException({
+        code: 'RECEIPT_ORDER_COMPANY_NOT_FOUND',
+        message: '采购主体不存在',
+      });
+    }
+    return company;
+  }
+
+  private aggregatePurchaseOrderReceipt(items: PurchaseOrderItem[]) {
+    const receivedTotalQuantity = items.reduce(
+      (sum, item) => sum + Number(item.receivedQuantity ?? 0),
+      0,
+    );
+    const allFullyReceived =
+      items.length > 0 &&
+      items.every(
+        (item) =>
+          Number(item.receivedQuantity ?? 0) >= Number(item.quantity ?? 0),
+      );
+    const anyReceived = items.some(
+      (item) => Number(item.receivedQuantity ?? 0) > 0,
+    );
+
+    return {
+      receivedTotalQuantity,
+      receiptStatus: allFullyReceived
+        ? PurchaseOrderReceiptStatus.RECEIVED
+        : anyReceived
+          ? PurchaseOrderReceiptStatus.PARTIALLY_RECEIVED
+          : PurchaseOrderReceiptStatus.NOT_RECEIVED,
+      status: allFullyReceived
+        ? PurchaseOrderStatus.RECEIVED
+        : anyReceived
+          ? PurchaseOrderStatus.PARTIALLY_RECEIVED
+          : PurchaseOrderStatus.PENDING_RECEIPT,
+    };
+  }
+
+  private async refreshShippingDemandReceivedQuantity(
+    queryRunner: QueryRunner,
+    shippingDemandItemIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!shippingDemandItemIds.length) return;
+
+    const rows = await queryRunner.manager
+      .getRepository(PurchaseOrderItem)
+      .createQueryBuilder('item')
+      .innerJoin('item.purchaseOrder', 'purchaseOrder')
+      .select('item.shipping_demand_item_id', 'shippingDemandItemId')
+      .addSelect('SUM(item.received_quantity)', 'receivedQuantity')
+      .where('item.shipping_demand_item_id IN (:...shippingDemandItemIds)', {
+        shippingDemandItemIds,
+      })
+      .andWhere('purchaseOrder.order_type = :orderType', {
+        orderType: PurchaseOrderType.REQUISITION,
+      })
+      .andWhere('purchaseOrder.status != :cancelled', {
+        cancelled: PurchaseOrderStatus.CANCELLED,
+      })
+      .groupBy('item.shipping_demand_item_id')
+      .getRawMany<{
+        shippingDemandItemId: string;
+        receivedQuantity: string;
+      }>();
+
+    const receivedByItemId = new Map(
+      rows.map((row) => [
+        Number(row.shippingDemandItemId),
+        Number(row.receivedQuantity ?? 0),
+      ]),
+    );
+
+    const shippingDemandItemRepo =
+      queryRunner.manager.getRepository(ShippingDemandItem);
+    const items = await shippingDemandItemRepo.find({
+      where: { id: In(shippingDemandItemIds) },
+    });
+
+    for (const item of items) {
+      item.receivedQuantity = receivedByItemId.get(Number(item.id)) ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await shippingDemandItemRepo.save(items);
+  }
+
+  private async writeOperationLogs(
+    queryRunner: QueryRunner,
+    receiptOrder: ReceiptOrder,
+    purchaseOrder: PurchaseOrder,
+    receiptItems: ReceiptOrderItem[],
+    previous: {
+      oldStatus: PurchaseOrderStatus;
+      oldReceiptStatus: PurchaseOrderReceiptStatus;
+      oldReceivedTotalQuantity: number;
+    },
+    operator?: string,
+  ) {
+    const operationLogRepo = queryRunner.manager.getRepository(OperationLog);
+
+    await operationLogRepo.save(
+      operationLogRepo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.CREATE,
+        resourceType: 'receipt-orders',
+        resourceId: String(receiptOrder.id),
+        resourcePath: '/api/receipt-orders',
+        requestSummary: {
+          sourceAction: 'confirm_purchase_receipt',
+          receiptCode: receiptOrder.receiptCode,
+          purchaseOrderId: Number(receiptOrder.purchaseOrderId),
+          purchaseOrderCode: receiptOrder.purchaseOrderCode,
+          totalQuantity: receiptOrder.totalQuantity,
+          totalAmount: receiptOrder.totalAmount,
+          itemCount: receiptItems.length,
+        },
+        changeSummary: [
+          {
+            field: 'status',
+            fieldLabel: '收货入库单状态',
+            oldValue: null,
+            newValue: ReceiptOrderStatus.CONFIRMED,
+          },
+        ],
+      }),
+    );
+
+    const changeSummary: Array<{
+      field: string;
+      fieldLabel: string;
+      oldValue: unknown;
+      newValue: unknown;
+    }> = [];
+    if (previous.oldStatus !== purchaseOrder.status) {
+      changeSummary.push({
+        field: 'status',
+        fieldLabel: '采购订单状态',
+        oldValue: previous.oldStatus,
+        newValue: purchaseOrder.status,
+      });
+    }
+    if (previous.oldReceiptStatus !== purchaseOrder.receiptStatus) {
+      changeSummary.push({
+        field: 'receiptStatus',
+        fieldLabel: '入库状态',
+        oldValue: previous.oldReceiptStatus,
+        newValue: purchaseOrder.receiptStatus,
+      });
+    }
+    if (
+      previous.oldReceivedTotalQuantity !==
+      Number(purchaseOrder.receivedTotalQuantity ?? 0)
+    ) {
+      changeSummary.push({
+        field: 'receivedTotalQuantity',
+        fieldLabel: '已入库总数',
+        oldValue: previous.oldReceivedTotalQuantity,
+        newValue: Number(purchaseOrder.receivedTotalQuantity ?? 0),
+      });
+    }
+
+    await operationLogRepo.save(
+      operationLogRepo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.UPDATE,
+        resourceType: 'purchase-orders',
+        resourceId: String(purchaseOrder.id),
+        resourcePath: `/api/receipt-orders/${receiptOrder.id}`,
+        requestSummary: {
+          sourceAction: 'purchase_receipt_confirmed',
+          receiptOrderId: Number(receiptOrder.id),
+          receiptCode: receiptOrder.receiptCode,
+          totalQuantity: receiptOrder.totalQuantity,
+          totalAmount: receiptOrder.totalAmount,
+        },
+        changeSummary,
+      }),
+    );
+  }
+
+  private async generateReceiptCode(queryRunner: QueryRunner): Promise<string> {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const prefix = `RKDH${year}${month}${day}`;
+    const latest = await queryRunner.manager
+      .getRepository(ReceiptOrder)
+      .createQueryBuilder('receiptOrder')
+      .setLock('pessimistic_write')
+      .where('receiptOrder.receipt_code LIKE :prefix', {
+        prefix: `${prefix}%`,
+      })
+      .orderBy('receiptOrder.receipt_code', 'DESC')
+      .getOne();
+    const lastNumber = latest?.receiptCode
+      ? Number(latest.receiptCode.slice(prefix.length))
+      : 0;
+    return `${prefix}${String(lastNumber + 1).padStart(4, '0')}`;
+  }
+
+  private decimal(value: number): string {
+    return value.toFixed(2);
+  }
+
+  private async executeWithReceiptOrderCodeRetry<T>(
+    operation: (queryRunner: QueryRunner) => Promise<T>,
+  ): Promise<T> {
+    let retryCount = 0;
+    while (true) {
+      const queryRunner = this.receiptOrdersRepository.createQueryRunner();
+      let transactionStarted = false;
+
+      try {
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+        transactionStarted = true;
+        const result = await operation(queryRunner);
+        await queryRunner.commitTransaction();
+        return result;
+      } catch (error) {
+        if (transactionStarted) {
+          await queryRunner.rollbackTransaction();
+        }
+        if (
+          this.isRetryableConcurrencyError(error) &&
+          retryCount < MAX_RECEIPT_ORDER_CODE_RETRIES
+        ) {
+          retryCount += 1;
+          await this.delay(INITIAL_RETRY_DELAY_MS * 2 ** (retryCount - 1));
+          continue;
+        }
+        if (this.isRetryableConcurrencyError(error)) {
+          throw new ConflictException({
+            code: 'CONCURRENT_UPDATE',
+            message: '收货入库并发更新失败，请稍后重试',
+          });
+        }
+        throw error;
+      } finally {
+        await queryRunner.release();
+      }
+    }
+  }
+
+  private isRetryableConcurrencyError(error: unknown): boolean {
+    const maybeError = error as { code?: string; errno?: number };
+    return (
+      maybeError?.code === 'ER_LOCK_DEADLOCK' ||
+      maybeError?.errno === 1213 ||
+      maybeError?.code === 'ER_DUP_ENTRY' ||
+      maybeError?.errno === 1062
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts
+++ b/apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts
@@ -1,0 +1,511 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  InventoryBatchSourceType,
+  PurchaseOrderReceiptStatus,
+  PurchaseOrderStatus,
+  ReceiptOrderStatus,
+  ReceiptOrderType,
+  YesNo,
+} from '@infitek/shared';
+import {
+  OperationLog,
+  OperationLogAction,
+} from '../../operation-logs/entities/operation-log.entity';
+import { Company } from '../../master-data/companies/entities/company.entity';
+import { Warehouse } from '../../master-data/warehouses/entities/warehouse.entity';
+import { PurchaseOrderItem } from '../../purchase-orders/entities/purchase-order-item.entity';
+import { PurchaseOrder } from '../../purchase-orders/entities/purchase-order.entity';
+import { ShippingDemandItem } from '../../shipping-demands/entities/shipping-demand-item.entity';
+import { User } from '../../users/entities/user.entity';
+import { ReceiptOrderItem } from '../entities/receipt-order-item.entity';
+import { ReceiptOrder } from '../entities/receipt-order.entity';
+import { ReceiptOrdersService } from '../receipt-orders.service';
+
+describe('ReceiptOrdersService', () => {
+  const receiptOrdersRepository = {
+    createQueryRunner: jest.fn(),
+    findById: jest.fn(),
+    findBySourceActionKey: jest.fn(),
+    findPurchaseOrderOptions: jest.fn(),
+  };
+
+  const inventoryService = {
+    increaseStockInTransaction: jest.fn(),
+  };
+
+  const makePurchaseOrder = (
+    overrides: Partial<PurchaseOrder> = {},
+  ): Partial<PurchaseOrder> => ({
+    id: 500,
+    poCode: 'XCPO202604300001',
+    status: PurchaseOrderStatus.PENDING_RECEIPT,
+    receiptStatus: PurchaseOrderReceiptStatus.NOT_RECEIVED,
+    supplierId: 88,
+    supplierName: '信达供应商',
+    purchaseCompanyId: 2,
+    purchaseCompanyName: '信达主体',
+    shippingDemandId: 700,
+    shippingDemandCode: 'XCFH202604300001',
+    totalQuantity: 5,
+    receivedTotalQuantity: 1,
+    items: [
+      {
+        id: 900,
+        purchaseOrderId: 500,
+        shippingDemandItemId: 701,
+        skuId: 11,
+        skuCode: 'SKU001',
+        productNameCn: '离心机',
+        productType: '设备类',
+        spuName: 'SPU001',
+        quantity: 5,
+        receivedQuantity: 1,
+        unitPrice: '12.50',
+        isFullyReceived: YesNo.NO,
+      },
+    ] as any,
+    receiptOrders: [],
+    ...overrides,
+  });
+
+  const makePurchaseOrderQueryBuilder = (state: Record<string, any>) => {
+    const qb = {
+      leftJoinAndSelect: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      addOrderBy: jest.fn(() => qb),
+      setLock: jest.fn(() => qb),
+      getOne: jest.fn().mockResolvedValue(state.purchaseOrder),
+    };
+    return qb;
+  };
+
+  const makeReceiptCodeQueryBuilder = (state: Record<string, any>) => {
+    const qb = {
+      setLock: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      getOne: jest.fn().mockResolvedValue(state.latestReceiptOrder ?? null),
+    };
+    return qb;
+  };
+
+  const makeRepository = (entity: unknown, state: Record<string, any>) => {
+    if (entity === PurchaseOrder) {
+      return {
+        createQueryBuilder: jest.fn(() => {
+          if (state.purchaseOrderQueryMode === 'find') {
+            return makePurchaseOrderQueryBuilder(state);
+          }
+          return makeReceiptCodeQueryBuilder(state);
+        }),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedPurchaseOrder = { ...data };
+          return state.savedPurchaseOrder;
+        }),
+      };
+    }
+    if (entity === PurchaseOrderItem) {
+      return {
+        createQueryBuilder: jest.fn(() => {
+          const qb = {
+            innerJoin: jest.fn(() => qb),
+            select: jest.fn(() => qb),
+            addSelect: jest.fn(() => qb),
+            where: jest.fn(() => qb),
+            andWhere: jest.fn(() => qb),
+            groupBy: jest.fn(() => qb),
+            getRawMany: jest.fn().mockImplementation(async () => {
+              const sourceItems =
+                state.savedPurchaseOrderItems ??
+                state.purchaseOrder?.items ??
+                [];
+              return sourceItems
+                .filter((item: any) => item.shippingDemandItemId != null)
+                .map((item: any) => ({
+                  shippingDemandItemId: String(item.shippingDemandItemId),
+                  receivedQuantity: String(item.receivedQuantity ?? 0),
+                }));
+            }),
+          };
+          return qb;
+        }),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedPurchaseOrderItems = Array.isArray(data) ? data : [data];
+          return data;
+        }),
+      };
+    }
+    if (entity === ShippingDemandItem) {
+      return {
+        find: jest.fn().mockResolvedValue(
+          state.shippingDemandItems ?? [
+            {
+              id: 701,
+              receivedQuantity: 1,
+            },
+          ],
+        ),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedShippingDemandItems = Array.isArray(data) ? data : [data];
+          return data;
+        }),
+      };
+    }
+    if (entity === ReceiptOrder) {
+      return {
+        findOne: jest.fn().mockResolvedValue(null),
+        createQueryBuilder: jest.fn(() => makeReceiptCodeQueryBuilder(state)),
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedReceiptOrder = { id: 800, ...data };
+          return state.savedReceiptOrder;
+        }),
+      };
+    }
+    if (entity === ReceiptOrderItem) {
+      return {
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          if (data.id) {
+            state.updatedReceiptItems = [
+              ...(state.updatedReceiptItems ?? []),
+              data,
+            ];
+            return data;
+          }
+          state.receiptItemSeq = (state.receiptItemSeq ?? 0) + 1;
+          const saved = { id: 900 + state.receiptItemSeq, ...data };
+          state.savedReceiptItems = [...(state.savedReceiptItems ?? []), saved];
+          return saved;
+        }),
+      };
+    }
+    if (entity === Warehouse) {
+      return {
+        find: jest.fn().mockResolvedValue(state.warehouses ?? []),
+      };
+    }
+    if (entity === User) {
+      return {
+        findOne: jest.fn().mockResolvedValue(state.receiver ?? null),
+      };
+    }
+    if (entity === Company) {
+      return {
+        findOne: jest.fn().mockResolvedValue(state.company ?? null),
+      };
+    }
+    if (entity === OperationLog) {
+      return {
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedOperationLogs = [
+            ...(state.savedOperationLogs ?? []),
+            ...(Array.isArray(data) ? data : [data]),
+          ];
+          return data;
+        }),
+      };
+    }
+    throw new Error(`Unexpected repository: ${String(entity)}`);
+  };
+
+  const makeQueryRunner = (state: Record<string, any>) => ({
+    connect: jest.fn().mockResolvedValue(undefined),
+    startTransaction: jest.fn().mockResolvedValue(undefined),
+    commitTransaction: jest.fn().mockResolvedValue(undefined),
+    rollbackTransaction: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn().mockResolvedValue(undefined),
+    manager: {
+      getRepository: jest.fn((entity) => makeRepository(entity, state)),
+    },
+  });
+
+  let service: ReceiptOrdersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(new Date('2026-04-30T10:00:00.000Z'));
+    service = new ReceiptOrdersService(
+      receiptOrdersRepository as any,
+      inventoryService as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('builds receipt prefill from remaining purchase quantities', async () => {
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder(),
+      purchaseOrderQueryMode: 'find',
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+
+    const result = await service.getCreatePrefill(500);
+
+    expect(result.purchaseOrder).toEqual(
+      expect.objectContaining({
+        id: 500,
+        poCode: 'XCPO202604300001',
+        remainingTotalQuantity: 4,
+      }),
+    );
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        purchaseOrderItemId: 900,
+        quantity: 5,
+        receivedQuantity: 1,
+        remainingQuantity: 4,
+        unitPrice: 12.5,
+      }),
+    ]);
+    expect(queryRunner.release).toHaveBeenCalled();
+  });
+
+  it('creates a confirmed receipt order and updates purchase order receipt status', async () => {
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder(),
+      purchaseOrderQueryMode: 'find',
+      latestReceiptOrder: null,
+      warehouses: [{ id: 10, name: '深圳仓' }],
+      receiver: { id: 20, name: '仓管小李' },
+      company: { id: 2, nameCn: '信达主体' },
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue(null);
+    receiptOrdersRepository.findById.mockResolvedValue({
+      id: 800,
+      receiptCode: 'RKDH202604300001',
+      purchaseOrderId: 500,
+      purchaseOrderCode: 'XCPO202604300001',
+      status: ReceiptOrderStatus.CONFIRMED,
+      totalQuantity: 4,
+      totalAmount: '50.00',
+    });
+    inventoryService.increaseStockInTransaction.mockResolvedValue({
+      summary: {},
+      batches: [{ id: 7001 }],
+    });
+
+    const result = await service.create(
+      {
+        purchaseOrderId: 500,
+        requestKey: 'receipt-order:test-1',
+        receiptType: ReceiptOrderType.PURCHASE_RECEIPT,
+        warehouseId: 10,
+        receiptDate: '2026-04-30',
+        receiverId: 20,
+        purchaseCompanyId: 2,
+        remark: '本次到货 4 台',
+        inventoryNote: '常规采购入库',
+        items: [
+          {
+            purchaseOrderItemId: 900,
+            receivedQuantity: 4,
+            warehouseId: 10,
+            qcImageKeys: ['qc/a.png'],
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        receiptCode: 'RKDH202604300001',
+        purchaseOrderId: 500,
+      }),
+    );
+    expect(state.savedReceiptOrder).toEqual(
+      expect.objectContaining({
+        receiptCode: 'RKDH202604300001',
+        purchaseOrderCode: 'XCPO202604300001',
+        totalQuantity: 4,
+        totalAmount: '50.00',
+        warehouseId: 10,
+        receiverId: 20,
+      }),
+    );
+    expect(inventoryService.increaseStockInTransaction).toHaveBeenCalledWith(
+      queryRunner,
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 10,
+        quantity: 4,
+        sourceType: InventoryBatchSourceType.PURCHASE_RECEIPT,
+        sourceDocumentId: 800,
+        receiptDate: '2026-04-30',
+      }),
+    );
+    expect(state.savedPurchaseOrder).toEqual(
+      expect.objectContaining({
+        status: PurchaseOrderStatus.RECEIVED,
+        receiptStatus: PurchaseOrderReceiptStatus.RECEIVED,
+        receivedTotalQuantity: 5,
+      }),
+    );
+    expect(state.savedPurchaseOrderItems).toEqual([
+      expect.objectContaining({
+        id: 900,
+        receivedQuantity: 5,
+        isFullyReceived: YesNo.YES,
+      }),
+    ]);
+    expect(state.savedShippingDemandItems).toEqual([
+      expect.objectContaining({
+        id: 701,
+        receivedQuantity: 5,
+      }),
+    ]);
+    expect(state.savedOperationLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          action: OperationLogAction.CREATE,
+          resourceType: 'receipt-orders',
+        }),
+        expect.objectContaining({
+          action: OperationLogAction.UPDATE,
+          resourceType: 'purchase-orders',
+        }),
+      ]),
+    );
+  });
+
+  it('marks purchase order as partially received when only part of the remaining quantity arrives', async () => {
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder(),
+      purchaseOrderQueryMode: 'find',
+      latestReceiptOrder: null,
+      warehouses: [{ id: 10, name: '深圳仓' }],
+      receiver: { id: 20, name: '仓管小李' },
+      company: { id: 2, nameCn: '信达主体' },
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue(null);
+    receiptOrdersRepository.findById.mockResolvedValue({
+      id: 800,
+      receiptCode: 'RKDH202604300001',
+      purchaseOrderId: 500,
+      purchaseOrderCode: 'XCPO202604300001',
+      status: ReceiptOrderStatus.CONFIRMED,
+      totalQuantity: 2,
+      totalAmount: '25.00',
+    });
+    inventoryService.increaseStockInTransaction.mockResolvedValue({
+      summary: {},
+      batches: [{ id: 7001 }],
+    });
+
+    await service.create(
+      {
+        purchaseOrderId: 500,
+        requestKey: 'receipt-order:test-2',
+        warehouseId: 10,
+        receiptDate: '2026-04-30',
+        receiverId: 20,
+        purchaseCompanyId: 2,
+        items: [
+          {
+            purchaseOrderItemId: 900,
+            receivedQuantity: 2,
+            warehouseId: 10,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(state.savedPurchaseOrder).toEqual(
+      expect.objectContaining({
+        status: PurchaseOrderStatus.PARTIALLY_RECEIVED,
+        receiptStatus: PurchaseOrderReceiptStatus.PARTIALLY_RECEIVED,
+        receivedTotalQuantity: 3,
+      }),
+    );
+    expect(state.savedShippingDemandItems).toEqual([
+      expect.objectContaining({
+        id: 701,
+        receivedQuantity: 3,
+      }),
+    ]);
+  });
+
+  it('rejects receipt quantity that exceeds remaining quantity', async () => {
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder(),
+      purchaseOrderQueryMode: 'find',
+      latestReceiptOrder: null,
+      warehouses: [{ id: 10, name: '深圳仓' }],
+      receiver: { id: 20, name: '仓管小李' },
+      company: { id: 2, nameCn: '信达主体' },
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        {
+          purchaseOrderId: 500,
+          requestKey: 'receipt-order:test-3',
+          warehouseId: 10,
+          receiptDate: '2026-04-30',
+          receiverId: 20,
+          items: [
+            {
+              purchaseOrderItemId: 900,
+              receivedQuantity: 9,
+              warehouseId: 10,
+            },
+          ],
+        },
+        'admin',
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(inventoryService.increaseStockInTransaction).not.toHaveBeenCalled();
+  });
+
+  it('returns existing receipt order when request key is repeated', async () => {
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue({
+      id: 801,
+    });
+    receiptOrdersRepository.findById.mockResolvedValue({
+      id: 801,
+      receiptCode: 'RKDH202604300099',
+      purchaseOrderId: 500,
+      purchaseOrderCode: 'XCPO202604300001',
+      status: ReceiptOrderStatus.CONFIRMED,
+    });
+
+    const result = await service.create(
+      {
+        purchaseOrderId: 500,
+        requestKey: 'receipt-order:test-repeat',
+        warehouseId: 10,
+        receiptDate: '2026-04-30',
+        receiverId: 20,
+        items: [
+          {
+            purchaseOrderItemId: 900,
+            receivedQuantity: 2,
+            warehouseId: 10,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({ receiptCode: 'RKDH202604300099' }),
+    );
+    expect(receiptOrdersRepository.createQueryRunner).not.toHaveBeenCalled();
+    expect(inventoryService.increaseStockInTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -65,6 +65,7 @@ import LogisticsOrderFormPage from "./pages/logistics-orders/form";
 import PurchaseOrdersListPage from "./pages/purchase-orders/index";
 import PurchaseOrderDetailPage from "./pages/purchase-orders/detail";
 import PurchaseOrderFormPage from "./pages/purchase-orders/form";
+import ReceiptOrderFormPage from "./pages/receipt-orders/form";
 import InventoryPage from "./pages/inventory/index";
 import InventoryTransactionsPage from "./pages/inventory/transactions";
 import HomePage from "./pages/home/index";
@@ -473,6 +474,14 @@ function App() {
                   <Route
                     path="/purchase-orders/create"
                     element={<PurchaseOrderFormPage />}
+                  />
+                  <Route
+                    path="/receipt-orders/new"
+                    element={<ReceiptOrderFormPage />}
+                  />
+                  <Route
+                    path="/receipt-orders/create"
+                    element={<ReceiptOrderFormPage />}
                   />
                   <Route
                     path="/inventory/transactions"

--- a/apps/web/src/api/purchase-orders.api.ts
+++ b/apps/web/src/api/purchase-orders.api.ts
@@ -6,6 +6,7 @@ import {
   PurchaseOrderSettlementType,
   PurchaseOrderStatus,
   PurchaseOrderType,
+  ReceiptOrderStatus,
   type FulfillmentType,
   type YesNo,
 } from "@infitek/shared";
@@ -41,6 +42,15 @@ export interface PurchaseOrderItem {
   coreParams?: string | null;
   hasPlugText?: string | null;
   specialAttributeNote?: string | null;
+}
+
+export interface PurchaseOrderReceiptOrderSummary {
+  id: number;
+  receiptCode: string;
+  status: ReceiptOrderStatus;
+  receiptDate: string;
+  totalQuantity: number;
+  totalAmount: string;
 }
 
 export interface PurchaseOrder {
@@ -103,6 +113,7 @@ export interface PurchaseOrder {
   formErrorMessage?: string | null;
   invoiceCompletedAt?: string | null;
   paymentCompletedAt?: string | null;
+  receiptOrders?: PurchaseOrderReceiptOrderSummary[];
   createdAt: string;
   updatedAt: string;
   items?: PurchaseOrderItem[];

--- a/apps/web/src/api/receipt-orders.api.ts
+++ b/apps/web/src/api/receipt-orders.api.ts
@@ -1,0 +1,181 @@
+import {
+  ReceiptOrderStatus,
+  ReceiptOrderType,
+  type PurchaseOrderReceiptStatus,
+  type PurchaseOrderStatus,
+} from "@infitek/shared";
+import request from "./request";
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === "object" && error !== null) throw error;
+  throw { message: "请求失败，请稍后重试" };
+}
+
+export interface ReceiptOrderItem {
+  id: number;
+  receiptOrderId: number;
+  purchaseOrderId: number;
+  purchaseOrderItemId: number;
+  shippingDemandItemId?: number | null;
+  skuId: number;
+  skuCode: string;
+  productName?: string | null;
+  productCategoryName?: string | null;
+  receivedQuantity: number;
+  qcImageKeys?: string[] | null;
+  unitPrice: string;
+  warehouseId: number;
+  warehouseName: string;
+  inventoryBatchId?: number | null;
+}
+
+export interface ReceiptOrder {
+  id: number;
+  receiptCode: string;
+  purchaseOrderId: number;
+  purchaseOrderCode: string;
+  receiptType: ReceiptOrderType;
+  status: ReceiptOrderStatus;
+  warehouseId: number;
+  warehouseName: string;
+  receiptDate: string;
+  receiverId: number;
+  receiverName: string;
+  shippingDemandId?: number | null;
+  shippingDemandCode?: string | null;
+  purchaseCompanyId?: number | null;
+  purchaseCompanyName?: string | null;
+  totalQuantity: number;
+  totalAmount: string;
+  remark?: string | null;
+  inventoryNote?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  items?: ReceiptOrderItem[];
+}
+
+export interface ReceiptPurchaseOrderOption {
+  id: number;
+  poCode: string;
+  supplierName: string;
+  status: PurchaseOrderStatus;
+  receiptStatus: PurchaseOrderReceiptStatus;
+  shippingDemandId?: number | null;
+  shippingDemandCode?: string | null;
+  remainingTotalQuantity: number;
+}
+
+export interface ReceiptOrderPrefillItem {
+  purchaseOrderItemId: number;
+  shippingDemandItemId?: number | null;
+  skuId: number;
+  skuCode: string;
+  productName: string;
+  productCategoryName?: string | null;
+  quantity: number;
+  receivedQuantity: number;
+  remainingQuantity: number;
+  unitPrice: number;
+  qcImageKeys: string[];
+}
+
+export interface ReceiptOrderCreatePrefill {
+  purchaseOrder: {
+    id: number;
+    poCode: string;
+    status: PurchaseOrderStatus;
+    receiptStatus: PurchaseOrderReceiptStatus;
+    supplierId: number;
+    supplierName: string;
+    shippingDemandId?: number | null;
+    shippingDemandCode?: string | null;
+    purchaseCompanyId?: number | null;
+    purchaseCompanyName?: string | null;
+    totalQuantity: number;
+    receivedTotalQuantity: number;
+    remainingTotalQuantity: number;
+  };
+  items: ReceiptOrderPrefillItem[];
+}
+
+export interface CreateReceiptOrderPayload {
+  purchaseOrderId: number;
+  requestKey: string;
+  receiptType?: ReceiptOrderType;
+  warehouseId: number;
+  receiptDate: string;
+  receiverId: number;
+  purchaseCompanyId?: number;
+  remark?: string;
+  inventoryNote?: string;
+  items: Array<{
+    purchaseOrderItemId: number;
+    receivedQuantity: number;
+    warehouseId?: number;
+    qcImageKeys?: string[];
+  }>;
+}
+
+export const RECEIPT_ORDER_STATUS_LABELS: Record<ReceiptOrderStatus, string> = {
+  [ReceiptOrderStatus.CONFIRMED]: "已确认",
+};
+
+export const RECEIPT_ORDER_TYPE_LABELS: Record<ReceiptOrderType, string> = {
+  [ReceiptOrderType.PURCHASE_RECEIPT]: "采购入库",
+  [ReceiptOrderType.SALES_RETURN_RECEIPT]: "销售退货入库",
+  [ReceiptOrderType.SALES_EXCHANGE_RECEIPT]: "销售换货入库",
+  [ReceiptOrderType.OPENING_RECEIPT]: "期初入库",
+  [ReceiptOrderType.SUPPLIER_GIFT_RECEIPT]: "供应商受赠入库",
+  [ReceiptOrderType.TRANSFER_RECEIPT]: "调拨入库",
+  [ReceiptOrderType.INVENTORY_GAIN_RECEIPT]: "盘盈入库",
+  [ReceiptOrderType.OTHER]: "其他",
+};
+
+export const getReceiptPurchaseOrderOptions = (
+  keyword?: string,
+): Promise<ReceiptPurchaseOrderOption[]> =>
+  request
+    .get<unknown, ReceiptPurchaseOrderOption[]>(
+      "/receipt-orders/purchase-order-options",
+      {
+        params: { keyword, pageSize: 20 },
+      },
+    )
+    .catch(normalizeApiError);
+
+export const getReceiptOrderCreatePrefill = (
+  purchaseOrderId: number,
+): Promise<ReceiptOrderCreatePrefill> =>
+  request
+    .get<unknown, ReceiptOrderCreatePrefill>("/receipt-orders/create-prefill", {
+      params: { purchaseOrderId },
+    })
+    .catch(normalizeApiError);
+
+export const getReceiptOrderById = (id: number): Promise<ReceiptOrder> =>
+  request
+    .get<unknown, ReceiptOrder>(`/receipt-orders/${id}`)
+    .catch(normalizeApiError);
+
+export const createReceiptOrder = (
+  payload: CreateReceiptOrderPayload,
+): Promise<ReceiptOrder> =>
+  request
+    .post<unknown, ReceiptOrder>("/receipt-orders", payload)
+    .catch(normalizeApiError);
+
+export const uploadReceiptOrderQcImage = (
+  file: File,
+): Promise<{ key: string }> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  return request
+    .post<unknown, { key: string }>(
+      "/files/upload?folder=receipt-orders",
+      formData,
+      {
+        headers: { "Content-Type": "multipart/form-data" },
+      },
+    )
+    .catch(normalizeApiError);
+};

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -159,6 +159,22 @@ const BREADCRUMB_ROUTES: BreadcrumbRoute[] = [
     sectionPath: INVENTORY_SECTION_PATH,
     listLabel: "库存变动流水",
   }),
+  {
+    pattern: /^\/receipt-orders\/new$/,
+    items: [
+      { title: "库存管理", path: INVENTORY_SECTION_PATH },
+      { title: "收货入库", path: "/receipt-orders/new" },
+      { title: "新建收货入库单" },
+    ],
+  },
+  {
+    pattern: /^\/receipt-orders\/create$/,
+    items: [
+      { title: "库存管理", path: INVENTORY_SECTION_PATH },
+      { title: "收货入库", path: "/receipt-orders/create" },
+      { title: "新建收货入库单" },
+    ],
+  },
   ...createCrudBreadcrumbRoutes({
     basePath: "/master-data/units",
     sectionLabel: "基础数据",

--- a/apps/web/src/pages/purchase-orders/detail.tsx
+++ b/apps/web/src/pages/purchase-orders/detail.tsx
@@ -330,6 +330,9 @@ export default function PurchaseOrderDetailPage() {
   const currentStatus = statusInfo(data);
   const isActionLoading =
     confirmInternalMutation.isPending || confirmSupplierMutation.isPending;
+  const canCreateReceiptOrder =
+    data?.status === PurchaseOrderStatus.PENDING_RECEIPT ||
+    data?.status === PurchaseOrderStatus.PARTIALLY_RECEIVED;
 
   return (
     <div className="master-page">
@@ -388,6 +391,18 @@ export default function PurchaseOrderDetailPage() {
                         供应商确认
                       </Button>
                     </Popconfirm>
+                  ) : null}
+                  {canCreateReceiptOrder ? (
+                    <Button
+                      type="primary"
+                      onClick={() =>
+                        navigate(
+                          `/receipt-orders/new?purchaseOrderId=${purchaseOrderId}`,
+                        )
+                      }
+                    >
+                      创建收货入库单
+                    </Button>
                   ) : null}
                 </Space>
               </div>
@@ -669,7 +684,24 @@ export default function PurchaseOrderDetailPage() {
             />
           </SectionCard>
 
-          <SectionCard id="relations" title="关联单据">
+          <SectionCard
+            id="relations"
+            title="关联单据"
+            extra={
+              canCreateReceiptOrder ? (
+                <Button
+                  type="primary"
+                  onClick={() =>
+                    navigate(
+                      `/receipt-orders/new?purchaseOrderId=${purchaseOrderId}`,
+                    )
+                  }
+                >
+                  创建收货入库单
+                </Button>
+              ) : undefined
+            }
+          >
             <div className="master-meta-grid">
               <MetaItem
                 label="销售订单号"
@@ -697,7 +729,21 @@ export default function PurchaseOrderDetailPage() {
               />
               <MetaItem
                 label="收货入库单"
-                value="收货入库将在 Story 6.5 接入"
+                value={
+                  data?.receiptOrders?.length ? (
+                    <Space direction="vertical" size={4}>
+                      {data.receiptOrders.map((receiptOrder) => (
+                        <span key={receiptOrder.id}>
+                          {receiptOrder.receiptCode} /{" "}
+                          {formatDate(receiptOrder.receiptDate)} / 数量{" "}
+                          {receiptOrder.totalQuantity}
+                        </span>
+                      ))}
+                    </Space>
+                  ) : (
+                    "暂无收货入库记录"
+                  )
+                }
                 full
               />
             </div>

--- a/apps/web/src/pages/receipt-orders/form.tsx
+++ b/apps/web/src/pages/receipt-orders/form.tsx
@@ -1,0 +1,654 @@
+import { UploadOutlined } from "@ant-design/icons";
+import {
+  App,
+  Button,
+  Empty,
+  InputNumber,
+  Popconfirm,
+  Result,
+  Select,
+  Table,
+  Upload,
+  type UploadFile,
+} from "antd";
+import {
+  ProForm,
+  ProFormDatePicker,
+  ProFormSelect,
+  ProFormText,
+  ProFormTextArea,
+  type ProFormInstance,
+} from "@ant-design/pro-components";
+import { ReceiptOrderType } from "@infitek/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import dayjs, { type Dayjs } from "dayjs";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { getCompanies } from "../../api/companies.api";
+import {
+  createReceiptOrder,
+  getReceiptOrderCreatePrefill,
+  getReceiptPurchaseOrderOptions,
+  RECEIPT_ORDER_TYPE_LABELS,
+  uploadReceiptOrderQcImage,
+  type ReceiptOrderPrefillItem,
+} from "../../api/receipt-orders.api";
+import { getUsers } from "../../api/users.api";
+import { getWarehouses } from "../../api/warehouses.api";
+import {
+  AnchorNav,
+  SectionCard,
+  displayOrDash,
+} from "../master-data/components/page-scaffold";
+import "../master-data/master-page.css";
+
+interface ReceiptOrderFormValues {
+  purchaseOrderId?: number;
+  receiptType?: ReceiptOrderType;
+  warehouseId?: number;
+  receiptDate?: Dayjs;
+  receiverId?: number;
+  purchaseCompanyId?: number;
+  shippingDemandCode?: string;
+  purchaseOrderCode?: string;
+  totalQuantity?: string;
+  totalAmount?: string;
+  inventoryNote?: string;
+  remark?: string;
+}
+
+interface EditableReceiptItem extends ReceiptOrderPrefillItem {
+  inputReceivedQuantity: number;
+  warehouseId?: number;
+}
+
+function formatMoney(value: number) {
+  return value.toLocaleString("zh-CN", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export default function ReceiptOrderFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  const { message, notification } = App.useApp();
+  const formRef = useRef<ProFormInstance<ReceiptOrderFormValues>>(undefined);
+  const [activeAnchor, setActiveAnchor] = useState("basic");
+  const [selectedPurchaseOrderId, setSelectedPurchaseOrderId] = useState<
+    number | undefined
+  >(() => {
+    const raw = searchParams.get("purchaseOrderId");
+    return raw ? Number(raw) : undefined;
+  });
+  const [receiptItems, setReceiptItems] = useState<EditableReceiptItem[]>([]);
+  const [qcFileLists, setQcFileLists] = useState<Record<number, UploadFile[]>>(
+    {},
+  );
+  const [uploadingItemId, setUploadingItemId] = useState<number | null>(null);
+
+  const prefillQuery = useQuery({
+    queryKey: ["receipt-order-create-prefill", selectedPurchaseOrderId],
+    queryFn: () => getReceiptOrderCreatePrefill(selectedPurchaseOrderId!),
+    enabled:
+      Number.isInteger(selectedPurchaseOrderId) &&
+      Number(selectedPurchaseOrderId) > 0,
+  });
+
+  const warehouseQuery = useQuery({
+    queryKey: ["receipt-order-warehouses"],
+    queryFn: () => getWarehouses({ pageSize: 100 }),
+  });
+
+  const warehouseOptions = useMemo(
+    () =>
+      (warehouseQuery.data?.list ?? []).map((warehouse) => ({
+        label: `${warehouse.name}${warehouse.warehouseCode ? ` (${warehouse.warehouseCode})` : ""}`,
+        value: Number(warehouse.id),
+      })),
+    [warehouseQuery.data],
+  );
+
+  useEffect(() => {
+    if (!prefillQuery.data) return;
+    const { purchaseOrder, items } = prefillQuery.data;
+    setReceiptItems(
+      items.map((item) => ({
+        ...item,
+        inputReceivedQuantity: item.remainingQuantity,
+        warehouseId: undefined,
+      })),
+    );
+    setQcFileLists({});
+    formRef.current?.setFieldsValue({
+      purchaseOrderId: purchaseOrder.id,
+      receiptType: ReceiptOrderType.PURCHASE_RECEIPT,
+      receiptDate: dayjs(),
+      purchaseCompanyId: purchaseOrder.purchaseCompanyId ?? undefined,
+      shippingDemandCode: purchaseOrder.shippingDemandCode ?? undefined,
+      purchaseOrderCode: purchaseOrder.poCode,
+    });
+  }, [prefillQuery.data]);
+
+  const totals = useMemo(() => {
+    const totalQuantity = receiptItems.reduce(
+      (sum, item) => sum + Number(item.inputReceivedQuantity ?? 0),
+      0,
+    );
+    const totalAmount = receiptItems.reduce(
+      (sum, item) =>
+        sum +
+        Number(item.inputReceivedQuantity ?? 0) * Number(item.unitPrice ?? 0),
+      0,
+    );
+    return { totalQuantity, totalAmount };
+  }, [receiptItems]);
+
+  useEffect(() => {
+    formRef.current?.setFieldsValue({
+      totalQuantity: String(totals.totalQuantity),
+      totalAmount: formatMoney(totals.totalAmount),
+    });
+  }, [totals]);
+
+  const createMutation = useMutation({
+    mutationFn: createReceiptOrder,
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ["purchase-orders"] });
+      queryClient.invalidateQueries({
+        queryKey: ["purchase-order-detail", created.purchaseOrderId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["receipt-order-create-prefill", created.purchaseOrderId],
+      });
+      notification.success({
+        message: "收货入库已确认",
+        description: `${created.receiptCode} 已完成入库，关联采购订单 ${created.purchaseOrderCode}。`,
+        duration: 5,
+      });
+      navigate(`/purchase-orders/${created.purchaseOrderId}`);
+    },
+  });
+
+  const anchors = [
+    { key: "basic", label: "基础信息" },
+    { key: "receipt", label: "入库明细" },
+    { key: "notes", label: "备注说明" },
+  ];
+
+  const handleDefaultWarehouseChange = (warehouseId?: number) => {
+    if (!warehouseId) return;
+    setReceiptItems((current) =>
+      current.map((item) => ({
+        ...item,
+        warehouseId,
+      })),
+    );
+  };
+
+  const handleItemChange = (
+    purchaseOrderItemId: number,
+    patch: Partial<EditableReceiptItem>,
+  ) => {
+    setReceiptItems((current) =>
+      current.map((item) =>
+        item.purchaseOrderItemId === purchaseOrderItemId
+          ? { ...item, ...patch }
+          : item,
+      ),
+    );
+  };
+
+  const handleQcUpload = async (
+    purchaseOrderItemId: number,
+    file: File,
+  ): Promise<boolean> => {
+    setUploadingItemId(purchaseOrderItemId);
+    try {
+      const result = await uploadReceiptOrderQcImage(file);
+      const currentKeys =
+        receiptItems.find(
+          (item) => item.purchaseOrderItemId === purchaseOrderItemId,
+        )?.qcImageKeys ?? [];
+      handleItemChange(purchaseOrderItemId, {
+        qcImageKeys: [...currentKeys, result.key],
+      });
+      setQcFileLists((current) => ({
+        ...current,
+        [purchaseOrderItemId]: [
+          ...(current[purchaseOrderItemId] ?? []),
+          {
+            uid: result.key,
+            name: file.name,
+            status: "done",
+          },
+        ],
+      }));
+      return false;
+    } finally {
+      setUploadingItemId(null);
+    }
+  };
+
+  const itemColumns = [
+    {
+      title: "SKU",
+      dataIndex: "skuCode",
+      key: "skuCode",
+      width: 140,
+      fixed: "left" as const,
+    },
+    {
+      title: "产品名称",
+      dataIndex: "productName",
+      key: "productName",
+      width: 180,
+      render: displayOrDash,
+    },
+    {
+      title: "产品分类",
+      dataIndex: "productCategoryName",
+      key: "productCategoryName",
+      width: 140,
+      render: displayOrDash,
+    },
+    {
+      title: "采购数量",
+      dataIndex: "quantity",
+      key: "quantity",
+      width: 100,
+      align: "right" as const,
+    },
+    {
+      title: "已收货数量",
+      dataIndex: "receivedQuantity",
+      key: "receivedQuantity",
+      width: 110,
+      align: "right" as const,
+      render: (_: unknown, record: EditableReceiptItem) => record.receivedQuantity,
+    },
+    {
+      title: "剩余可收货",
+      dataIndex: "remainingQuantity",
+      key: "remainingQuantity",
+      width: 120,
+      align: "right" as const,
+    },
+    {
+      title: "入库数量",
+      dataIndex: "editableQuantity",
+      key: "editableQuantity",
+      width: 120,
+      render: (_: unknown, record: EditableReceiptItem) => (
+        <InputNumber
+          min={0}
+          max={record.remainingQuantity}
+          precision={0}
+          value={record.receivedQuantity}
+          style={{ width: "100%" }}
+          onChange={(value) =>
+            handleItemChange(record.purchaseOrderItemId, {
+              inputReceivedQuantity: Number(value ?? 0),
+            })
+          }
+        />
+      ),
+    },
+    {
+      title: "采购单价",
+      dataIndex: "unitPrice",
+      key: "unitPrice",
+      width: 120,
+      align: "right" as const,
+      render: (value: number) => formatMoney(Number(value ?? 0)),
+    },
+    {
+      title: "目标仓库",
+      dataIndex: "warehouseId",
+      key: "warehouseId",
+      width: 220,
+      render: (_: unknown, record: EditableReceiptItem) => (
+        <Select
+          showSearch
+          allowClear
+          placeholder="选择目标仓库"
+          options={warehouseOptions}
+          value={record.warehouseId}
+          style={{ width: "100%" }}
+          optionFilterProp="label"
+          onChange={(value) =>
+            handleItemChange(record.purchaseOrderItemId, {
+              warehouseId: value,
+            })
+          }
+        />
+      ),
+    },
+    {
+      title: "质检图片",
+      dataIndex: "qcImageKeys",
+      key: "qcImageKeys",
+      width: 220,
+      render: (_: unknown, record: EditableReceiptItem) => (
+        <Upload
+          multiple
+          fileList={qcFileLists[record.purchaseOrderItemId] ?? []}
+          beforeUpload={(file) =>
+            handleQcUpload(record.purchaseOrderItemId, file)
+          }
+          onRemove={(file) => {
+            setQcFileLists((current) => ({
+              ...current,
+              [record.purchaseOrderItemId]: (
+                current[record.purchaseOrderItemId] ?? []
+              ).filter((item) => item.uid !== file.uid),
+            }));
+            handleItemChange(record.purchaseOrderItemId, {
+              qcImageKeys: (record.qcImageKeys ?? []).filter(
+                (key) => key !== file.uid,
+              ),
+            });
+          }}
+        >
+          <Button
+            icon={<UploadOutlined />}
+            loading={uploadingItemId === record.purchaseOrderItemId}
+          >
+            上传
+          </Button>
+        </Upload>
+      ),
+    },
+  ];
+
+  if (
+    selectedPurchaseOrderId &&
+    prefillQuery.isError &&
+    !prefillQuery.data
+  ) {
+    return (
+      <Result
+        status="error"
+        title="收货入库预填失败"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => prefillQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate("/purchase-orders")}>
+            返回采购订单
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  return (
+    <div className="master-page master-form-page">
+      <div className="master-page-header">
+        <div className="master-page-heading">
+          <div className="master-page-title">创建收货入库单</div>
+          <div className="master-page-description">
+            关联采购订单录入本次实收数量，确认后自动生成采购入库批次和库存流水。
+          </div>
+        </div>
+      </div>
+
+      <ProForm<ReceiptOrderFormValues>
+        formRef={formRef}
+        submitter={false}
+        initialValues={{
+          receiptType: ReceiptOrderType.PURCHASE_RECEIPT,
+          receiptDate: dayjs(),
+        }}
+        onFinish={async (values) => {
+          if (!values.purchaseOrderId) {
+            message.error("请选择采购订单");
+            return false;
+          }
+          if (!values.warehouseId) {
+            message.error("请选择默认入库仓库");
+            return false;
+          }
+          if (!values.receiverId) {
+            message.error("请选择入库员");
+            return false;
+          }
+
+          const positiveItems = receiptItems
+            .filter((item) => Number(item.inputReceivedQuantity ?? 0) > 0)
+            .map((item) => ({
+              purchaseOrderItemId: item.purchaseOrderItemId,
+              receivedQuantity: Number(item.inputReceivedQuantity ?? 0),
+              warehouseId: item.warehouseId,
+              qcImageKeys: item.qcImageKeys,
+            }));
+
+          if (!positiveItems.length) {
+            message.error("至少需要录入一条入库数量大于 0 的明细");
+            return false;
+          }
+
+          const missingWarehouseItem = positiveItems.find(
+            (item) => !item.warehouseId && !values.warehouseId,
+          );
+          if (missingWarehouseItem) {
+            message.error("请为所有入库数量大于 0 的明细选择目标仓库");
+            return false;
+          }
+
+          await createMutation.mutateAsync({
+            purchaseOrderId: Number(values.purchaseOrderId),
+            requestKey: `receipt-order:${Date.now()}`,
+            receiptType: ReceiptOrderType.PURCHASE_RECEIPT,
+            warehouseId: Number(values.warehouseId),
+            receiptDate: (values.receiptDate ?? dayjs()).format("YYYY-MM-DD"),
+            receiverId: Number(values.receiverId),
+            purchaseCompanyId: values.purchaseCompanyId
+              ? Number(values.purchaseCompanyId)
+              : undefined,
+            inventoryNote: values.inventoryNote,
+            remark: values.remark,
+            items: positiveItems,
+          });
+          return true;
+        }}
+      >
+        <div className="master-form-layout">
+          <AnchorNav
+            anchors={anchors}
+            activeKey={activeAnchor}
+            onChange={setActiveAnchor}
+          />
+          <div className="master-form-main">
+            <SectionCard
+              id="basic"
+              title="基础信息"
+              description="先选择采购订单，再确认本次入库的默认仓库、日期和入库员。"
+            >
+              <div className="master-form-grid">
+                <ProFormSelect
+                  name="purchaseOrderId"
+                  label="采购订单"
+                  placeholder="搜索采购订单号 / 供应商 / 发货需求"
+                  showSearch
+                  rules={[{ required: true, message: "请选择采购订单" }]}
+                  request={async ({ keyWords }) => {
+                    const options = await getReceiptPurchaseOrderOptions(
+                      keyWords,
+                    );
+                    return options.map((option) => ({
+                      label: `${option.poCode} / ${option.supplierName} / 剩余 ${option.remainingTotalQuantity}`,
+                      value: option.id,
+                    }));
+                  }}
+                  fieldProps={{
+                    optionFilterProp: "label",
+                    onChange: (value) => {
+                      setSelectedPurchaseOrderId(
+                        value ? Number(value) : undefined,
+                      );
+                    },
+                  }}
+                />
+                <ProFormText
+                  name="purchaseOrderCode"
+                  label="采购订单号"
+                  readonly
+                />
+                <ProFormSelect
+                  name="receiptType"
+                  label="入库类型"
+                  disabled
+                  options={Object.entries(RECEIPT_ORDER_TYPE_LABELS).map(
+                    ([value, label]) => ({
+                      label,
+                      value,
+                    }),
+                  )}
+                />
+                <ProFormDatePicker
+                  name="receiptDate"
+                  label="入库日期"
+                  rules={[{ required: true, message: "请选择入库日期" }]}
+                />
+                <ProFormSelect
+                  name="warehouseId"
+                  label="入库仓库"
+                  showSearch
+                  rules={[{ required: true, message: "请选择默认入库仓库" }]}
+                  request={async ({ keyWords }) => {
+                    const response = await getWarehouses({
+                      keyword: keyWords,
+                      pageSize: 100,
+                    });
+                    return response.list.map((warehouse) => ({
+                      label: `${warehouse.name}${warehouse.warehouseCode ? ` (${warehouse.warehouseCode})` : ""}`,
+                      value: Number(warehouse.id),
+                    }));
+                  }}
+                  fieldProps={{
+                    optionFilterProp: "label",
+                    onChange: (value) =>
+                      handleDefaultWarehouseChange(
+                        value ? Number(value) : undefined,
+                      ),
+                  }}
+                />
+                <ProFormSelect
+                  name="receiverId"
+                  label="入库员"
+                  showSearch
+                  rules={[{ required: true, message: "请选择入库员" }]}
+                  request={async ({ keyWords }) => {
+                    const response = await getUsers(1, 100, keyWords);
+                    return response.list.map((user) => ({
+                      label: `${user.name} (${user.username})`,
+                      value: Number(user.id),
+                    }));
+                  }}
+                  fieldProps={{ optionFilterProp: "label" }}
+                />
+                <ProFormSelect
+                  name="purchaseCompanyId"
+                  label="采购主体"
+                  showSearch
+                  request={async ({ keyWords }) => {
+                    const response = await getCompanies({
+                      keyword: keyWords,
+                      pageSize: 100,
+                    });
+                    return response.list.map((company) => ({
+                      label: company.nameCn,
+                      value: Number(company.id),
+                    }));
+                  }}
+                  fieldProps={{ optionFilterProp: "label" }}
+                />
+                <ProFormText
+                  name="shippingDemandCode"
+                  label="发货需求编号"
+                  readonly
+                />
+                <ProFormText
+                  name="totalQuantity"
+                  label="入库总数量"
+                  readonly
+                />
+                <ProFormText
+                  name="totalAmount"
+                  label="入库总金额"
+                  readonly
+                />
+              </div>
+            </SectionCard>
+
+            <SectionCard
+              id="receipt"
+              title="入库明细"
+              description="默认按剩余可收货数量全额预填；可把本次未到货行改为 0，系统只处理入库数量大于 0 的明细。"
+            >
+              <Table<EditableReceiptItem>
+                rowKey="purchaseOrderItemId"
+                pagination={false}
+                columns={itemColumns as never}
+                dataSource={receiptItems}
+                scroll={{ x: 1400 }}
+                locale={{ emptyText: <Empty description="请选择采购订单后加载明细" /> }}
+              />
+            </SectionCard>
+
+            <SectionCard id="notes" title="备注说明">
+              <div className="master-form-grid">
+                <div className="full">
+                  <ProFormTextArea
+                    name="inventoryNote"
+                    label="库存说明"
+                    fieldProps={{ rows: 3 }}
+                  />
+                </div>
+                <div className="full">
+                  <ProFormTextArea
+                    name="remark"
+                    label="备注"
+                    fieldProps={{ rows: 3 }}
+                  />
+                </div>
+              </div>
+            </SectionCard>
+          </div>
+        </div>
+
+        <div className="master-form-footer">
+          <div className="master-form-footer-tip">
+            确认后会立即创建收货入库单、库存批次和采购入库流水；请先核对入库数量与目标仓库。
+          </div>
+          <div className="master-form-footer-actions">
+            <Button
+              onClick={() =>
+                navigate(
+                  selectedPurchaseOrderId
+                    ? `/purchase-orders/${selectedPurchaseOrderId}`
+                    : "/purchase-orders",
+                )
+              }
+            >
+              取消
+            </Button>
+            <Popconfirm
+              title="确认收货并写入库存？"
+              description="确认后会立即创建收货入库单、库存批次和采购入库流水。"
+              okText="确认"
+              cancelText="取消"
+              onConfirm={() => formRef.current?.submit?.()}
+            >
+              <Button type="primary" loading={createMutation.isPending}>
+                确认收货
+              </Button>
+            </Popconfirm>
+          </div>
+        </div>
+      </ProForm>
+    </div>
+  );
+}

--- a/packages/shared/src/enums/receipt-order-status.enum.ts
+++ b/packages/shared/src/enums/receipt-order-status.enum.ts
@@ -1,0 +1,6 @@
+export const ReceiptOrderStatus = {
+  CONFIRMED: 'confirmed',
+} as const;
+
+export type ReceiptOrderStatus =
+  (typeof ReceiptOrderStatus)[keyof typeof ReceiptOrderStatus];

--- a/packages/shared/src/enums/receipt-order-type.enum.ts
+++ b/packages/shared/src/enums/receipt-order-type.enum.ts
@@ -1,0 +1,13 @@
+export const ReceiptOrderType = {
+  PURCHASE_RECEIPT: 'purchase_receipt',
+  SALES_RETURN_RECEIPT: 'sales_return_receipt',
+  SALES_EXCHANGE_RECEIPT: 'sales_exchange_receipt',
+  OPENING_RECEIPT: 'opening_receipt',
+  SUPPLIER_GIFT_RECEIPT: 'supplier_gift_receipt',
+  TRANSFER_RECEIPT: 'transfer_receipt',
+  INVENTORY_GAIN_RECEIPT: 'inventory_gain_receipt',
+  OTHER: 'other',
+} as const;
+
+export type ReceiptOrderType =
+  (typeof ReceiptOrderType)[keyof typeof ReceiptOrderType];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,6 +38,8 @@ export * from "./enums/shipping-demand-allocation-status.enum";
 export * from "./enums/fulfillment-type.enum";
 export * from "./enums/inventory-batch-source-type.enum";
 export * from "./enums/inventory-change-type.enum";
+export * from "./enums/receipt-order-status.enum";
+export * from "./enums/receipt-order-type.enum";
 export * from "./enums/domestic-trade-type.enum";
 export * from "./enums/payment-term.enum";
 export * from "./enums/trade-term.enum";


### PR DESCRIPTION
## Summary
- add the receipt-orders backend module, migration, and shared enums for purchase receipt confirmation
- create the receipt order form flow and connect purchase order detail to launch and display receipt records
- update receipt confirmation to backfill purchase order and shipping demand receipt caches, then finish Story 6.5 tracking

## Test plan
- pnpm --filter api test -- --runInBand modules/receipt-orders/tests/receipt-orders.service.spec.ts
- pnpm --filter api test -- --runInBand modules/purchase-orders/tests/purchase-orders.service.spec.ts modules/inventory/tests/inventory.service.spec.ts
- pnpm --filter api build
- pnpm --filter web build
- git diff --check
