### PR TITLE
feat(receipt-orders): auto lock requisition receipts

### DIFF
--- a/_bmad-output/implementation-artifacts/6-6-收货后自动触发.md
+++ b/_bmad-output/implementation-artifacts/6-6-收货后自动触发.md
@@ -1,0 +1,204 @@
+# Story 6.6: 收货后自动触发（请购型 FIFO 锁定 + 状态联动）
+
+Status: done
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a 仓管,
+I want 系统在请购型采购订单确认收货后，自动把本次实收数量按 FIFO 锁定到对应发货需求，并在锁定完成后联动推进发货需求与销售订单状态,
+so that 到货后的备货动作无需人工二次分配，采购链路与履约链路的数量状态始终一致。
+
+## Acceptance Criteria
+
+1. 请购型采购订单关联的收货入库单确认成功后，后端必须在同一条业务链路内对对应 `shippingDemandItemId` 执行自动锁定：锁定增量不得超过该收货明细本次 `receivedQuantity`，也不得超过该发货需求明细尚未满足的数量缺口；批次选择遵守 FIFO（入库日期最早优先），并写入 `shipping_demand_inventory_allocations`、`inventory_batch.batch_locked_quantity`、`inventory_summary.locked_quantity/available_quantity` 以及 `inventory_transactions`（`change_type = lock`）。
+2. 自动锁定仅适用于请购型采购订单；备货型采购订单在收货确认后只增加实际库存与采购入库流水，不创建发货需求分配记录、不自动锁定库存。
+3. 自动锁定后，系统必须回填对应发货需求明细的 `receivedQuantity`、`lockedRemainingQuantity`，并继续把销售订单明细上的 `preparedQuantity` 作为展示缓存回填为 `lockedRemainingQuantity + shippedQuantity`；这些缓存只能由后端聚合器更新。
+4. 若请购型收货并自动锁定后，发货需求仍存在任一明细不满足 `lockedRemainingQuantity + shippedQuantity = requiredQuantity`，则发货需求保持 `ShippingDemandStatus.PURCHASING`，销售订单不得提前推进为 `SalesOrderStatus.PREPARED`。
+5. 若请购型收货并自动锁定后，发货需求所有明细均满足 `lockedRemainingQuantity + shippedQuantity = requiredQuantity`，则发货需求必须推进为 `ShippingDemandStatus.PREPARED`，关联销售订单推进为 `SalesOrderStatus.PREPARED`，并在必要时回填对应销售订单明细 `preparedQuantity`。
+6. 采购订单收货状态仍遵守 Story 6.5 已落地口径：按累计 `receivedQuantity` 聚合为 `pending_receipt` / `partially_received` / `received`；Story 6.6 不得把部分收货重新改回旧的“直接全部收货”规则。
+7. 同一收货请求重复提交时，自动锁定必须保持幂等，不得重复创建 allocation、重复写锁定流水或重复累计 `lockedRemainingQuantity`；并发场景下必须使用 `SELECT ... FOR UPDATE` 与死锁指数退避重试（最多 3 次），超限抛出 `CONCURRENT_UPDATE`。
+8. 自动锁定与状态推进必须保留审计证据：至少包含库存锁定流水、发货需求操作日志 / ActivityTimeline、必要的 source action key，以及对采购订单、发货需求、销售订单状态变化的可追踪记录。
+
+## Tasks / Subtasks
+
+- [x] Story 规格确认与冲突裁决落地（AC: 1-8）
+  - [x] 明确本 Story 只处理“请购型采购订单收货后的自动锁定与状态联动”，不重做 Story 6.5 的采购入库基础能力。
+  - [x] 在 Dev Agent Record 记录本 Story 的冲突裁决：FIFO 锁定增量以“本次实收数量”和“发货需求剩余缺口”两者较小值为准；FIFO 选批可以跨历史可用批次，但不得超出本次收货应触发的锁定增量。
+  - [x] 引用 `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-29.md` 与 `_bmad-output/prototypes/shipping-demand-status-flow-prototype.html`，并把它们列为 Story 6.6 的强制上下文。
+- [x] 后端自动锁定编排（AC: 1-2, 7-8）
+  - [x] 在 `apps/api/src/modules/receipt-orders/receipt-orders.service.ts` 的收货确认事务中，为请购型采购订单识别需要自动锁定的收货明细，并在同一 `QueryRunner` 内调用领域级自动锁定逻辑。
+  - [x] 复用或提炼 `shipping-demands` / `inventory` 现有能力，按 `shippingDemandItemId + skuId + warehouseId` 执行 FIFO 锁定，新增或更新 `shipping_demand_inventory_allocations`，并写入稳定的 `sourceActionKey`。
+  - [x] 备货型采购订单跳过自动锁定，仅保留 Story 6.5 已实现的采购入库库存增加逻辑。
+- [x] 发货需求与销售订单聚合回填（AC: 3-5, 8）
+  - [x] 收货后刷新目标 `shipping_demand_items.received_quantity`、`locked_remaining_quantity`，并基于 `lockedRemainingQuantity + shippedQuantity` 判断是否推进到 `prepared`。
+  - [x] 为关联 `sales_order_items` 增加统一聚合回填逻辑，更新 `preparedQuantity` 展示缓存，并在全部满足备货条件时推进 `sales_orders.status = prepared`。
+  - [x] 确保 `pending_purchase_order -> purchasing -> prepared` 状态链只由领域动作自动推进，前端与通用 PATCH 接口不得直接提交目标状态。
+- [x] 审计、幂等与错误处理（AC: 1, 7-8）
+  - [x] 自动锁定写入 `inventory_transactions` 的 `lock` 流水，并补齐发货需求操作日志 / ActivityTimeline 文案。
+  - [x] 为自动锁定动作设计稳定的 request/action key，防止重复确认收货导致重复 allocation 或重复锁定。
+  - [x] 并发或库存不足时返回明确业务错误，错误中包含当前可用量或并发冲突信息。
+- [x] 前端与接口回归（按需，AC: 3-5, 8）
+  - [x] 若现有详情接口未返回新的聚合结果或状态文本，补齐 API 层类型与详情映射；不新增独立页面。
+  - [x] 确认发货需求详情、销售订单详情、采购订单详情和收货入库详情能直接读到最新状态 / 数量缓存，无需手工刷新文案规则。
+- [x] 测试与验证（AC: 1-8）
+  - [x] 新增或更新后端测试，覆盖：请购型自动锁定、备货型跳过锁定、部分收货保持 `purchasing`、全部锁定后推进 `prepared`、重复确认幂等、销售订单缓存回填。
+  - [x] 运行 `pnpm --filter api exec jest modules/receipt-orders/tests --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/purchase-orders/tests --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`。
+  - [x] 运行 `pnpm --filter api build`。
+  - [x] 运行 `pnpm --filter web build`。
+  - [x] 运行 `git diff --check`。
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守以下三份 flow 文档：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic、旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 发货需求状态链必须遵守 `pending_allocation -> pending_purchase_order -> purchasing -> prepared`，Story 6.6 负责的是 `purchasing -> prepared` 这一段收货后自动推进。
+- 数量权威来源依次为：`receipt_order_items.received_quantity`、`shipping_demand_inventory_allocations`、`inventory_batch.batch_locked_quantity`、`inventory_summary`；销售订单明细上的 `preparedQuantity` 只是展示缓存。
+- 收货后自动锁定只允许锁定到“当前采购订单行关联的 `shippingDemandItemId`”，不能抢占其他发货需求。
+- 所有库存写操作必须使用现有 `InventoryService` + `QueryRunner` 事务能力，禁止直接手写 `UPDATE inventory_summary` / `inventory_batch` 绕过领域服务。
+- 自动锁定必须带稳定 `sourceActionKey`，避免重复确认收货导致数量重复累计。
+
+### Conflict Resolution
+
+- Story 6.5 已将采购订单收货状态修正为按累计收货数量聚合到 `partially_received` / `received`；Story 6.6 只扩展收货后的下游联动，不得推翻该口径。
+- `flow-quantity-data-lineage.md` 要求“部分收货只锁定实收数量”，因此自动锁定增量不能直接等于“当前剩余全部缺口”；应取 `min(本次实收数量, 当前未满足缺口)`。
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-29.md` 明确请购型采购订单创建成功才进入 `purchasing`，收货后全部锁定完成才进入 `prepared`；本 Story 不负责 `pending_purchase_order -> purchasing`。
+- `prepared_quantity`、`purchase_quantity`、`use_stock_quantity`、`shipped_quantity` 都是销售订单展示缓存，必须由后端聚合器回填，不能作为自动锁定的事实输入。
+
+### Source Context
+
+- Epic 6 Story 6.6 原始目标是“请购型采购订单收货后 FIFO 自动锁定到对应发货需求，并在全部锁定完成后推进发货需求与销售订单状态”。[Source: `_bmad-output/planning-artifacts/epics.md#Story 6.6`]
+- 2026-04-29 correct-course 明确 Story 6.6 必须引用 `sprint-change-proposal-2026-04-29.md` 和 `shipping-demand-status-flow-prototype.html`，且只承接 Story 6.3 的 `purchasing` 状态，不负责采购单创建入口。[Source: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-29.md`]
+- 数量权威文档要求：请购型收货确认后只自动锁定到对应发货需求，不抢占其他需求；部分收货保持 `purchasing`，直到全部应发数量锁定完成才推进 `prepared`。[Source: `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md#9.4`]
+- 状态机文档要求：发货需求从 `purchasing` 进入 `prepared` 的唯一入口是“请购型收货后自动锁定且全部应发数量已锁定到位”。[Source: `_bmad-output/planning-artifacts/flow-state-machine.md`]
+
+### Previous Story Intelligence
+
+- Story 5.6 已完成状态机纠偏，新增 `pending_purchase_order`，并把 Story 6.3 / 6.6 的职责边界重新固化；本 Story 必须继承该修正文档口径。
+- Story 6.3 已建立请购型采购订单与 `shippingDemandItemId` 的链路，并在采购单创建成功后把发货需求推进到 `purchasing`；Story 6.6 必须复用该关联而不是重新推导需求归属。
+- Story 6.5 已实现收货入库主从表、采购入库批次写入、采购订单收货数量回填，以及 `shipping_demand_items.received_quantity` 的刷新；Story 6.6 应在此基础上增加自动锁定与状态联动，而不是另起一套收货流程。
+- Story 6.5 的跟进补丁已经补齐收货入库列表 / 详情视图，因此本 Story 的重心在领域逻辑与状态展示结果，不在新增页面骨架。
+
+### Existing Code Map
+
+- `apps/api/src/modules/receipt-orders/receipt-orders.service.ts`
+  - `createInTransaction()` 已完成收货确认、采购入库批次写入、采购订单收货状态聚合，并在结尾刷新 `shipping_demand_items.received_quantity`。
+  - Story 6.6 的最佳接入点是该事务尾部，在采购入库完成后继续执行“请购型自动锁定 + 状态聚合”。
+- `apps/api/src/modules/shipping-demands/shipping-demands.service.ts`
+  - `confirmAllocationInTransaction()` 已经实现“使用现有库存”的 FIFO 锁定、allocation 写入、`lock` 库存流水和 `prepared` 推进，是 Story 6.6 最接近的可复用逻辑来源。
+  - 目前对 `SalesOrderItem.preparedQuantity` 的聚合回填较弱，Story 6.6 需要补齐统一聚合器，避免只更新 `SalesOrder.status`。
+- `apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts`
+  - 已提供批次级分配表结构与 `sourceActionKey + inventoryBatchId` 唯一约束，可直接承载收货后自动锁定结果。
+- `apps/api/src/modules/inventory/inventory.service.ts`
+  - `lockStockInTransaction()` 已支持按批次 FIFO 锁定库存并刷新汇总层，但不会自动写 `lock` 流水或发货需求 allocation 记录；这些仍需上层服务补齐。
+  - 死锁重试能力与 `CONCURRENT_UPDATE` 约束已经在库存服务中形成模式，应延续到 Story 6.6 的调用链。
+- `apps/api/src/modules/purchase-orders/purchase-orders.service.ts`
+  - 请购型采购订单创建时已经持久化 `shippingDemandItemId` 和 `purchaseOrderedQuantity` 回填；Story 6.6 不需要改写采购创建逻辑，只需复用它留下的关联字段。
+- `apps/api/src/modules/sales-orders/entities/sales-order-item.entity.ts`
+  - `preparedQuantity`、`purchaseQuantity`、`useStockQuantity`、`shippedQuantity` 仍然存在，按 flow 文档都应视为展示缓存；Story 6.6 可以补齐这些缓存中的 `preparedQuantity` 聚合回填。
+
+### Field List Reference
+
+本 Story 不是新的列表页/表单字段建设，当前未发现专门针对“收货后自动触发”的字段清单文档。字段与展示参考以以下资料为准：
+
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-04-29.md`
+- `_bmad-output/prototypes/shipping-demand-status-flow-prototype.html`
+- 现有发货需求详情、采购订单详情、收货入库详情接口与页面
+
+若用户后续提供额外字段清单或旧系统对照表，应以用户确认版本覆盖本节。
+
+### Candidate Search And Display Fields
+
+本 Story 不新增正式列表页，因此“搜索字段 / 列表展示字段”确认不适用。
+
+### UI / UX Guidance
+
+- 本 Story 以后台自动化为主，不新增独立页面；优先保证现有详情页在刷新后能看到正确的状态、数量缓存和时间线记录。
+- 若需要补充文案，保持与现有状态色彩映射一致：`purchasing` 为蓝色进行中，`prepared` 为绿色成功态。
+- ActivityTimeline / 操作日志文案需明确区分“采购入库”和“收货后自动锁定”，避免把两次动作混成一次笼统的“已收货”。
+
+### Testing Requirements
+
+- 后端测试至少覆盖：
+  - 请购型采购订单收货后按 FIFO 自动锁定，且锁定增量不超过本次实收数量。
+  - 备货型采购订单收货后不创建 allocation、不写 `lock` 库存流水。
+  - 部分收货后发货需求保持 `purchasing`；全部数量锁定完成后推进到 `prepared`。
+  - 销售订单明细 `preparedQuantity` 按 `lockedRemainingQuantity + shippedQuantity` 聚合回填。
+  - 重复确认同一收货请求时不重复锁定、不重复写 allocation / 流水。
+  - 并发锁定冲突或库存不足时返回明确业务错误。
+- 前端 / 集成验证至少覆盖：
+  - 发货需求详情、采购订单详情、收货入库详情读取到最新状态与数量。
+  - `pnpm --filter web build` 通过，API 类型与返回结构一致。
+- 统一验证命令：
+  - `pnpm --filter api exec jest modules/receipt-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/shipping-demands/tests --runInBand`
+  - `pnpm --filter api exec jest modules/purchase-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`
+  - `pnpm --filter api build`
+  - `pnpm --filter web build`
+  - `git diff --check`
+
+### Implementation Boundaries
+
+- 不新增新的通用状态修改接口，不通过通用 `PATCH` 直接改发货需求 / 销售订单状态。
+- 不实现物流单、出库单或发货需求作废链路调整；这些属于 Epic 7 / 已完成 Story 的职责。
+- 不让自动锁定跨到无关发货需求，也不把请购型到货自动转成“先锁全仓可用库存再补记需求归属”的近似实现。
+- 不新增绕过 `packages/shared` 的本地枚举，不新增绕过 `InventoryService` 的临时库存写接口。
+- 不为了 Story 6.6 回退或重构 Story 6.5 已合并的收货状态口径，除非发现明确缺陷且修复对本 Story 必要。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/ai_study/worktrees/story/6-6-receipt-auto-trigger`
+- Branch: `story/6-6-receipt-auto-trigger`
+- WORKTREE_MODE: `true`
+- 2026-05-01：已创建 Story 6.6 开发上下文，加载 Epic 5-7 三份强制 flow 文档、Story 5.6 / 6.3 / 6.5、2026-04-29 correct-course proposal、状态机原型与现有收货 / 发货需求 / 库存代码。
+- 2026-05-01：已记录关键冲突裁决：自动锁定增量受“本次实收数量”和“需求剩余缺口”双重约束；销售订单 `preparedQuantity` 作为展示缓存由后端聚合回填。
+- 2026-05-02：已在 `apps/api/src/modules/receipt-orders/receipt-orders.service.ts` 落地请购型收货后自动锁定、发货需求状态推进、销售订单展示缓存回填与操作日志。
+- 2026-05-02：`pnpm --filter api test -- --runInBand modules/receipt-orders/tests/receipt-orders.service.spec.ts` 通过（7 tests）。
+- 2026-05-02：`pnpm --filter api test -- --runInBand modules/shipping-demands/tests/shipping-demands.service.spec.ts` 通过（28 tests）。
+- 2026-05-02：`pnpm --filter api test -- --runInBand modules/purchase-orders/tests/purchase-orders.service.spec.ts` 通过（13 tests）。
+- 2026-05-02：`pnpm --filter api test -- --runInBand modules/inventory/tests/inventory.service.spec.ts` 通过（19 tests）。
+- 2026-05-02：`pnpm --filter api build` 通过。
+- 2026-05-02：`pnpm --filter web build` 通过；仅保留既有 Vite chunk size warning。
+- 2026-05-02：code review 完成，未发现需要修复的 patch finding。
+
+### Completion Notes List
+
+- Story file created by context engine with Epic 5-7 mandatory flow context.
+- Story 6.6 已与 Story 6.5 的最终合并状态对齐，避免继承旧的“部分收货直接全部收货”错误口径。
+- 已在收货确认事务中补齐请购型自动锁定闭环：按 FIFO 锁定到对应发货需求、写入 allocation 与 lock 流水，并按聚合结果推进发货需求 / 销售订单状态。
+- 已补齐销售订单明细 `purchaseQuantity` / `useStockQuantity` / `preparedQuantity` / `shippedQuantity` 的后端聚合回填。
+- 已补充收货模块单测，覆盖请购型自动锁定、备货型跳过自动锁定、部分收货保持 `purchasing`、缺口上限裁剪等关键场景。
+- 所有选定测试、构建和 code review 已完成，无未处理 review finding。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/6-6-收货后自动触发.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `apps/api/src/modules/receipt-orders/receipt-orders.service.ts`
+- `apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-05-01 | 0.1 | 创建 Story 6.6 开发上下文，加入 Epic 5-7 强制 flow 约束、Story 6.5 延续边界、收货后自动锁定与状态联动的实现守则 | GPT-5 Codex |
+| 2026-05-02 | 1.0 | 完成请购型收货后自动锁定、状态联动、测试验证与 code review，状态更新为 done | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-04-30 (story-6.5-done)
+# last_updated: 2026-05-02 (story-6.6-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-04-30 (story-6.5-done)
+last_updated: 2026-05-02 (story-6.6-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -124,7 +124,7 @@ development_status:
   6-3-采购订单创建与确认: done
   6-4-采购订单列表与详情: done
   6-5-收货入库单创建与确认: done
-  6-6-收货后自动触发: backlog
+  6-6-收货后自动触发: done
   epic-6-retrospective: optional
 
   # ─────────────────────────────────────────────────

--- a/apps/api/src/modules/receipt-orders/receipt-orders.service.ts
+++ b/apps/api/src/modules/receipt-orders/receipt-orders.service.ts
@@ -5,16 +5,21 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import {
+  InventoryChangeType,
   InventoryBatchSourceType,
   PurchaseOrderReceiptStatus,
   PurchaseOrderStatus,
   PurchaseOrderType,
   ReceiptOrderStatus,
   ReceiptOrderType,
+  SalesOrderStatus,
+  ShippingDemandAllocationStatus,
+  ShippingDemandStatus,
   YesNo,
 } from '@infitek/shared';
 import { In, QueryRunner } from 'typeorm';
 import { InventoryService } from '../inventory/inventory.service';
+import { InventoryTransaction } from '../inventory/entities/inventory-transaction.entity';
 import {
   OperationLog,
   OperationLogAction,
@@ -23,7 +28,11 @@ import { Company } from '../master-data/companies/entities/company.entity';
 import { Warehouse } from '../master-data/warehouses/entities/warehouse.entity';
 import { PurchaseOrderItem } from '../purchase-orders/entities/purchase-order-item.entity';
 import { PurchaseOrder } from '../purchase-orders/entities/purchase-order.entity';
+import { SalesOrderItem } from '../sales-orders/entities/sales-order-item.entity';
+import { SalesOrder } from '../sales-orders/entities/sales-order.entity';
+import { ShippingDemandInventoryAllocation } from '../shipping-demands/entities/shipping-demand-inventory-allocation.entity';
 import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
+import { ShippingDemand } from '../shipping-demands/entities/shipping-demand.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateReceiptOrderDto } from './dto/create-receipt-order.dto';
 import { QueryReceiptOrderDto } from './dto/query-receipt-order.dto';
@@ -38,6 +47,20 @@ const INITIAL_RETRY_DELAY_MS = 25;
 interface ReceiptWarehouseSnapshot {
   id: number;
   name: string;
+}
+
+interface ReceiptAutoLockEvent {
+  demandId: number;
+  demandCode: string;
+  demandItemId: number;
+  salesOrderId: number;
+  salesOrderItemId: number;
+  skuId: number;
+  skuCode: string;
+  warehouseId: number;
+  receiptItemId: number;
+  lockedQuantity: number;
+  batchAllocations: Array<{ batchId: number; quantity: number }>;
 }
 
 @Injectable()
@@ -375,6 +398,13 @@ export class ReceiptOrdersService {
         .filter((itemId): itemId is number => itemId != null),
       operator,
     );
+    await this.autoLockReceiptForRequisitionOrder(
+      queryRunner,
+      purchaseOrder,
+      receiptOrder,
+      savedReceiptItems,
+      operator,
+    );
 
     const aggregated = this.aggregatePurchaseOrderReceipt(
       purchaseOrder.items ?? [],
@@ -619,6 +649,694 @@ export class ReceiptOrdersService {
     }
 
     await shippingDemandItemRepo.save(items);
+  }
+
+  private async autoLockReceiptForRequisitionOrder(
+    queryRunner: QueryRunner,
+    purchaseOrder: PurchaseOrder,
+    receiptOrder: ReceiptOrder,
+    receiptItems: ReceiptOrderItem[],
+    operator?: string,
+  ): Promise<void> {
+    if (purchaseOrder.orderType !== PurchaseOrderType.REQUISITION) {
+      return;
+    }
+
+    const demandItemIds = [
+      ...new Set(
+        receiptItems
+          .map((item) =>
+            item.shippingDemandItemId == null
+              ? null
+              : Number(item.shippingDemandItemId),
+          )
+          .filter((itemId): itemId is number => itemId != null),
+      ),
+    ];
+    if (!demandItemIds.length) {
+      return;
+    }
+
+    const demandIds =
+      purchaseOrder.shippingDemandId != null
+        ? [Number(purchaseOrder.shippingDemandId)]
+        : [
+            ...new Set(
+              (
+                await queryRunner.manager
+                  .getRepository(ShippingDemandItem)
+                  .find({
+                    where: { id: In(demandItemIds) },
+                  })
+              )
+                .map((item) => Number(item.shippingDemandId))
+                .filter((demandId) => demandId > 0),
+            ),
+          ];
+    const demands = await this.findShippingDemandsForUpdate(
+      queryRunner,
+      demandIds,
+    );
+    const demandById = new Map(
+      demands.map((demand) => [Number(demand.id), demand]),
+    );
+    const demandItemById = new Map<number, ShippingDemandItem>();
+    const oldDemandStatusById = new Map<number, ShippingDemandStatus>();
+    for (const demand of demands) {
+      oldDemandStatusById.set(
+        Number(demand.id),
+        demand.status as ShippingDemandStatus,
+      );
+      for (const item of demand.items ?? []) {
+        demandItemById.set(Number(item.id), item);
+      }
+    }
+
+    const activeLockedByItemId =
+      await this.sumActiveLockedQuantityByDemandItemIds(
+        queryRunner,
+        demandItemIds,
+      );
+    const allocationRepo = queryRunner.manager.getRepository(
+      ShippingDemandInventoryAllocation,
+    );
+    const inventoryTransactionRepo =
+      queryRunner.manager.getRepository(InventoryTransaction);
+    const events: ReceiptAutoLockEvent[] = [];
+
+    for (const receiptItem of receiptItems) {
+      const demandItemId =
+        receiptItem.shippingDemandItemId == null
+          ? null
+          : Number(receiptItem.shippingDemandItemId);
+      if (demandItemId == null) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_DEMAND_LINK_MISSING',
+          message: '请购型采购订单收货明细缺少发货需求关联',
+        });
+      }
+
+      const demandItem = demandItemById.get(demandItemId);
+      if (!demandItem) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_DEMAND_ITEM_NOT_FOUND',
+          message: '收货明细关联的发货需求不存在',
+        });
+      }
+
+      const demand = demandById.get(Number(demandItem.shippingDemandId));
+      if (!demand) {
+        throw new BadRequestException({
+          code: 'RECEIPT_ORDER_DEMAND_NOT_FOUND',
+          message: '收货明细关联的发货需求不存在',
+        });
+      }
+
+      const currentLockedQuantity =
+        activeLockedByItemId.get(demandItemId) ??
+        Number(demandItem.lockedRemainingQuantity ?? 0);
+      const remainingGap = Math.max(
+        0,
+        Number(demandItem.requiredQuantity ?? 0) -
+          Number(demandItem.shippedQuantity ?? 0) -
+          currentLockedQuantity,
+      );
+      const lockQuantity = Math.min(
+        Number(receiptItem.receivedQuantity ?? 0),
+        remainingGap,
+      );
+      if (lockQuantity <= 0) {
+        continue;
+      }
+
+      const warehouseId = Number(receiptItem.warehouseId);
+      const lockResult = await this.inventoryService.lockStockInTransaction(
+        queryRunner,
+        {
+          skuId: Number(receiptItem.skuId),
+          warehouseId,
+          quantity: lockQuantity,
+          operator,
+        },
+      );
+
+      const actionKey = this.buildReceiptAutoLockActionKey(
+        receiptOrder,
+        receiptItem,
+        demandItem,
+      );
+      const allocations = lockResult.allocations ?? [];
+      if (allocations.length > 0) {
+        await allocationRepo.save(
+          allocations.map((allocation) =>
+            allocationRepo.create({
+              shippingDemandId: Number(demand.id),
+              shippingDemandItemId: Number(demandItem.id),
+              salesOrderItemId: Number(demandItem.salesOrderItemId),
+              skuId: Number(demandItem.skuId),
+              warehouseId,
+              inventoryBatchId: allocation.batchId,
+              lockSource: 'purchase_receipt',
+              sourceDocumentType: 'receipt_order',
+              sourceDocumentId: Number(receiptOrder.id),
+              originalLockedQuantity: allocation.quantity,
+              lockedQuantity: allocation.quantity,
+              shippedQuantity: 0,
+              releasedQuantity: 0,
+              status: ShippingDemandAllocationStatus.ACTIVE,
+              sourceActionKey: actionKey,
+              createdBy: operator,
+              updatedBy: operator,
+            }),
+          ),
+        );
+      }
+
+      await inventoryTransactionRepo.save(
+        inventoryTransactionRepo.create(
+          this.buildReceiptAutoLockInventoryTransaction(
+            receiptOrder,
+            receiptItem,
+            demandItem,
+            warehouseId,
+            lockQuantity,
+            {
+              actualQuantity: Number(lockResult.summary.actualQuantity ?? 0),
+              lockedQuantity: Number(lockResult.summary.lockedQuantity ?? 0),
+              availableQuantity: Number(
+                lockResult.summary.availableQuantity ?? 0,
+              ),
+            },
+            operator,
+          ),
+        ),
+      );
+
+      activeLockedByItemId.set(
+        demandItemId,
+        currentLockedQuantity + lockQuantity,
+      );
+      events.push({
+        demandId: Number(demand.id),
+        demandCode: demand.demandCode,
+        demandItemId: Number(demandItem.id),
+        salesOrderId: Number(demand.salesOrderId),
+        salesOrderItemId: Number(demandItem.salesOrderItemId),
+        skuId: Number(demandItem.skuId),
+        skuCode: demandItem.skuCode,
+        warehouseId,
+        receiptItemId: Number(receiptItem.id),
+        lockedQuantity: lockQuantity,
+        batchAllocations: allocations.map((allocation) => ({
+          batchId: Number(allocation.batchId),
+          quantity: Number(allocation.quantity ?? 0),
+        })),
+      });
+    }
+
+    await this.refreshShippingDemandLockedQuantity(
+      queryRunner,
+      demandItemIds,
+      operator,
+    );
+
+    const refreshedDemands = await this.findShippingDemandsForUpdate(
+      queryRunner,
+      [...demandById.keys()],
+    );
+    const salesOrderItemIds = [
+      ...new Set(
+        refreshedDemands.flatMap((demand) =>
+          (demand.items ?? [])
+            .map((item) => Number(item.salesOrderItemId))
+            .filter((itemId) => itemId > 0),
+        ),
+      ),
+    ];
+    await this.refreshSalesOrderItemSnapshots(
+      queryRunner,
+      salesOrderItemIds,
+      operator,
+    );
+    await this.updateShippingDemandStatusesAfterReceipt(
+      queryRunner,
+      refreshedDemands,
+      operator,
+    );
+    const salesOrderStatusChanges =
+      await this.updateSalesOrderStatusesAfterReceipt(
+        queryRunner,
+        refreshedDemands,
+        operator,
+      );
+
+    await this.writeReceiptAutoLockOperationLogs(
+      queryRunner,
+      receiptOrder,
+      refreshedDemands,
+      oldDemandStatusById,
+      events,
+      operator,
+    );
+    for (const change of salesOrderStatusChanges) {
+      await this.writeSalesOrderPreparedOperationLog(
+        queryRunner,
+        receiptOrder,
+        change.order,
+        change.oldStatus,
+        operator,
+      );
+    }
+  }
+
+  private async findShippingDemandsForUpdate(
+    queryRunner: QueryRunner,
+    demandIds: number[],
+  ): Promise<ShippingDemand[]> {
+    if (!demandIds.length) return [];
+
+    return queryRunner.manager
+      .getRepository(ShippingDemand)
+      .createQueryBuilder('demand')
+      .leftJoinAndSelect('demand.items', 'items')
+      .setLock('pessimistic_write')
+      .where('demand.id IN (:...demandIds)', { demandIds })
+      .orderBy('demand.id', 'ASC')
+      .addOrderBy('items.id', 'ASC')
+      .getMany();
+  }
+
+  private async sumActiveLockedQuantityByDemandItemIds(
+    queryRunner: QueryRunner,
+    demandItemIds: number[],
+  ): Promise<Map<number, number>> {
+    if (!demandItemIds.length) return new Map();
+
+    const rows = await queryRunner.manager
+      .getRepository(ShippingDemandInventoryAllocation)
+      .createQueryBuilder('allocation')
+      .select('allocation.shipping_demand_item_id', 'shippingDemandItemId')
+      .addSelect('SUM(allocation.locked_quantity)', 'lockedQuantity')
+      .where('allocation.shipping_demand_item_id IN (:...demandItemIds)', {
+        demandItemIds,
+      })
+      .andWhere('allocation.status = :status', {
+        status: ShippingDemandAllocationStatus.ACTIVE,
+      })
+      .groupBy('allocation.shipping_demand_item_id')
+      .getRawMany<{
+        shippingDemandItemId: string;
+        lockedQuantity: string;
+      }>();
+
+    return new Map(
+      rows.map((row) => [
+        Number(row.shippingDemandItemId),
+        Number(row.lockedQuantity ?? 0),
+      ]),
+    );
+  }
+
+  private async refreshShippingDemandLockedQuantity(
+    queryRunner: QueryRunner,
+    demandItemIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!demandItemIds.length) return;
+
+    const lockedByItemId = await this.sumActiveLockedQuantityByDemandItemIds(
+      queryRunner,
+      demandItemIds,
+    );
+    const shippingDemandItemRepo =
+      queryRunner.manager.getRepository(ShippingDemandItem);
+    const items = await shippingDemandItemRepo.find({
+      where: { id: In(demandItemIds) },
+    });
+
+    for (const item of items) {
+      item.lockedRemainingQuantity =
+        lockedByItemId.get(Number(item.id)) ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await shippingDemandItemRepo.save(items);
+  }
+
+  private async refreshSalesOrderItemSnapshots(
+    queryRunner: QueryRunner,
+    salesOrderItemIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!salesOrderItemIds.length) return;
+
+    const rows = await queryRunner.manager
+      .getRepository(ShippingDemandItem)
+      .createQueryBuilder('item')
+      .innerJoin('item.shippingDemand', 'demand')
+      .select('item.sales_order_item_id', 'salesOrderItemId')
+      .addSelect('SUM(item.purchase_required_quantity)', 'purchaseQuantity')
+      .addSelect('SUM(item.stock_required_quantity)', 'useStockQuantity')
+      .addSelect('SUM(item.locked_remaining_quantity)', 'lockedQuantity')
+      .addSelect('SUM(item.shipped_quantity)', 'shippedQuantity')
+      .where('item.sales_order_item_id IN (:...salesOrderItemIds)', {
+        salesOrderItemIds,
+      })
+      .andWhere('demand.status != :voided', {
+        voided: ShippingDemandStatus.VOIDED,
+      })
+      .groupBy('item.sales_order_item_id')
+      .getRawMany<{
+        salesOrderItemId: string;
+        purchaseQuantity: string;
+        useStockQuantity: string;
+        lockedQuantity: string;
+        shippedQuantity: string;
+      }>();
+
+    const snapshotByItemId = new Map(
+      rows.map((row) => [
+        Number(row.salesOrderItemId),
+        {
+          purchaseQuantity: Number(row.purchaseQuantity ?? 0),
+          useStockQuantity: Number(row.useStockQuantity ?? 0),
+          preparedQuantity:
+            Number(row.lockedQuantity ?? 0) + Number(row.shippedQuantity ?? 0),
+          shippedQuantity: Number(row.shippedQuantity ?? 0),
+        },
+      ]),
+    );
+    const salesOrderItemRepo = queryRunner.manager.getRepository(SalesOrderItem);
+    const items = await salesOrderItemRepo.find({
+      where: { id: In(salesOrderItemIds) },
+    });
+
+    for (const item of items) {
+      const snapshot = snapshotByItemId.get(Number(item.id));
+      item.purchaseQuantity = snapshot?.purchaseQuantity ?? 0;
+      item.useStockQuantity = snapshot?.useStockQuantity ?? 0;
+      item.preparedQuantity = snapshot?.preparedQuantity ?? 0;
+      item.shippedQuantity = snapshot?.shippedQuantity ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await salesOrderItemRepo.save(items);
+  }
+
+  private async updateShippingDemandStatusesAfterReceipt(
+    queryRunner: QueryRunner,
+    demands: ShippingDemand[],
+    operator?: string,
+  ): Promise<ShippingDemand[]> {
+    const demandRepo = queryRunner.manager.getRepository(ShippingDemand);
+    const changed: ShippingDemand[] = [];
+
+    for (const demand of demands) {
+      if (
+        demand.status === ShippingDemandStatus.VOIDED ||
+        demand.status === ShippingDemandStatus.SHIPPED ||
+        demand.status === ShippingDemandStatus.PARTIALLY_SHIPPED
+      ) {
+        continue;
+      }
+
+      const items = demand.items ?? [];
+      const allPrepared =
+        items.length > 0 &&
+        items.every(
+          (item) =>
+            Number(item.lockedRemainingQuantity ?? 0) +
+              Number(item.shippedQuantity ?? 0) >=
+            Number(item.requiredQuantity ?? 0),
+        );
+
+      let nextStatus = demand.status;
+      if (allPrepared) {
+        nextStatus = ShippingDemandStatus.PREPARED;
+      } else if (
+        demand.status === ShippingDemandStatus.PENDING_PURCHASE_ORDER ||
+        demand.status === ShippingDemandStatus.PURCHASING
+      ) {
+        nextStatus = ShippingDemandStatus.PURCHASING;
+      }
+
+      if (nextStatus === demand.status) {
+        continue;
+      }
+
+      demand.status = nextStatus;
+      if (operator !== undefined) {
+        demand.updatedBy = operator;
+      }
+      changed.push(await demandRepo.save(demand));
+    }
+
+    return changed;
+  }
+
+  private async updateSalesOrderStatusesAfterReceipt(
+    queryRunner: QueryRunner,
+    demands: ShippingDemand[],
+    operator?: string,
+  ): Promise<Array<{ order: SalesOrder; oldStatus: SalesOrderStatus }>> {
+    const preparedDemandBySalesOrderId = new Map<number, ShippingDemand>();
+    for (const demand of demands) {
+      if (demand.status === ShippingDemandStatus.PREPARED) {
+        preparedDemandBySalesOrderId.set(Number(demand.salesOrderId), demand);
+      }
+    }
+    const salesOrderIds = [...preparedDemandBySalesOrderId.keys()];
+    if (!salesOrderIds.length) return [];
+
+    const orders = await queryRunner.manager
+      .getRepository(SalesOrder)
+      .createQueryBuilder('salesOrder')
+      .setLock('pessimistic_write')
+      .where('salesOrder.id IN (:...salesOrderIds)', { salesOrderIds })
+      .getMany();
+    const salesOrderRepo = queryRunner.manager.getRepository(SalesOrder);
+    const changes: Array<{ order: SalesOrder; oldStatus: SalesOrderStatus }> =
+      [];
+
+    for (const order of orders) {
+      if (
+        order.status === SalesOrderStatus.PREPARED ||
+        order.status === SalesOrderStatus.PARTIALLY_SHIPPED ||
+        order.status === SalesOrderStatus.SHIPPED ||
+        order.status === SalesOrderStatus.VOIDED
+      ) {
+        continue;
+      }
+
+      const oldStatus = order.status as SalesOrderStatus;
+      order.status = SalesOrderStatus.PREPARED;
+      if (operator !== undefined) {
+        order.updatedBy = operator;
+      }
+      changes.push({
+        order: await salesOrderRepo.save(order),
+        oldStatus,
+      });
+    }
+
+    return changes;
+  }
+
+  private async writeReceiptAutoLockOperationLogs(
+    queryRunner: QueryRunner,
+    receiptOrder: ReceiptOrder,
+    demands: ShippingDemand[],
+    oldDemandStatusById: Map<number, ShippingDemandStatus>,
+    events: ReceiptAutoLockEvent[],
+    operator?: string,
+  ): Promise<void> {
+    const eventsByDemandId = new Map<number, ReceiptAutoLockEvent[]>();
+    for (const event of events) {
+      const group = eventsByDemandId.get(event.demandId) ?? [];
+      group.push(event);
+      eventsByDemandId.set(event.demandId, group);
+    }
+
+    const operationLogRepo = queryRunner.manager.getRepository(OperationLog);
+    for (const demand of demands) {
+      const demandId = Number(demand.id);
+      const demandEvents = eventsByDemandId.get(demandId) ?? [];
+      const oldStatus = oldDemandStatusById.get(demandId) ?? demand.status;
+      const changeSummary: Array<{
+        field: string;
+        fieldLabel: string;
+        oldValue: unknown;
+        newValue: unknown;
+      }> = [];
+
+      if (oldStatus !== demand.status) {
+        changeSummary.push({
+          field: 'status',
+          fieldLabel: '发货需求状态',
+          oldValue: oldStatus,
+          newValue: demand.status,
+        });
+      }
+      if (demandEvents.length > 0) {
+        changeSummary.push({
+          field: 'allocationSummary',
+          fieldLabel: '自动锁定结果',
+          oldValue: null,
+          newValue: this.buildReceiptAutoLockOperationSummary(demandEvents),
+        });
+        changeSummary.push({
+          field: 'allocationDetails',
+          fieldLabel: '自动锁定明细',
+          oldValue: null,
+          newValue: this.buildReceiptAutoLockOperationDetails(demandEvents),
+        });
+      }
+
+      if (!changeSummary.length) {
+        continue;
+      }
+
+      await operationLogRepo.save(
+        operationLogRepo.create({
+          operator: operator ?? 'system',
+          operatorId: null,
+          action: OperationLogAction.UPDATE,
+          resourceType: 'shipping-demands',
+          resourceId: String(demand.id),
+          resourcePath: `/api/receipt-orders/${receiptOrder.id}`,
+          requestSummary: {
+            sourceAction: 'receipt_auto_lock',
+            receiptOrderId: Number(receiptOrder.id),
+            receiptCode: receiptOrder.receiptCode,
+            lockedQuantity: demandEvents.reduce(
+              (sum, event) => sum + event.lockedQuantity,
+              0,
+            ),
+            itemCount: demandEvents.length,
+          },
+          changeSummary,
+        }),
+      );
+    }
+  }
+
+  private async writeSalesOrderPreparedOperationLog(
+    queryRunner: QueryRunner,
+    receiptOrder: ReceiptOrder,
+    order: SalesOrder,
+    oldStatus: SalesOrderStatus,
+    operator?: string,
+  ): Promise<void> {
+    const operationLogRepo = queryRunner.manager.getRepository(OperationLog);
+    await operationLogRepo.save(
+      operationLogRepo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.UPDATE,
+        resourceType: 'sales-orders',
+        resourceId: String(order.id),
+        resourcePath: `/api/receipt-orders/${receiptOrder.id}`,
+        requestSummary: {
+          sourceAction: 'receipt_auto_lock',
+          receiptOrderId: Number(receiptOrder.id),
+          receiptCode: receiptOrder.receiptCode,
+        },
+        changeSummary: [
+          {
+            field: 'status',
+            fieldLabel: '订单状态',
+            oldValue: oldStatus,
+            newValue: order.status,
+          },
+        ],
+      }),
+    );
+  }
+
+  private buildReceiptAutoLockOperationSummary(
+    events: ReceiptAutoLockEvent[],
+  ): string {
+    const lockedQuantity = events.reduce(
+      (sum, event) => sum + event.lockedQuantity,
+      0,
+    );
+    return `共 ${events.length} 条收货明细触发自动锁定；锁定数量 ${lockedQuantity}`;
+  }
+
+  private buildReceiptAutoLockOperationDetails(
+    events: ReceiptAutoLockEvent[],
+  ): string {
+    return events
+      .map((event, index) => {
+        const batchText = event.batchAllocations
+          .map((allocation) => `批次 ${allocation.batchId} 锁定 ${allocation.quantity}`)
+          .join('，');
+        return `${index + 1}. ${event.skuCode}：仓库 ${event.warehouseId}，本次锁定 ${event.lockedQuantity}${batchText ? `（${batchText}）` : ''}`;
+      })
+      .join('\n');
+  }
+
+  private buildReceiptAutoLockActionKey(
+    receiptOrder: ReceiptOrder,
+    receiptItem: ReceiptOrderItem,
+    demandItem: ShippingDemandItem,
+  ): string {
+    return `receipt-order:${receiptOrder.id}:item:${receiptItem.id}:shipping-demand-item:${demandItem.id}:lock`;
+  }
+
+  private buildReceiptAutoLockInventoryTransactionActionKey(
+    receiptOrder: ReceiptOrder,
+    receiptItem: ReceiptOrderItem,
+    demandItem: ShippingDemandItem,
+  ): string {
+    return `receipt-order:${receiptOrder.id}:item:${receiptItem.id}:shipping-demand-item:${demandItem.id}:inventory-lock`;
+  }
+
+  private buildReceiptAutoLockInventoryTransaction(
+    receiptOrder: ReceiptOrder,
+    receiptItem: ReceiptOrderItem,
+    demandItem: ShippingDemandItem,
+    warehouseId: number,
+    lockedQuantity: number,
+    summary: {
+      actualQuantity: number;
+      lockedQuantity: number;
+      availableQuantity: number;
+    },
+    operator?: string,
+  ) {
+    const afterActual = Number(summary.actualQuantity ?? 0);
+    const afterLocked = Number(summary.lockedQuantity ?? 0);
+    const afterAvailable = Number(summary.availableQuantity ?? 0);
+
+    return {
+      skuId: Number(demandItem.skuId),
+      warehouseId,
+      inventoryBatchId: null,
+      changeType: InventoryChangeType.LOCK,
+      actualQuantityDelta: 0,
+      lockedQuantityDelta: lockedQuantity,
+      availableQuantityDelta: -lockedQuantity,
+      beforeActualQuantity: afterActual,
+      afterActualQuantity: afterActual,
+      beforeLockedQuantity: afterLocked - lockedQuantity,
+      afterLockedQuantity: afterLocked,
+      beforeAvailableQuantity: afterAvailable + lockedQuantity,
+      afterAvailableQuantity: afterAvailable,
+      sourceDocumentType: 'receipt_order',
+      sourceDocumentId: Number(receiptOrder.id),
+      sourceDocumentItemId: Number(receiptItem.id),
+      sourceActionKey: this.buildReceiptAutoLockInventoryTransactionActionKey(
+        receiptOrder,
+        receiptItem,
+        demandItem,
+      ),
+      operatedBy: operator ?? 'system',
+    };
   }
 
   private async writeOperationLogs(

--- a/apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts
+++ b/apps/api/src/modules/receipt-orders/tests/receipt-orders.service.spec.ts
@@ -1,10 +1,15 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import {
+  InventoryChangeType,
   InventoryBatchSourceType,
   PurchaseOrderReceiptStatus,
   PurchaseOrderStatus,
+  PurchaseOrderType,
   ReceiptOrderStatus,
   ReceiptOrderType,
+  SalesOrderStatus,
+  ShippingDemandAllocationStatus,
+  ShippingDemandStatus,
   YesNo,
 } from '@infitek/shared';
 import {
@@ -15,7 +20,12 @@ import { Company } from '../../master-data/companies/entities/company.entity';
 import { Warehouse } from '../../master-data/warehouses/entities/warehouse.entity';
 import { PurchaseOrderItem } from '../../purchase-orders/entities/purchase-order-item.entity';
 import { PurchaseOrder } from '../../purchase-orders/entities/purchase-order.entity';
+import { SalesOrderItem } from '../../sales-orders/entities/sales-order-item.entity';
+import { SalesOrder } from '../../sales-orders/entities/sales-order.entity';
+import { ShippingDemandInventoryAllocation } from '../../shipping-demands/entities/shipping-demand-inventory-allocation.entity';
 import { ShippingDemandItem } from '../../shipping-demands/entities/shipping-demand-item.entity';
+import { ShippingDemand } from '../../shipping-demands/entities/shipping-demand.entity';
+import { InventoryTransaction } from '../../inventory/entities/inventory-transaction.entity';
 import { User } from '../../users/entities/user.entity';
 import { ReceiptOrderItem } from '../entities/receipt-order-item.entity';
 import { ReceiptOrder } from '../entities/receipt-order.entity';
@@ -31,7 +41,77 @@ describe('ReceiptOrdersService', () => {
 
   const inventoryService = {
     increaseStockInTransaction: jest.fn(),
+    lockStockInTransaction: jest.fn(),
   };
+
+  const syncShippingDemandItems = (state: Record<string, any>, data: any) => {
+    const items = Array.isArray(data) ? data : [data];
+    state.shippingDemandItems = items.map((item: any) => ({ ...item }));
+    const demandById = new Map(
+      (state.shippingDemands ?? []).map((demand: any) => [Number(demand.id), demand]),
+    );
+    for (const item of state.shippingDemandItems) {
+      const demand = demandById.get(Number(item.shippingDemandId));
+      if (!demand) continue;
+      const existingItems = demand.items ?? [];
+      const nextItems = existingItems.filter(
+        (current: any) => Number(current.id) !== Number(item.id),
+      );
+      nextItems.push(item);
+      nextItems.sort((a: any, b: any) => Number(a.id) - Number(b.id));
+      demand.items = nextItems;
+    }
+  };
+
+  const syncSalesOrderItems = (state: Record<string, any>, data: any) => {
+    const items = Array.isArray(data) ? data : [data];
+    state.salesOrderItems = items.map((item: any) => ({ ...item }));
+  };
+
+  const makeShippingDemand = (
+    overrides: Partial<ShippingDemand> = {},
+  ): Partial<ShippingDemand> => ({
+    id: 700,
+    demandCode: 'XCFH202604300001',
+    salesOrderId: 1100,
+    status: ShippingDemandStatus.PURCHASING,
+    items: [
+      {
+        id: 701,
+        shippingDemandId: 700,
+        salesOrderItemId: 1201,
+        skuId: 11,
+        skuCode: 'SKU001',
+        requiredQuantity: 5,
+        lockedRemainingQuantity: 1,
+        shippedQuantity: 0,
+        purchaseRequiredQuantity: 5,
+        stockRequiredQuantity: 0,
+        purchaseOrderedQuantity: 5,
+        receivedQuantity: 1,
+      },
+    ] as any,
+    ...overrides,
+  });
+
+  const makeSalesOrder = (
+    overrides: Partial<SalesOrder> = {},
+  ): Partial<SalesOrder> => ({
+    id: 1100,
+    status: SalesOrderStatus.PREPARING,
+    ...overrides,
+  });
+
+  const makeSalesOrderItem = (
+    overrides: Partial<SalesOrderItem> = {},
+  ): Partial<SalesOrderItem> => ({
+    id: 1201,
+    purchaseQuantity: 5,
+    useStockQuantity: 0,
+    preparedQuantity: 1,
+    shippedQuantity: 0,
+    ...overrides,
+  });
 
   const makePurchaseOrder = (
     overrides: Partial<PurchaseOrder> = {},
@@ -46,6 +126,7 @@ describe('ReceiptOrdersService', () => {
     purchaseCompanyName: '信达主体',
     shippingDemandId: 700,
     shippingDemandCode: 'XCFH202604300001',
+    orderType: PurchaseOrderType.REQUISITION,
     totalQuantity: 5,
     receivedTotalQuantity: 1,
     items: [
@@ -86,6 +167,34 @@ describe('ReceiptOrdersService', () => {
       where: jest.fn(() => qb),
       orderBy: jest.fn(() => qb),
       getOne: jest.fn().mockResolvedValue(state.latestReceiptOrder ?? null),
+    };
+    return qb;
+  };
+
+  const makeShippingDemandQueryBuilder = (state: Record<string, any>) => {
+    const qb = {
+      leftJoinAndSelect: jest.fn(() => qb),
+      setLock: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      orderBy: jest.fn(() => qb),
+      addOrderBy: jest.fn(() => qb),
+      getMany: jest.fn().mockImplementation(async () =>
+        (state.shippingDemands ?? []).map((demand: any) => ({
+          ...demand,
+          items: [...(demand.items ?? [])],
+        })),
+      ),
+    };
+    return qb;
+  };
+
+  const makeSalesOrderQueryBuilder = (state: Record<string, any>) => {
+    const qb = {
+      setLock: jest.fn(() => qb),
+      where: jest.fn(() => qb),
+      getMany: jest.fn().mockImplementation(async () =>
+        (state.salesOrders ?? []).map((order: any) => ({ ...order })),
+      ),
     };
     return qb;
   };
@@ -143,17 +252,178 @@ describe('ReceiptOrdersService', () => {
     }
     if (entity === ShippingDemandItem) {
       return {
+        createQueryBuilder: jest.fn(() => {
+          const qb = {
+            innerJoin: jest.fn(() => qb),
+            select: jest.fn(() => qb),
+            addSelect: jest.fn(() => qb),
+            where: jest.fn(() => qb),
+            andWhere: jest.fn(() => qb),
+            groupBy: jest.fn(() => qb),
+            getRawMany: jest.fn().mockImplementation(async () => {
+              const demandStatusById = new Map(
+                (state.shippingDemands ?? []).map((demand: any) => [
+                  Number(demand.id),
+                  demand.status,
+                ]),
+              );
+              const totals = new Map<
+                number,
+                {
+                  purchaseQuantity: number;
+                  useStockQuantity: number;
+                  lockedQuantity: number;
+                  shippedQuantity: number;
+                }
+              >();
+              for (const item of state.shippingDemandItems ?? []) {
+                if (
+                  demandStatusById.get(Number(item.shippingDemandId)) ===
+                  ShippingDemandStatus.VOIDED
+                ) {
+                  continue;
+                }
+                const key = Number(item.salesOrderItemId);
+                const current = totals.get(key) ?? {
+                  purchaseQuantity: 0,
+                  useStockQuantity: 0,
+                  lockedQuantity: 0,
+                  shippedQuantity: 0,
+                };
+                current.purchaseQuantity += Number(
+                  item.purchaseRequiredQuantity ?? 0,
+                );
+                current.useStockQuantity += Number(
+                  item.stockRequiredQuantity ?? 0,
+                );
+                current.lockedQuantity += Number(
+                  item.lockedRemainingQuantity ?? 0,
+                );
+                current.shippedQuantity += Number(item.shippedQuantity ?? 0);
+                totals.set(key, current);
+              }
+              return [...totals.entries()].map(
+                ([salesOrderItemId, aggregate]) => ({
+                  salesOrderItemId: String(salesOrderItemId),
+                  purchaseQuantity: String(aggregate.purchaseQuantity),
+                  useStockQuantity: String(aggregate.useStockQuantity),
+                  lockedQuantity: String(aggregate.lockedQuantity),
+                  shippedQuantity: String(aggregate.shippedQuantity),
+                }),
+              );
+            }),
+          };
+          return qb;
+        }),
         find: jest.fn().mockResolvedValue(
-          state.shippingDemandItems ?? [
-            {
-              id: 701,
-              receivedQuantity: 1,
-            },
-          ],
+          state.shippingDemandItems ?? makeShippingDemand().items,
         ),
         save: jest.fn().mockImplementation(async (data) => {
           state.savedShippingDemandItems = Array.isArray(data) ? data : [data];
+          syncShippingDemandItems(state, data);
           return data;
+        }),
+      };
+    }
+    if (entity === ShippingDemand) {
+      return {
+        createQueryBuilder: jest.fn(() => makeShippingDemandQueryBuilder(state)),
+        save: jest.fn().mockImplementation(async (data) => {
+          const items = Array.isArray(data) ? data : [data];
+          state.shippingDemands = items.map((item: any) => ({
+            ...item,
+            items: [...(item.items ?? [])],
+          }));
+          state.savedShippingDemands = state.shippingDemands;
+          return data;
+        }),
+      };
+    }
+    if (entity === ShippingDemandInventoryAllocation) {
+      return {
+        createQueryBuilder: jest.fn(() => {
+          const qb = {
+            select: jest.fn(() => qb),
+            addSelect: jest.fn(() => qb),
+            where: jest.fn(() => qb),
+            andWhere: jest.fn(() => qb),
+            groupBy: jest.fn(() => qb),
+            getRawMany: jest.fn().mockImplementation(async () => {
+              const totals = new Map<number, number>();
+              for (const allocation of state.allocations ?? []) {
+                if (
+                  allocation.status !== ShippingDemandAllocationStatus.ACTIVE
+                ) {
+                  continue;
+                }
+                const key = Number(allocation.shippingDemandItemId);
+                totals.set(
+                  key,
+                  (totals.get(key) ?? 0) +
+                    Number(allocation.lockedQuantity ?? 0),
+                );
+              }
+              return [...totals.entries()].map(
+                ([shippingDemandItemId, lockedQuantity]) => ({
+                  shippingDemandItemId: String(shippingDemandItemId),
+                  lockedQuantity: String(lockedQuantity),
+                }),
+              );
+            }),
+          };
+          return qb;
+        }),
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          const items = Array.isArray(data) ? data : [data];
+          state.allocations = [...(state.allocations ?? []), ...items];
+          state.savedAllocations = [...(state.savedAllocations ?? []), ...items];
+          return data;
+        }),
+      };
+    }
+    if (entity === InventoryTransaction) {
+      return {
+        create: jest.fn((data) => data),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedInventoryTransactions = [
+            ...(state.savedInventoryTransactions ?? []),
+            ...(Array.isArray(data) ? data : [data]),
+          ];
+          return data;
+        }),
+      };
+    }
+    if (entity === SalesOrderItem) {
+      return {
+        find: jest.fn().mockResolvedValue(
+          state.salesOrderItems ?? [makeSalesOrderItem()],
+        ),
+        save: jest.fn().mockImplementation(async (data) => {
+          state.savedSalesOrderItems = Array.isArray(data) ? data : [data];
+          syncSalesOrderItems(state, data);
+          return data;
+        }),
+      };
+    }
+    if (entity === SalesOrder) {
+      return {
+        createQueryBuilder: jest.fn(() => makeSalesOrderQueryBuilder(state)),
+        save: jest.fn().mockImplementation(async (data) => {
+          const item = { ...data };
+          const nextOrders = (state.salesOrders ?? []).map((order: any) =>
+            Number(order.id) === Number(item.id) ? item : order,
+          );
+          state.salesOrders = nextOrders.some(
+            (order: any) => Number(order.id) === Number(item.id),
+          )
+            ? nextOrders
+            : [...nextOrders, item];
+          state.savedSalesOrders = [
+            ...(state.savedSalesOrders ?? []),
+            item,
+          ];
+          return item;
         }),
       };
     }
@@ -272,6 +542,7 @@ describe('ReceiptOrdersService', () => {
   });
 
   it('creates a confirmed receipt order and updates purchase order receipt status', async () => {
+    const shippingDemand = makeShippingDemand();
     const state: Record<string, any> = {
       purchaseOrder: makePurchaseOrder(),
       purchaseOrderQueryMode: 'find',
@@ -279,6 +550,17 @@ describe('ReceiptOrdersService', () => {
       warehouses: [{ id: 10, name: '深圳仓' }],
       receiver: { id: 20, name: '仓管小李' },
       company: { id: 2, nameCn: '信达主体' },
+      shippingDemands: [shippingDemand],
+      shippingDemandItems: shippingDemand.items,
+      salesOrders: [makeSalesOrder()],
+      salesOrderItems: [makeSalesOrderItem()],
+      allocations: [
+        {
+          shippingDemandItemId: 701,
+          lockedQuantity: 1,
+          status: ShippingDemandAllocationStatus.ACTIVE,
+        },
+      ],
     };
     const queryRunner = makeQueryRunner(state);
     receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
@@ -295,6 +577,14 @@ describe('ReceiptOrdersService', () => {
     inventoryService.increaseStockInTransaction.mockResolvedValue({
       summary: {},
       batches: [{ id: 7001 }],
+    });
+    inventoryService.lockStockInTransaction.mockResolvedValue({
+      summary: {
+        actualQuantity: 5,
+        lockedQuantity: 5,
+        availableQuantity: 0,
+      },
+      allocations: [{ batchId: 7001, quantity: 4 }],
     });
 
     const result = await service.create(
@@ -347,6 +637,14 @@ describe('ReceiptOrdersService', () => {
         receiptDate: '2026-04-30',
       }),
     );
+    expect(inventoryService.lockStockInTransaction).toHaveBeenCalledWith(
+      queryRunner,
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 10,
+        quantity: 4,
+      }),
+    );
     expect(state.updatedPurchaseOrder).toEqual(
       expect.objectContaining({
         id: 500,
@@ -366,8 +664,36 @@ describe('ReceiptOrdersService', () => {
       expect.objectContaining({
         id: 701,
         receivedQuantity: 5,
+        lockedRemainingQuantity: 5,
       }),
     ]);
+    expect(state.savedSalesOrderItems).toEqual([
+      expect.objectContaining({
+        id: 1201,
+        purchaseQuantity: 5,
+        useStockQuantity: 0,
+        preparedQuantity: 5,
+        shippedQuantity: 0,
+      }),
+    ]);
+    expect(state.savedSalesOrders).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 1100,
+          status: SalesOrderStatus.PREPARED,
+        }),
+      ]),
+    );
+    expect(state.savedInventoryTransactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          changeType: InventoryChangeType.LOCK,
+          sourceDocumentType: 'receipt_order',
+          sourceDocumentId: 800,
+          sourceDocumentItemId: 901,
+        }),
+      ]),
+    );
     expect(state.savedOperationLogs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -378,11 +704,26 @@ describe('ReceiptOrdersService', () => {
           action: OperationLogAction.UPDATE,
           resourceType: 'purchase-orders',
         }),
+        expect.objectContaining({
+          action: OperationLogAction.UPDATE,
+          resourceType: 'shipping-demands',
+          requestSummary: expect.objectContaining({
+            sourceAction: 'receipt_auto_lock',
+          }),
+        }),
+        expect.objectContaining({
+          action: OperationLogAction.UPDATE,
+          resourceType: 'sales-orders',
+          requestSummary: expect.objectContaining({
+            sourceAction: 'receipt_auto_lock',
+          }),
+        }),
       ]),
     );
   });
 
   it('marks purchase order as partially received when only part of the remaining quantity arrives', async () => {
+    const shippingDemand = makeShippingDemand();
     const state: Record<string, any> = {
       purchaseOrder: makePurchaseOrder(),
       purchaseOrderQueryMode: 'find',
@@ -390,6 +731,17 @@ describe('ReceiptOrdersService', () => {
       warehouses: [{ id: 10, name: '深圳仓' }],
       receiver: { id: 20, name: '仓管小李' },
       company: { id: 2, nameCn: '信达主体' },
+      shippingDemands: [shippingDemand],
+      shippingDemandItems: shippingDemand.items,
+      salesOrders: [makeSalesOrder()],
+      salesOrderItems: [makeSalesOrderItem()],
+      allocations: [
+        {
+          shippingDemandItemId: 701,
+          lockedQuantity: 1,
+          status: ShippingDemandAllocationStatus.ACTIVE,
+        },
+      ],
     };
     const queryRunner = makeQueryRunner(state);
     receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
@@ -406,6 +758,14 @@ describe('ReceiptOrdersService', () => {
     inventoryService.increaseStockInTransaction.mockResolvedValue({
       summary: {},
       batches: [{ id: 7001 }],
+    });
+    inventoryService.lockStockInTransaction.mockResolvedValue({
+      summary: {
+        actualQuantity: 3,
+        lockedQuantity: 3,
+        availableQuantity: 0,
+      },
+      allocations: [{ batchId: 7001, quantity: 2 }],
     });
 
     await service.create(
@@ -439,6 +799,200 @@ describe('ReceiptOrdersService', () => {
       expect.objectContaining({
         id: 701,
         receivedQuantity: 3,
+        lockedRemainingQuantity: 3,
+      }),
+    ]);
+    expect(state.savedSalesOrderItems).toEqual([
+      expect.objectContaining({
+        id: 1201,
+        preparedQuantity: 3,
+      }),
+    ]);
+    expect(state.savedSalesOrders).toBeUndefined();
+  });
+
+  it('skips auto lock for stock purchase orders', async () => {
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder({
+        orderType: PurchaseOrderType.STOCK,
+        shippingDemandId: null,
+        shippingDemandCode: null,
+        items: [
+          {
+            id: 900,
+            purchaseOrderId: 500,
+            shippingDemandItemId: null,
+            skuId: 11,
+            skuCode: 'SKU001',
+            productNameCn: '离心机',
+            productType: '设备类',
+            spuName: 'SPU001',
+            quantity: 5,
+            receivedQuantity: 1,
+            unitPrice: '12.50',
+            isFullyReceived: YesNo.NO,
+          },
+        ] as any,
+      }),
+      purchaseOrderQueryMode: 'find',
+      latestReceiptOrder: null,
+      warehouses: [{ id: 10, name: '深圳仓' }],
+      receiver: { id: 20, name: '仓管小李' },
+      company: { id: 2, nameCn: '信达主体' },
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue(null);
+    receiptOrdersRepository.findById.mockResolvedValue({
+      id: 800,
+      receiptCode: 'RKDH202604300001',
+      purchaseOrderId: 500,
+      purchaseOrderCode: 'XCPO202604300001',
+      status: ReceiptOrderStatus.CONFIRMED,
+      totalQuantity: 2,
+      totalAmount: '25.00',
+    });
+    inventoryService.increaseStockInTransaction.mockResolvedValue({
+      summary: {},
+      batches: [{ id: 7001 }],
+    });
+
+    await service.create(
+      {
+        purchaseOrderId: 500,
+        requestKey: 'receipt-order:test-stock',
+        warehouseId: 10,
+        receiptDate: '2026-04-30',
+        receiverId: 20,
+        purchaseCompanyId: 2,
+        items: [
+          {
+            purchaseOrderItemId: 900,
+            receivedQuantity: 2,
+            warehouseId: 10,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(inventoryService.lockStockInTransaction).not.toHaveBeenCalled();
+    expect(state.savedAllocations).toBeUndefined();
+    expect(state.savedInventoryTransactions).toBeUndefined();
+  });
+
+  it('caps auto lock quantity by the remaining demand gap', async () => {
+    const shippingDemand = makeShippingDemand({
+      items: [
+        {
+          id: 701,
+          shippingDemandId: 700,
+          salesOrderItemId: 1201,
+          skuId: 11,
+          skuCode: 'SKU001',
+          requiredQuantity: 5,
+          lockedRemainingQuantity: 4,
+          shippedQuantity: 0,
+          purchaseRequiredQuantity: 5,
+          stockRequiredQuantity: 0,
+          purchaseOrderedQuantity: 5,
+          receivedQuantity: 4,
+        },
+      ] as any,
+    });
+    const state: Record<string, any> = {
+      purchaseOrder: makePurchaseOrder({
+        receivedTotalQuantity: 4,
+        items: [
+          {
+            id: 900,
+            purchaseOrderId: 500,
+            shippingDemandItemId: 701,
+            skuId: 11,
+            skuCode: 'SKU001',
+            productNameCn: '离心机',
+            productType: '设备类',
+            spuName: 'SPU001',
+            quantity: 7,
+            receivedQuantity: 4,
+            unitPrice: '12.50',
+            isFullyReceived: YesNo.NO,
+          },
+        ] as any,
+      }),
+      purchaseOrderQueryMode: 'find',
+      latestReceiptOrder: null,
+      warehouses: [{ id: 10, name: '深圳仓' }],
+      receiver: { id: 20, name: '仓管小李' },
+      company: { id: 2, nameCn: '信达主体' },
+      shippingDemands: [shippingDemand],
+      shippingDemandItems: shippingDemand.items,
+      salesOrders: [makeSalesOrder()],
+      salesOrderItems: [makeSalesOrderItem({ preparedQuantity: 4 })],
+      allocations: [
+        {
+          shippingDemandItemId: 701,
+          lockedQuantity: 4,
+          status: ShippingDemandAllocationStatus.ACTIVE,
+        },
+      ],
+    };
+    const queryRunner = makeQueryRunner(state);
+    receiptOrdersRepository.createQueryRunner.mockReturnValue(queryRunner);
+    receiptOrdersRepository.findBySourceActionKey.mockResolvedValue(null);
+    receiptOrdersRepository.findById.mockResolvedValue({
+      id: 800,
+      receiptCode: 'RKDH202604300001',
+      purchaseOrderId: 500,
+      purchaseOrderCode: 'XCPO202604300001',
+      status: ReceiptOrderStatus.CONFIRMED,
+      totalQuantity: 3,
+      totalAmount: '37.50',
+    });
+    inventoryService.increaseStockInTransaction.mockResolvedValue({
+      summary: {},
+      batches: [{ id: 7002 }],
+    });
+    inventoryService.lockStockInTransaction.mockResolvedValue({
+      summary: {
+        actualQuantity: 7,
+        lockedQuantity: 5,
+        availableQuantity: 2,
+      },
+      allocations: [{ batchId: 7002, quantity: 1 }],
+    });
+
+    await service.create(
+      {
+        purchaseOrderId: 500,
+        requestKey: 'receipt-order:test-gap-cap',
+        warehouseId: 10,
+        receiptDate: '2026-04-30',
+        receiverId: 20,
+        purchaseCompanyId: 2,
+        items: [
+          {
+            purchaseOrderItemId: 900,
+            receivedQuantity: 3,
+            warehouseId: 10,
+          },
+        ],
+      },
+      'admin',
+    );
+
+    expect(inventoryService.lockStockInTransaction).toHaveBeenCalledWith(
+      queryRunner,
+      expect.objectContaining({
+        skuId: 11,
+        warehouseId: 10,
+        quantity: 1,
+      }),
+    );
+    expect(state.savedShippingDemandItems).toEqual([
+      expect.objectContaining({
+        id: 701,
+        lockedRemainingQuantity: 5,
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- auto lock requisition purchase receipts to their linked shipping demand items inside the receipt transaction
- refresh shipping demand and sales order fulfillment snapshots/statuses after receipt auto-lock
- add receipt-order coverage for requisition auto-lock, stock-order skip, and remaining-gap capping

## Test Plan
- pnpm --filter api test -- --runInBand modules/receipt-orders/tests/receipt-orders.service.spec.ts
- pnpm --filter api test -- --runInBand modules/shipping-demands/tests/shipping-demands.service.spec.ts
- pnpm --filter api test -- --runInBand modules/purchase-orders/tests/purchase-orders.service.spec.ts
- pnpm --filter api test -- --runInBand modules/inventory/tests/inventory.service.spec.ts
- pnpm --filter api build
- pnpm --filter web build