### PR TITLE
feat(web): redesign home dashboard as ops workbench

### DIFF
--- a/apps/web/src/pages/home/dashboard.css
+++ b/apps/web/src/pages/home/dashboard.css
@@ -2,7 +2,11 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 18px;
+}
+
+.dash-workbench {
+  gap: 20px;
 }
 
 .dash-section-label {
@@ -10,130 +14,427 @@
   font-weight: 700;
   color: #94a3b8;
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin-top: 4px;
+  letter-spacing: 0.08em;
+  margin-top: 2px;
 }
 
-.dash-stat-grid {
+.dash-hero-grid {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
+  grid-template-columns: 1.6fr 1fr;
+  gap: 18px;
+}
+
+.dash-hero-panel {
+  border-radius: 24px;
+  padding: 24px 26px;
+  border: 1px solid #dbeafe;
+  background:
+    radial-gradient(circle at top right, rgba(59, 130, 246, 0.16), transparent 24%),
+    linear-gradient(135deg, #ffffff 0%, #f6f9ff 100%);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.08);
+}
+
+.dash-hero-kicker {
+  font-size: 12px;
+  font-weight: 700;
+  color: #2563eb;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dash-hero-title {
+  margin-top: 10px;
+  font-size: 30px;
+  line-height: 1.14;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: -0.03em;
+}
+
+.dash-hero-description {
+  margin-top: 10px;
+  max-width: 680px;
+  font-size: 14px;
+  line-height: 1.7;
+  color: #64748b;
+}
+
+.dash-hero-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.dash-hero-pill-row span {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.dash-hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 22px;
+}
+
+.dash-hero-metric {
+  padding: 16px 18px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(219, 234, 254, 0.85);
+}
+
+.dash-hero-metric-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #94a3b8;
+  letter-spacing: 0.04em;
+}
+
+.dash-hero-metric-value {
+  margin-top: 8px;
+  font-size: 30px;
+  line-height: 1;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.dash-hero-metric-value span {
+  margin-left: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #94a3b8;
+}
+
+.dash-hero-metric-delta {
+  margin-top: 10px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.dash-surface-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--erp-border);
+  border-radius: 22px;
+  padding: 22px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.dash-surface-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.dash-surface-title {
+  font-size: 15px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.dash-surface-extra {
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.dash-task-list {
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 
-.dash-stat-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 16px 20px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+.dash-task-item {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.dash-task-copy {
+  min-width: 0;
+}
+
+.dash-task-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.dash-task-note {
+  margin-top: 4px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: #64748b;
+}
+
+.dash-task-value {
+  flex-shrink: 0;
+  font-size: 28px;
+  font-weight: 800;
+}
+
+.dash-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 14px;
 }
 
-.dash-stat-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
+.dash-kpi-card {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding: 18px 18px 16px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--erp-border);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.04);
+}
+
+.dash-kpi-icon {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  border-radius: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 18px;
-  flex-shrink: 0;
 }
 
-.dash-stat-icon-blue   { background: #eff6ff; color: #2563eb; }
-.dash-stat-icon-green  { background: #ecfdf5; color: #10b981; }
-.dash-stat-icon-orange { background: #fffbeb; color: #f59e0b; }
-.dash-stat-icon-gray   { background: #f8fafc; color: #64748b; }
-.dash-stat-icon-red    { background: #fef2f2; color: #ef4444; }
+.dash-kpi-icon.tone-blue { background: #eff6ff; color: #2563eb; }
+.dash-kpi-icon.tone-green { background: #ecfdf5; color: #16a34a; }
+.dash-kpi-icon.tone-amber { background: #fffbeb; color: #d97706; }
+.dash-kpi-icon.tone-sky { background: #f0f9ff; color: #0284c7; }
+.dash-kpi-icon.tone-red { background: #fef2f2; color: #dc2626; }
+.dash-kpi-icon.tone-emerald { background: #ecfdf5; color: #059669; }
 
-.dash-stat-body {
+.dash-kpi-body {
   min-width: 0;
 }
 
-.dash-stat-value {
-  font-size: 22px;
-  font-weight: 700;
-  color: #0f172a;
-  line-height: 1.2;
-}
-
-.dash-stat-unit {
+.dash-kpi-label {
   font-size: 12px;
-  font-weight: 400;
   color: #94a3b8;
-  margin-left: 3px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
-.dash-stat-label {
+.dash-kpi-value {
+  margin-top: 8px;
+  font-size: 28px;
+  font-weight: 800;
+  line-height: 1;
+  color: #0f172a;
+}
+
+.dash-kpi-value span {
+  margin-left: 4px;
   font-size: 12px;
-  color: #64748b;
-  margin-top: 3px;
-}
-
-.dash-chart-grid-3 {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-
-.dash-chart-card {
-  background: #fff;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  padding: 20px 24px 12px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-}
-
-.dash-chart-title {
-  font-size: 14px;
   font-weight: 600;
-  color: #1e293b;
-  margin-bottom: 16px;
+  color: #94a3b8;
 }
 
-.dash-placeholder {
+.dash-kpi-meta {
+  margin-top: 10px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  min-height: 180px;
-  padding: 20px 24px;
-}
-
-.dash-placeholder-label {
-  font-size: 13px;
-  color: #cbd5e1;
-  font-weight: 500;
-}
-
-.dash-placeholder-desc {
+  gap: 3px;
   font-size: 12px;
-  color: #e2e8f0;
-  text-align: center;
-  line-height: 1.6;
 }
 
-@media (max-width: 1400px) {
-  .dash-stat-grid {
-    grid-template-columns: repeat(3, 1fr);
+.dash-kpi-meta strong {
+  font-size: 12px;
+}
+
+.dash-kpi-meta span {
+  color: #94a3b8;
+}
+
+.dash-main-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 0.9fr;
+  gap: 18px;
+}
+
+.dash-extra-note {
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.dash-entry-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dash-entry-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid #dbeafe;
+  background: #f8fbff;
+}
+
+.dash-entry-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.dash-entry-desc {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.6;
+  color: #64748b;
+}
+
+.dash-entry-arrow {
+  color: #2563eb;
+  font-size: 14px;
+}
+
+.dash-subsection-title {
+  margin-top: 22px;
+  margin-bottom: 14px;
+  font-size: 14px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.dash-health-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dash-health-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: #334155;
+}
+
+.dash-health-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.dash-health-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.dash-health-fill.tone-blue { background: #2563eb; }
+.dash-health-fill.tone-green { background: #22c55e; }
+.dash-health-fill.tone-amber { background: #f59e0b; }
+.dash-health-fill.tone-emerald { background: #10b981; }
+
+.dash-risk-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dash-risk-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.9fr) minmax(0, 0.8fr);
+  gap: 10px;
+  padding: 13px 0;
+  border-bottom: 1px solid #eef2f7;
+  font-size: 13px;
+  color: #334155;
+}
+
+.dash-risk-row:last-child {
+  border-bottom: none;
+}
+
+.dash-analysis-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.tone-blue { color: #2563eb; }
+.tone-green { color: #16a34a; }
+.tone-amber { color: #d97706; }
+.tone-sky { color: #0284c7; }
+.tone-red { color: #dc2626; }
+.tone-emerald { color: #059669; }
+
+@media (max-width: 1600px) {
+  .dash-kpi-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .dash-analysis-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1280px) {
+  .dash-hero-grid,
+  .dash-main-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-hero-metrics {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 1024px) {
-  .dash-chart-grid-3 {
-    grid-template-columns: repeat(2, 1fr);
+  .dash-kpi-grid,
+  .dash-entry-grid,
+  .dash-analysis-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 768px) {
-  .dash-stat-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .dash-page {
+    gap: 16px;
   }
 
-  .dash-chart-grid-3 {
+  .dash-hero-panel,
+  .dash-surface-card,
+  .dash-kpi-card {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .dash-hero-title {
+    font-size: 24px;
+  }
+
+  .dash-kpi-grid,
+  .dash-entry-grid,
+  .dash-analysis-grid {
     grid-template-columns: 1fr;
+  }
+
+  .dash-risk-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
   }
 }

--- a/apps/web/src/pages/home/dashboard.mock.ts
+++ b/apps/web/src/pages/home/dashboard.mock.ts
@@ -1,43 +1,154 @@
-export const kpis = {
-  skuTotal: 248,
-  spuTotal: 86,
-  supplierTotal: 34,
-  customerTotal: 52,
-  certificateValid: 41,
-  contractApproved: 7,
-};
+export const heroMetrics = [
+  { label: '待履约订单', value: 27, unit: '单', delta: '较昨日 -3', tone: 'blue' },
+  { label: '证书预警', value: 9, unit: '张', delta: '7 天内到期', tone: 'red' },
+  { label: '资料缺口', value: 14, unit: '项', delta: '重点 SKU 4 个', tone: 'amber' },
+] as const;
+
+export const kpis = [
+  {
+    label: 'SKU 总数',
+    value: 248,
+    unit: '个',
+    delta: '+12',
+    tone: 'blue',
+    helper: '近 30 天净增',
+  },
+  {
+    label: 'SPU 总计',
+    value: 86,
+    unit: '个',
+    delta: '+5',
+    tone: 'green',
+    helper: '近 30 天新增',
+  },
+  {
+    label: '供应商',
+    value: 34,
+    unit: '家',
+    delta: '+2',
+    tone: 'amber',
+    helper: '合作主体',
+  },
+  {
+    label: '客户',
+    value: 52,
+    unit: '家',
+    delta: '+6',
+    tone: 'sky',
+    helper: '活跃客户',
+  },
+  {
+    label: '有效证书',
+    value: 41,
+    unit: '张',
+    delta: '+4',
+    tone: 'green',
+    helper: '当前有效',
+  },
+  {
+    label: '已通过合同模板',
+    value: 7,
+    unit: '份',
+    delta: '+1',
+    tone: 'blue',
+    helper: '可复用模板',
+  },
+] as const;
+
+export const urgentTasks = [
+  {
+    label: '证书即将到期',
+    value: 9,
+    note: '本周内需复核，涉及德国与美国客户包',
+    tone: 'red',
+  },
+  {
+    label: '待提交合同模板',
+    value: 3,
+    note: '采购与法务待确认，影响新采购单创建',
+    tone: 'amber',
+  },
+  {
+    label: '待完善产品资料',
+    value: 14,
+    note: '涉及 4 个重点 SKU，影响销售与发货资料齐套',
+    tone: 'blue',
+  },
+] as const;
+
+export const quickLinks = [
+  { label: '销售订单', description: '录入新订单并确认客户需求' },
+  { label: '发货需求', description: '查看待履约与备货状态' },
+  { label: '采购订单', description: '跟进采购在途与交期' },
+  { label: '库存查询', description: '核对可用库存和锁定量' },
+] as const;
+
+export const moduleHealth = [
+  { label: '销售履约完整度', value: 82, tone: 'blue' },
+  { label: '采购跟单完成度', value: 68, tone: 'amber' },
+  { label: '产品资料齐备率', value: 74, tone: 'green' },
+  { label: '合规证书有效率', value: 81, tone: 'emerald' },
+] as const;
+
+export const riskBoard = [
+  {
+    item: '美国插头资料包',
+    status: '缺少 UL 证书',
+    owner: '产品资料组',
+    tone: 'red',
+  },
+  {
+    item: '采购合同条款模板',
+    status: '待法务复核',
+    owner: '采购中心',
+    tone: 'amber',
+  },
+  {
+    item: '发货需求 SD-2031',
+    status: '待库存确认',
+    owner: '商务履约组',
+    tone: 'blue',
+  },
+  {
+    item: '德国客户证书包',
+    status: '7 天内到期',
+    owner: '合规专员',
+    tone: 'red',
+  },
+] as const;
+
+export const trendData = [
+  { month: '11月', sales: 126, purchase: 98, inventory: 72 },
+  { month: '12月', sales: 132, purchase: 103, inventory: 75 },
+  { month: '1月', sales: 138, purchase: 108, inventory: 78 },
+  { month: '2月', sales: 146, purchase: 112, inventory: 83 },
+  { month: '3月', sales: 154, purchase: 118, inventory: 87 },
+  { month: '4月', sales: 162, purchase: 125, inventory: 92 },
+] as const;
 
 export const skuStatusData = [
-  { name: '上架', value: 128, color: '#22C55E' },
+  { name: '上架', value: 128, color: '#2563EB' },
   { name: '下架可售', value: 64, color: '#F59E0B' },
   { name: '下架不可售', value: 38, color: '#EF4444' },
   { name: '临拓', value: 18, color: '#94A3B8' },
-];
+] as const;
 
 export const templateStatusData = [
-  { name: '待提交', value: 3 },
-  { name: '审核中', value: 2 },
-  { name: '审核通过', value: 7 },
-  { name: '已拒绝', value: 1 },
-  { name: '已作废', value: 4 },
-];
-
-export const trendData = [
-  { month: '11月', spu: 62, sku: 185 },
-  { month: '12月', spu: 68, sku: 198 },
-  { month: '1月',  spu: 71, sku: 210 },
-  { month: '2月',  spu: 75, sku: 220 },
-  { month: '3月',  spu: 81, sku: 235 },
-  { month: '4月',  spu: 86, sku: 248 },
-];
+  { name: '待提交', value: 3, color: '#2563EB' },
+  { name: '审核中', value: 2, color: '#0EA5E9' },
+  { name: '审核通过', value: 7, color: '#22C55E' },
+  { name: '已拒绝', value: 1, color: '#EF4444' },
+  { name: '已作废', value: 4, color: '#94A3B8' },
+] as const;
 
 export const supplierStatusData = [
   { name: '合作', value: 24, color: '#2563EB' },
-  { name: '临拓', value: 7,  color: '#F59E0B' },
-  { name: '淘汰', value: 3,  color: '#94A3B8' },
-];
+  { name: '临拓', value: 7, color: '#F59E0B' },
+  { name: '淘汰', value: 3, color: '#94A3B8' },
+] as const;
 
 export const certificateStatusData = [
   { name: '有效', value: 41, color: '#22C55E' },
-  { name: '已过期', value: 9, color: '#EF4444' },
-];
+  { name: '预警', value: 6, color: '#F59E0B' },
+  { name: '过期', value: 3, color: '#EF4444' },
+] as const;

--- a/apps/web/src/pages/home/index.tsx
+++ b/apps/web/src/pages/home/index.tsx
@@ -1,7 +1,16 @@
 import {
-  PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer,
-  BarChart, Bar, XAxis, YAxis, CartesianGrid,
-  LineChart, Line,
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
 } from 'recharts';
 import {
   AppstoreOutlined,
@@ -10,24 +19,35 @@ import {
   UserOutlined,
   SafetyCertificateOutlined,
   FileTextOutlined,
+  ArrowRightOutlined,
 } from '@ant-design/icons';
 import { useAuthStore } from '../../store/auth.store';
 import {
-  kpis, skuStatusData, templateStatusData,
-  trendData, supplierStatusData, certificateStatusData,
+  heroMetrics,
+  kpis,
+  urgentTasks,
+  quickLinks,
+  moduleHealth,
+  riskBoard,
+  trendData,
+  skuStatusData,
+  templateStatusData,
+  supplierStatusData,
+  certificateStatusData,
 } from './dashboard.mock';
 import '../master-data/master-page.css';
 import './dashboard.css';
 
 type TimeSlot = 'dawn' | 'morning' | 'noon' | 'afternoon' | 'evening' | 'night';
+type Tone = 'blue' | 'green' | 'amber' | 'sky' | 'red' | 'emerald';
 
 function getTimeSlot(): TimeSlot {
-  const h = new Date().getHours();
-  if (h >= 0 && h < 5)  return 'dawn';
-  if (h >= 5 && h < 9)  return 'morning';
-  if (h >= 9 && h < 12) return 'noon';
-  if (h >= 12 && h < 18) return 'afternoon';
-  if (h >= 18 && h < 22) return 'evening';
+  const hour = new Date().getHours();
+  if (hour >= 0 && hour < 5) return 'dawn';
+  if (hour >= 5 && hour < 9) return 'morning';
+  if (hour >= 9 && hour < 12) return 'noon';
+  if (hour >= 12 && hour < 18) return 'afternoon';
+  if (hour >= 18 && hour < 22) return 'evening';
   return 'night';
 }
 
@@ -40,44 +60,97 @@ const GREETINGS: Record<TimeSlot, string> = {
   night: '夜里好',
 };
 
-type StatColor = 'blue' | 'green' | 'orange' | 'gray' | 'red';
+const KPI_ICONS = [
+  <AppstoreOutlined />,
+  <ShoppingOutlined />,
+  <TeamOutlined />,
+  <UserOutlined />,
+  <SafetyCertificateOutlined />,
+  <FileTextOutlined />,
+] as const;
 
 function formatTooltipValue(value: number | string | undefined, unit: string): [string, string] {
   const numericValue = typeof value === 'number' ? value : Number(value ?? 0);
   return [`${numericValue} ${unit}`, ''];
 }
 
-function normalizeChartValue(value: number | string | ReadonlyArray<number | string> | undefined) {
-  if (Array.isArray(value)) {
-    return value[0];
-  }
-  return value;
-}
-
-function StatCard({ label, value, unit = '', icon, color }: {
-  label: string; value: number; unit?: string;
-  icon: React.ReactNode; color: StatColor;
+function HeroMetric({
+  label,
+  value,
+  unit,
+  delta,
+  tone,
+}: {
+  label: string;
+  value: number;
+  unit: string;
+  delta: string;
+  tone: Tone;
 }) {
   return (
-    <div className="dash-stat-card">
-      <div className={`dash-stat-icon dash-stat-icon-${color}`}>{icon}</div>
-      <div className="dash-stat-body">
-        <div className="dash-stat-value">
+    <div className="dash-hero-metric">
+      <div className="dash-hero-metric-label">{label}</div>
+      <div className="dash-hero-metric-value">
+        {value}
+        <span>{unit}</span>
+      </div>
+      <div className={`dash-hero-metric-delta tone-${tone}`}>{delta}</div>
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  unit,
+  delta,
+  helper,
+  tone,
+  icon,
+}: {
+  label: string;
+  value: number;
+  unit: string;
+  delta: string;
+  helper: string;
+  tone: Tone;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div className="dash-kpi-card">
+      <div className={`dash-kpi-icon tone-${tone}`}>{icon}</div>
+      <div className="dash-kpi-body">
+        <div className="dash-kpi-label">{label}</div>
+        <div className="dash-kpi-value">
           {value.toLocaleString()}
-          {unit && <span className="dash-stat-unit">{unit}</span>}
+          <span>{unit}</span>
         </div>
-        <div className="dash-stat-label">{label}</div>
+        <div className="dash-kpi-meta">
+          <strong className={`tone-${tone}`}>{delta}</strong>
+          <span>{helper}</span>
+        </div>
       </div>
     </div>
   );
 }
 
-function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+function SurfaceCard({
+  title,
+  extra,
+  children,
+}: {
+  title: string;
+  extra?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="dash-chart-card">
-      <div className="dash-chart-title">{title}</div>
+    <section className="dash-surface-card">
+      <div className="dash-surface-head">
+        <div className="dash-surface-title">{title}</div>
+        {extra ? <div className="dash-surface-extra">{extra}</div> : null}
+      </div>
       {children}
-    </div>
+    </section>
   );
 }
 
@@ -85,98 +158,196 @@ export default function DashboardPage() {
   const user = useAuthStore((s) => s.user);
   const name = user?.name || user?.username || '用户';
   const greeting = GREETINGS[getTimeSlot()];
-  const dateStr = new Date().toLocaleDateString('zh-CN', { month: 'long', day: 'numeric', weekday: 'long' });
+  const dateStr = new Date().toLocaleDateString('zh-CN', {
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  });
 
   return (
-    <div className="dash-page">
-      <div className="master-page-header">
-        <div className="master-page-heading">
-          <div className="master-page-title">数据概览</div>
-          <div className="master-page-description">{greeting}，{name} · {dateStr} · Infitek ERP 主数据核心概览</div>
-        </div>
+    <div className="dash-page dash-workbench">
+      <div className="dash-hero-grid">
+        <section className="dash-hero-panel">
+          <div className="dash-hero-kicker">今日工作面板</div>
+          <div className="dash-hero-title">
+            {greeting}，{name}
+          </div>
+          <div className="dash-hero-description">
+            {dateStr} · 今天优先处理履约、合规和资料闭环。先把高风险节点清掉，再看趋势和结构数据。
+          </div>
+          <div className="dash-hero-pill-row">
+            <span>待履约 27 单</span>
+            <span>证书预警 9 张</span>
+            <span>资料缺口 14 项</span>
+          </div>
+          <div className="dash-hero-metrics">
+            {heroMetrics.map((metric) => (
+              <HeroMetric
+                key={metric.label}
+                label={metric.label}
+                value={metric.value}
+                unit={metric.unit}
+                delta={metric.delta}
+                tone={metric.tone}
+              />
+            ))}
+          </div>
+        </section>
+
+        <SurfaceCard title="今日最该处理">
+          <div className="dash-task-list">
+            {urgentTasks.map((task) => (
+              <div key={task.label} className="dash-task-item">
+                <div className="dash-task-copy">
+                  <div className="dash-task-label">{task.label}</div>
+                  <div className="dash-task-note">{task.note}</div>
+                </div>
+                <div className={`dash-task-value tone-${task.tone}`}>{task.value}</div>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
       </div>
 
       <div className="dash-section-label">核心指标</div>
-      <div className="dash-stat-grid">
-        <StatCard label="SKU 总数" value={kpis.skuTotal} unit="个" icon={<AppstoreOutlined />} color="blue" />
-        <StatCard label="SPU 总计" value={kpis.spuTotal} unit="个" icon={<ShoppingOutlined />} color="green" />
-        <StatCard label="供应商" value={kpis.supplierTotal} unit="家" icon={<TeamOutlined />} color="orange" />
-        <StatCard label="客户" value={kpis.customerTotal} unit="家" icon={<UserOutlined />} color="blue" />
-        <StatCard label="有效证书" value={kpis.certificateValid} unit="张" icon={<SafetyCertificateOutlined />} color="green" />
-        <StatCard label="已通过合同模板" value={kpis.contractApproved} unit="份" icon={<FileTextOutlined />} color="gray" />
+      <div className="dash-kpi-grid">
+        {kpis.map((item, index) => (
+          <KpiCard
+            key={item.label}
+            label={item.label}
+            value={item.value}
+            unit={item.unit}
+            delta={item.delta}
+            helper={item.helper}
+            tone={item.tone}
+            icon={KPI_ICONS[index]}
+          />
+        ))}
       </div>
 
-      <div className="dash-section-label">产品与合同分析</div>
-      <div className="dash-chart-grid-3">
-        <ChartCard title="SKU 状态分布">
+      <div className="dash-section-label">工作台视图</div>
+      <div className="dash-main-grid">
+        <SurfaceCard title="业务走势" extra={<span className="dash-extra-note">销售 / 采购 / 库存</span>}>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={trendData} margin={{ top: 8, right: 8, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+              <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94A3B8' }} />
+              <YAxis tick={{ fontSize: 11, fill: '#94A3B8' }} />
+              <Tooltip formatter={(value) => formatTooltipValue(value as number, '项')} />
+              <Line type="monotone" dataKey="sales" name="销售" stroke="#2563EB" strokeWidth={2.5} dot={false} />
+              <Line type="monotone" dataKey="purchase" name="采购" stroke="#14B8A6" strokeWidth={2.5} dot={false} />
+              <Line type="monotone" dataKey="inventory" name="库存" stroke="#F59E0B" strokeWidth={2.5} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </SurfaceCard>
+
+        <SurfaceCard title="快捷入口">
+          <div className="dash-entry-grid">
+            {quickLinks.map((item) => (
+              <div key={item.label} className="dash-entry-card">
+                <div>
+                  <div className="dash-entry-title">{item.label}</div>
+                  <div className="dash-entry-desc">{item.description}</div>
+                </div>
+                <ArrowRightOutlined className="dash-entry-arrow" />
+              </div>
+            ))}
+          </div>
+
+          <div className="dash-subsection-title">模块健康度</div>
+          <div className="dash-health-list">
+            {moduleHealth.map((item) => (
+              <div key={item.label} className="dash-health-item">
+                <div className="dash-health-row">
+                  <span>{item.label}</span>
+                  <strong>{item.value}%</strong>
+                </div>
+                <div className="dash-health-bar">
+                  <span className={`dash-health-fill tone-${item.tone}`} style={{ width: `${item.value}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
+
+        <SurfaceCard title="风险与依赖">
+          <div className="dash-risk-list">
+            {riskBoard.map((item) => (
+              <div key={item.item} className="dash-risk-row">
+                <span>{item.item}</span>
+                <strong className={`tone-${item.tone}`}>{item.status}</strong>
+                <span>{item.owner}</span>
+              </div>
+            ))}
+          </div>
+        </SurfaceCard>
+      </div>
+
+      <div className="dash-section-label">结构分析</div>
+      <div className="dash-analysis-grid">
+        <SurfaceCard title="SKU 状态分布">
           <ResponsiveContainer width="100%" height={220}>
             <PieChart>
-              <Pie data={skuStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80}
-                label={({ name: n, percent }) => `${n} ${(((percent ?? 0) * 100)).toFixed(0)}%`} labelLine={false}>
-                {skuStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
+              <Pie
+                data={skuStatusData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                outerRadius={82}
+                label={({ name: itemName, percent }) => `${itemName} ${(((percent ?? 0) * 100)).toFixed(0)}%`}
+                labelLine={false}
+              >
+                {skuStatusData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
               </Pie>
-              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '个')} />
+              <Tooltip formatter={(value) => formatTooltipValue(value as number, '个')} />
             </PieChart>
           </ResponsiveContainer>
-        </ChartCard>
+        </SurfaceCard>
 
-        <ChartCard title="合同模板状态分布">
+        <SurfaceCard title="合同模板状态">
           <ResponsiveContainer width="100%" height={220}>
-            <BarChart data={templateStatusData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+            <BarChart data={templateStatusData} margin={{ top: 8, right: 8, left: -20, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
               <XAxis dataKey="name" tick={{ fontSize: 11, fill: '#94A3B8' }} />
               <YAxis tick={{ fontSize: 11, fill: '#94A3B8' }} allowDecimals={false} />
-              <Tooltip />
-              <Bar dataKey="value" name="数量" fill="#2563EB" radius={[4, 4, 0, 0]} />
+              <Tooltip formatter={(value) => formatTooltipValue(value as number, '份')} />
+              <Bar dataKey="value" radius={[8, 8, 0, 0]}>
+                {templateStatusData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
-        </ChartCard>
+        </SurfaceCard>
 
-        <ChartCard title="近 6 个月 SPU / SKU 趋势">
+        <SurfaceCard title="供应商状态分布">
           <ResponsiveContainer width="100%" height={220}>
-            <LineChart data={trendData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#F1F5F9" />
-              <XAxis dataKey="month" tick={{ fontSize: 11, fill: '#94A3B8' }} />
-              <YAxis tick={{ fontSize: 11, fill: '#94A3B8' }} />
-              <Tooltip />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
-              <Line type="monotone" dataKey="spu" name="SPU" stroke="#2563EB" strokeWidth={2} dot={{ r: 3 }} />
-              <Line type="monotone" dataKey="sku" name="SKU" stroke="#22C55E" strokeWidth={2} dot={{ r: 3 }} />
-            </LineChart>
-          </ResponsiveContainer>
-        </ChartCard>
-      </div>
-
-      <div className="dash-section-label">供应链 & 合规</div>
-      <div className="dash-chart-grid-3">
-        <ChartCard title="供应商状态分布">
-          <ResponsiveContainer width="100%" height={180}>
             <PieChart>
-              <Pie data={supplierStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={45} outerRadius={72}>
-                {supplierStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
+              <Pie data={supplierStatusData} dataKey="value" nameKey="name" innerRadius={46} outerRadius={76}>
+                {supplierStatusData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
               </Pie>
-              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '家')} />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Tooltip formatter={(value) => formatTooltipValue(value as number, '家')} />
             </PieChart>
           </ResponsiveContainer>
-        </ChartCard>
+        </SurfaceCard>
 
-        <ChartCard title="证书有效性">
-          <ResponsiveContainer width="100%" height={180}>
+        <SurfaceCard title="证书有效性">
+          <ResponsiveContainer width="100%" height={220}>
             <PieChart>
-              <Pie data={certificateStatusData} dataKey="value" nameKey="name" cx="50%" cy="50%" innerRadius={45} outerRadius={72}>
-                {certificateStatusData.map((entry) => <Cell key={entry.name} fill={entry.color} />)}
+              <Pie data={certificateStatusData} dataKey="value" nameKey="name" innerRadius={46} outerRadius={76}>
+                {certificateStatusData.map((entry) => (
+                  <Cell key={entry.name} fill={entry.color} />
+                ))}
               </Pie>
-              <Tooltip formatter={(value) => formatTooltipValue(normalizeChartValue(value), '张')} />
-              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Tooltip formatter={(value) => formatTooltipValue(value as number, '张')} />
             </PieChart>
           </ResponsiveContainer>
-        </ChartCard>
-
-        <div className="dash-chart-card dash-placeholder">
-          <div className="dash-placeholder-label">销售 / 采购 / 库存</div>
-          <div className="dash-placeholder-desc">业务模块数据<br />接口接入后展示</div>
-        </div>
+        </SurfaceCard>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- redesign the home dashboard into an operations workbench layout
- prioritize today's tasks, risk reminders, quick entries, and module health before chart analysis
- refresh dashboard mock data and chart sections to match the new workbench information architecture

## Testing
- not run (the worktree previously lacked a fully working local frontend dependency/runtime setup, so no reliable local verification was completed in this session)