### PR TITLE
feat(outbound-orders): implement story 7-3 outbound confirmation flow

### DIFF
--- a/_bmad-output/implementation-artifacts/7-3-发货出库单创建与确认.md
+++ b/_bmad-output/implementation-artifacts/7-3-发货出库单创建与确认.md
@@ -1,0 +1,276 @@
+# Story 7.3: 发货出库单创建与确认
+
+Status: review
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+As a 仓管,
+I want 从已确认物流单创建并确认发货出库单，逐行填写实际出库数量和来源仓库，
+so that 仓库发货动作有完整记录，库存与锁定量按真实出库结果实时扣减。
+
+## Scope Adjustment
+
+- Story 7.1 已完成物流单创建与创建即确认，Story 7.2 已完成物流单列表、详情和物流跟踪编辑；本 Story 不从零设计物流或库存流程，而是在现有 `logistics-orders`、`shipping-demands`、`inventory` 基础上补齐“发货出库单创建 + 出库确认”闭环。
+- 本 Story 聚焦四件事：从物流单预填出库表单、出库确认时消费发货需求锁定分配、扣减库存并释放锁定量、把出库数量缓存回填到物流单/发货需求/销售订单明细。
+- 本 Story 不新增正式“出库单列表页 / 详情页”范围，不重做物流单列表，也不提前实现物流费用、取消出库或复杂返工流程。
+- Story 7.4 继续承接“状态联动与页面呈现”这个更上游的交付切片。本 Story 必须把后续状态联动所需的数量事实、审计记录和查询接口准备好，但不强行在此 Story 内扩展整套出库后详情页联动体验。
+
+## Acceptance Criteria
+
+1. 仓管可从物流单详情页进入 `/outbound-orders/create?logisticsOrderId=:id` 创建出库单；仅 `confirmed` 且存在未出库数量的物流单允许进入创建流程。
+2. 进入创建页后，系统自动预填关联物流单与货物行项，至少展示：物流单号、发货需求编号、销售订单号、SKU 编码、产品名称、计划数量、已出库数量、剩余可出库数量；这些来源字段只读。
+3. 每个货物行必须允许录入实际出库数量和来源仓库；实际出库数量必须为正整数，且不得超过该物流行剩余可出库数量。
+4. 仓管点击“确认出库”时使用 `Popconfirm` 二次确认；后端在 3 秒内完成出库确认、库存更新与数量回填（NFR-P5）。
+5. 出库确认时，后端必须按当前发货需求明细在所选仓库下的 active allocation FIFO 消费锁定分配，且每行出库数量不得超过“本发货需求在该仓库的锁定量”；超出时返回明确业务错误，并包含当前本需求锁定数量（FR47、NFR-U3）。
+6. 出库确认成功后，系统必须对被消费的批次执行：
+   - 批次层 `batch_quantity -N`
+   - 批次层 `batch_locked_quantity -N`
+   - 汇总层 `actual_quantity -N`
+   - 汇总层 `locked_quantity -N`
+   - `available_quantity` 保持 `actual - locked`
+   - 自动写入 `inventory_transactions`，`change_type = outbound`
+7. 出库确认成功后，系统必须回填数量事实：
+   - 更新 `shipping_demand_inventory_allocations.locked_quantity / shipped_quantity / status`
+   - 记录 `outbound_allocation_consumptions`，可审计“哪张出库单明细消耗了哪些 allocation / 批次”
+   - 更新 `shipping_demand_items.locked_remaining_quantity / shipped_quantity`
+   - 更新 `logistics_order_items.outbound_quantity`
+   - 更新 `sales_order_items.shipped_quantity` 展示缓存
+8. 后端发货出库单实体至少包含：`id`、`outbound_code`、`logistics_order_id`、`shipping_demand_id`、`sales_order_id`、`status`、`remark`、审计字段；出库明细至少包含：`id`、`outbound_order_id`、`logistics_order_item_id`、`shipping_demand_item_id`、`sku_id`、`warehouse_id`、`outbound_quantity`、审计字段。
+9. 出库确认必须具备幂等保护：同一确认请求只能成功消费一次数量事实，`source_action_key = outbound:{id}:confirm` 必须唯一；重复提交不得重复扣库存、重复消费 allocation 或重复累计已出库数量。
+10. 补充后端测试覆盖创建预填、锁定量校验、FIFO allocation 消费、库存扣减、幂等保护与数量回填；前端至少通过 `web build`，并验证从物流单详情页进入出库页的交互链路。
+
+## Tasks / Subtasks
+
+- [x] Story 7.3 规格裁决与字段确认（AC: 1-10）
+  - [x] 固化本 Story 与 7.1 / 7.2 / 7.4 的边界：7.3 负责出库创建确认与数量真值；7.4 负责更完整的状态联动和详情页呈现。
+  - [x] 以 `docs/系统模块对应字段清单.md#出库单-管理` 作为旧系统字段参考，但以 Epic 7.3 AC、flow 文档和现有代码模型为准裁剪 MVP 字段。
+  - [x] 记录并遵守冲突裁决：旧 PRD 的“一个物流单对应一个出库单”仅作为早期 MVP 简化参考，若会阻断“允许部分发货并后续补发”的最新 flow 口径，应优先服从 flow 文档与 Epic 7 AC。
+- [x] 后端出库模块与迁移落地（AC: 1, 5-9）
+  - [x] 新增 `apps/api/src/modules/outbound-orders/` 模块，遵守项目 7 文件标准，包含 module / controller / service / repository / entity / dto / tests。
+  - [x] 新增出库单主表、出库明细表，以及 `outbound_allocation_consumptions` 关联表 migration；所有状态/枚举定义放入 `packages/shared`，不要在前后端各自定义。
+  - [x] 提供从物流单预填的后端接口，仅允许 `confirmed` 且有剩余待出库数量的物流单创建出库单。
+  - [x] 提供“创建即确认”的出库接口，在同一事务里完成单据落库、allocation 消费、库存扣减、流水写入与数量回填。
+- [x] allocation 消费、库存扣减与幂等保护（AC: 5-9）
+  - [x] 复用 `shipping_demand_inventory_allocations` 作为锁定权威来源，按 `shipping_demand_item_id + warehouse_id` 过滤 active allocation，并按批次 FIFO 消费。
+  - [x] 复用 `InventoryService.deductLockedStockInTransaction()` 执行精确批次扣减，禁止绕过库存服务直接更新 `inventory_summary` / `inventory_batch`。
+  - [x] 为出库确认设计稳定 `sourceActionKey`，并让 `inventory_transactions`、allocation 消费记录和出库单确认保持幂等。
+  - [x] 出库成功后刷新 `shipping_demand_items`、`logistics_order_items`、`sales_order_items` 的数量缓存，为 Story 7.4 状态联动提供真值基础。
+- [x] 审计日志与查询补强（AC: 7-10）
+  - [x] 为 `outbound-orders` 写 CREATE/UPDATE 级操作日志，文案遵守 `docs/operation-log-standard.md`。
+  - [x] 补齐 `ActivityTimeline` 所需的字段中文化、枚举映射和 companion 字段，避免英文名、ID 或未翻译枚举泄露。
+  - [x] 让物流单详情页不再显示“Story 7.3 接入占位”，而是显示真实出库入口或真实出库结果摘要。
+- [x] 前端 API、路由与创建页实现（AC: 1-4, 10）
+  - [x] 新增 `apps/web/src/api/outbound-orders.api.ts`，包含预填与创建接口类型。
+  - [x] 在 `apps/web/src/App.tsx` 注册 `/outbound-orders/create` 路由。
+  - [x] 新增 `apps/web/src/pages/outbound-orders/form.tsx`，使用现有详情页/创建页风格与 `ProForm` 模式，承接物流单预填数据。
+  - [x] 在 `apps/web/src/pages/logistics-orders/detail.tsx` 增加“创建出库单”入口，并在关联单据区显示真实出库信息替代占位文案。
+- [x] 测试与验证（AC: 1-10）
+  - [x] 新增或更新后端测试，覆盖：预填读取、非 `confirmed` 物流单拒绝创建、锁定量超限报错、allocation FIFO 消费、库存扣减、幂等重复提交保护、数量缓存回填。
+  - [x] 运行 `pnpm install --frozen-lockfile`。
+  - [x] 运行 `pnpm --filter api exec jest modules/outbound-orders/tests --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/logistics-orders/tests --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand`。
+  - [x] 运行 `pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`。
+  - [x] 运行 `pnpm --filter api build`。
+  - [x] 运行 `pnpm --filter web build`。
+  - [x] 运行 `git diff --check`。
+
+## Dev Notes
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 属于 Epic 5-7 交易链路，开发前必须完整加载并优先遵守：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+若 PRD、Architecture、UX、Epic 或旧 Story 文本与上述文档冲突，以三份 flow 文档为准。本 Story 的具体约束：
+
+- 出库数量校验的权威来源不是全局可用库存，而是“本发货需求在该仓库的 active allocation 锁定量”。
+- 出库确认必须消费具体 allocation，并记录 `outbound_allocation_consumptions`，不能只按物流单行数量或全局库存直接扣减。
+- 库存写操作必须继续走 `QueryRunner + SELECT ... FOR UPDATE + 死锁指数退避最多 3 次`。
+- 所有枚举定义必须位于 `packages/shared`，禁止前后端各自新增本地状态口径。
+- 出库确认必须保留幂等键、库存流水、operation log 和上游数量缓存回填，避免重复确认导致数量重复累加。
+
+### Conflict Resolution
+
+- `flow-quantity-data-lineage.md#4.8` 描述的是系统最终行为：出库确认后库存、allocation、数量缓存与状态会一起联动。Epic 7 的 Story 切分则把“完整状态联动与页面呈现”拆到 7.4。因此 7.3 先落稳库存扣减、allocation 消费、数量缓存真值与审计链路；7.4 在此基础上补足显式状态推进和页面联动。
+- 旧 PRD 曾将 MVP 简化为“一个物流单对应一个出库单”，但同一份最新 PRD / Epic / flow 文档又明确允许部分发货，并存在 `partially_shipped -> shipped` 的持续推进。因此实现时不得把数据模型硬编码成阻断后续补发的不可扩展 1:1 限制；至少要保证后续 Story 7.4 能在不返工库存事实层的前提下继续推进。
+- 出库单自身无草稿状态机，创建动作即确认动作；前端表单只是填写中的临时态，不持久化为草稿。
+
+### Source Context
+
+- Epic 7 Story 7.3 定义了从物流单创建出库单、填写实际出库数量与来源仓库、确认后 FIFO 扣减库存并释放锁定量的目标。[Source: `_bmad-output/planning-artifacts/epics.md#Story 7.3`]
+- `flow-quantity-data-lineage.md#4.8` 明确了出库确认的前置状态、allocation 消费、库存影响、数量回填和幂等键规则。[Source: `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md#4.8`]
+- `flow-state-machine.md` 明确物流单由 `confirmed` 在全部出库后推进到 `shipped`，发货需求与销售订单支持 `partially_shipped / shipped` 状态链。[Source: `_bmad-output/planning-artifacts/flow-state-machine.md`]
+- PRD FR46 / FR47 / FR41 / FR42 要求：允许部分发货、按本需求锁定量校验、确认后扣减实际库存并释放锁定量、自动记录库存变动流水。[Source: `_bmad-output/planning-artifacts/prd.md`]
+
+### Previous Story Intelligence
+
+- Story 7.1 已完成物流单创建，`logistics_order_items` 已持久化 `plannedQuantity` 与 `outboundQuantity`，为本 Story 提供出库前的计划数量基线。
+- Story 7.2 已完成物流单详情页和“出库单将在 Story 7.3 接入”的占位文案，且详情页已有合适的“创建出库单”入口落点。
+- Story 6.6 已把收货后自动锁定落到 `shipping_demand_inventory_allocations`，并补齐了 `shipping_demand_items.lockedRemainingQuantity` / `sales_order_items.preparedQuantity` 等缓存回填；7.3 必须直接消费这套 allocation 事实，不要重建锁定来源。
+- Epic 5 的 retrospective 已明确警告：出库不能绕过 allocation，不能只按全局库存或物流计划数量扣减；否则会出现“本需求超发”和批次审计丢失问题。
+
+### Existing Code Map
+
+- 后端物流单模块：`apps/api/src/modules/logistics-orders/`
+  - `logistics-orders.service.ts` 已提供 `findById()`、`getCreatePrefill()`、创建事务、operation log 写入。
+  - `logistics_order_items` 已持久化 `planned_quantity` 与 `outbound_quantity`，本 Story 需要回填 `outbound_quantity`。
+  - `apps/web/src/pages/logistics-orders/detail.tsx` 已有“关联单据 > 出库单”占位文案和顶部操作区，可直接加出库入口。
+- 发货需求锁定权威：`apps/api/src/modules/shipping-demands/entities/shipping-demand-inventory-allocation.entity.ts`
+  - 已提供 `locked_quantity / shipped_quantity / released_quantity / status / source_action_key`，本 Story 应消费它而非旁路建表。
+- 库存扣减能力：`apps/api/src/modules/inventory/inventory.service.ts`
+  - 已提供 `deductLockedStockInTransaction()`，可按指定批次扣减实际库存与锁定量，并自动写 `InventoryChangeType.OUTBOUND` 流水。
+- 收货后自动锁定参考：`apps/api/src/modules/receipt-orders/receipt-orders.service.ts`
+  - 已展示如何在事务内创建 allocation、写库存流水、刷新数量缓存和操作日志，可作为本 Story 的实现模板。
+- 当前缺口：
+  - 代码库中尚无 `outbound-orders` 业务模块、shared outbound status 枚举、出库单前端 API 与创建页。
+  - 物流单详情页与发货需求枢纽目前还没有真实出库单数据来源，只能依赖占位或 `outboundQuantity` 聚合。
+
+### Field List Reference
+
+已找到旧系统字段参考：`docs/系统模块对应字段清单.md#出库单-管理`。结合 Epic 7.3，本 Story 建议优先参考以下 MVP 相关字段：
+
+#### 基础与关联
+
+- 出库单号
+- 出库员
+- 出库日期
+- 物流单号 / 发货通知单号
+- 发货需求编号
+- 销售主体
+- 备注
+
+#### 出库执行
+
+- 出库仓库
+- 出库明细
+- SKU / SKU 编码 / 产品名称 / 产品单位
+- 出库数量
+- 批次号（按已锁定批次 FIFO 自动分配；允许同一出库明细跨多个批次）
+- 批次出库数量（按实际消费到的每个批次记录）
+- 发货需求明细 id
+- 分配库存实例 id
+
+#### 辅助展示
+
+- 出库仓库名称
+- 仓库编号 / 名称辅助字段
+
+以下字段暂不作为 Story 7.3 MVP 必做项，除非实现中发现已有稳定来源且不增加额外复杂度：
+
+- 销售单价 / 销售合计 / 销售总金额
+- 成本单价 / 成本合计 / 出库成本金额
+- 出库类型
+- 审批状态
+- 调拨唯一值 / 流程是否完成 / 是否已处理
+
+### Candidate Search And Display Fields
+
+本 Story 不新增正式列表页，因此“搜索字段 / 列表展示字段”确认不适用。
+
+### UI / UX Guidance
+
+- 前端入口优先复用现有物流单详情页顶部操作区，保持“创建物流单 -> 查看物流单 -> 创建出库单”的链路一致。
+- 出库创建页遵守项目表单规范：独立创建页、来源信息只读、可编辑字段集中在“实际出库数量 + 来源仓库 + 备注”。
+- 出库确认使用 `Popconfirm`，错误提示必须说人话，并明确返回“当前本需求锁定数量”。
+- 批次号在创建前不要求人工选择，系统按已锁定库存执行 FIFO；若锁定量跨多个批次，则同一出库明细允许跨批次消费。
+- 若物流单详情页暂不新增完整出库详情跳转，至少需要将“Story 7.3 占位文案”替换为真实的出库入口或真实出库摘要。
+
+### Testing Requirements
+
+- 后端测试至少覆盖：
+  - 仅 `confirmed` 且存在剩余可出库数量的物流单允许创建出库单。
+  - 预填接口正确返回物流单基础信息、计划数量、已出库数量与剩余可出库数量。
+  - 出库数量超过本需求在目标仓库的 active allocation 锁定量时返回明确业务错误。
+  - allocation 消费按 FIFO 进行，且 `outbound_allocation_consumptions` 记录完整。
+  - 出库成功后 `inventory_summary`、`inventory_batch`、`inventory_transactions`、`shipping_demand_items`、`logistics_order_items`、`sales_order_items` 回填正确。
+  - 重复提交同一确认请求时不重复扣库存、不重复消费 allocation。
+- 前端验证至少覆盖：
+  - 从物流单详情页进入出库创建页。
+  - 来源字段只读，实际出库数量与来源仓库可编辑。
+  - 确认出库使用二次确认，成功后能返回正确反馈并刷新相关查询缓存。
+- 统一验证命令：
+  - `pnpm --filter api exec jest modules/outbound-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/logistics-orders/tests --runInBand`
+  - `pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand`
+  - `pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`
+  - `pnpm --filter api build`
+  - `pnpm --filter web build`
+  - `git diff --check`
+
+### Implementation Boundaries
+
+- 不实现正式出库单列表页、详情页、打印、取消或作废链路。
+- 不重写物流单创建、物流跟踪编辑或物流费用能力；这些已由 7.1 / 7.2 / 7.5 承接。
+- 不绕过 `shipping_demand_inventory_allocations` 直接按全局库存或 `lockedRemainingQuantity` 聚合值扣减库存。
+- 不绕过 `InventoryService` 直接更新 `inventory_summary` / `inventory_batch`。
+- 不在前端提交目标状态或手工回填上游数量事实。
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Worktree path: `/Users/chenkangping/ai_study/worktrees/story/7-3-outbound-order-create-confirmation`
+- Branch: `story/7-3-outbound-order-create-confirmation`
+- WORKTREE_MODE: `true`
+- 2026-05-03：已创建 Story 7.3 开发上下文，加载 Epic 5-7 三份强制 flow 文档、Epic 7 Story 7.3/7.4、Story 7.1、Story 7.2、Story 6.6、旧系统“出库单-管理”字段清单与现有 logistics / shipping-demand / inventory 代码。
+- 2026-05-03：已识别关键实现 seam：`shipping_demand_inventory_allocations` 是锁定权威，`InventoryService.deductLockedStockInTransaction()` 是库存扣减入口，`logistics_order_items.outboundQuantity` 是物流单已出库缓存承载点。
+- 2026-05-03：已识别关键冲突：旧 PRD 的“物流单与出库单 1:1 简化”与最新 flow/FR46 的“允许部分发货”存在张力；本 Story 以最新 flow 文档和 Epic AC 为准。
+
+### Completion Notes List
+
+- Story file created by context engine with Epic 5-7 mandatory flow context.
+- 已新增 `outbound-orders` 后端模块、出库单迁移和 shared `OutboundOrderStatus`，打通了从物流单预填到出库确认的后端主链。
+- 出库确认已复用 `shipping_demand_inventory_allocations` 与 `InventoryService.deductLockedStockInTransaction()`，并按批次 `receipt_date` FIFO 消费锁定量。
+- 已回填 `shipping_demand_items.lockedRemainingQuantity / shippedQuantity`、`logistics_order_items.outboundQuantity`、`sales_order_items.shippedQuantity`，为后续 Story 7.4 状态联动保留真值基础。
+- 已补齐 `outbound-orders`、`logistics-orders`、`shipping-demands`、`sales-orders` 的操作日志联动，以及前端 `ActivityTimeline` / 字段标签映射。
+- 已新增前端出库 API 与创建页，并在物流单详情页替换原“Story 7.3 占位文案”为真实出库入口。
+- 本次实现允许同一物流单分多次部分出库，避免被旧 PRD 的 1:1 简化模型锁死后续补发场景。
+- 销售金额口径已调整为优先读取销售订单明细单价；成本金额口径按对应采购订单明细采购单价计算。
+- 批次号展示已明确为“按已锁定批次 FIFO 自动分配，允许跨批次”，并在创建页加入业务说明。
+- 已完成 `pnpm --filter api build`、`pnpm --filter web build`、`pnpm --filter api exec jest modules/outbound-orders/tests --runInBand`、`pnpm --filter api exec jest modules/logistics-orders/tests --runInBand`、`pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand`、`pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand`、`git diff --check`。
+
+### File List
+
+- `_bmad-output/implementation-artifacts/7-3-发货出库单创建与确认.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `apps/api/src/__mocks__/infitek-shared.ts`
+- `apps/api/src/app.module.ts`
+- `apps/api/src/migrations/20260503000100-create-outbound-orders.ts`
+- `apps/api/src/modules/outbound-orders/dto/create-outbound-order.dto.ts`
+- `apps/api/src/modules/outbound-orders/dto/query-outbound-create-prefill.dto.ts`
+- `apps/api/src/modules/outbound-orders/entities/outbound-allocation-consumption.entity.ts`
+- `apps/api/src/modules/outbound-orders/entities/outbound-order-item.entity.ts`
+- `apps/api/src/modules/outbound-orders/entities/outbound-order.entity.ts`
+- `apps/api/src/modules/outbound-orders/outbound-orders.controller.ts`
+- `apps/api/src/modules/outbound-orders/outbound-orders.module.ts`
+- `apps/api/src/modules/outbound-orders/outbound-orders.repository.ts`
+- `apps/api/src/modules/outbound-orders/outbound-orders.service.ts`
+- `apps/api/src/modules/outbound-orders/tests/outbound-orders.service.spec.ts`
+- `apps/web/src/App.tsx`
+- `apps/web/src/api/outbound-orders.api.ts`
+- `apps/web/src/components/ActivityTimeline.tsx`
+- `apps/web/src/components/layout/AppLayout.tsx`
+- `apps/web/src/pages/logistics-orders/detail.tsx`
+- `apps/web/src/pages/outbound-orders/form.tsx`
+- `packages/shared/src/enums/outbound-order-status.enum.ts`
+- `packages/shared/src/enums/outbound-order-type.enum.ts`
+- `packages/shared/src/index.ts`
+- `packages/shared/src/types/operation-log-field-labels.ts`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-05-03 | 0.1 | 创建 Story 7.3 开发上下文，固化出库创建确认范围、allocation 消费规则、旧系统字段参考与现有代码接入点 | GPT-5 Codex |
+| 2026-05-03 | 1.0 | 完成发货出库单创建与确认主链、数量回填、前端入口与构建验证，状态更新为 review | GPT-5 Codex |
+| 2026-05-03 | 1.1 | 按确认字段口径补齐主表字段、金额来源与批次 FIFO 说明，复验构建与关键测试 | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/7-3-发货出库单创建与确认.md
+++ b/_bmad-output/implementation-artifacts/7-3-发货出库单创建与确认.md
@@ -1,6 +1,6 @@
 # Story 7.3: 发货出库单创建与确认
 
-Status: review
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -274,3 +274,4 @@ GPT-5 Codex
 | 2026-05-03 | 0.1 | 创建 Story 7.3 开发上下文，固化出库创建确认范围、allocation 消费规则、旧系统字段参考与现有代码接入点 | GPT-5 Codex |
 | 2026-05-03 | 1.0 | 完成发货出库单创建与确认主链、数量回填、前端入口与构建验证，状态更新为 review | GPT-5 Codex |
 | 2026-05-03 | 1.1 | 按确认字段口径补齐主表字段、金额来源与批次 FIFO 说明，复验构建与关键测试 | GPT-5 Codex |
+| 2026-05-03 | 1.2 | 同步工作流收尾状态，Story 7.3 标记为 done | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-05-02 (story-7.2-review)
+# last_updated: 2026-05-03 (story-7.3-review)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-05-02 (story-7.2-review)
+last_updated: 2026-05-03 (story-7.3-review)
 project: infitek_erp
 
 project_key: NOKEY
@@ -133,7 +133,7 @@ development_status:
   epic-7: in-progress
   7-1-物流单创建: done
   7-2-物流单列表与详情: review
-  7-3-发货出库单创建与确认: backlog
+  7-3-发货出库单创建与确认: review
   7-4-发货出库后状态联动: backlog
   epic-7-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-05-03 (story-7.3-review)
+# last_updated: 2026-05-03 (story-7.3-done)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-05-03 (story-7.3-review)
+last_updated: 2026-05-03 (story-7.3-done)
 project: infitek_erp
 
 project_key: NOKEY
@@ -133,7 +133,7 @@ development_status:
   epic-7: in-progress
   7-1-物流单创建: done
   7-2-物流单列表与详情: review
-  7-3-发货出库单创建与确认: review
+  7-3-发货出库单创建与确认: done
   7-4-发货出库后状态联动: backlog
   epic-7-retrospective: optional
 

--- a/apps/api/src/__mocks__/infitek-shared.ts
+++ b/apps/api/src/__mocks__/infitek-shared.ts
@@ -182,6 +182,21 @@ export const ReceiptOrderStatus = {
 export type ReceiptOrderStatus =
   (typeof ReceiptOrderStatus)[keyof typeof ReceiptOrderStatus];
 
+export const OutboundOrderStatus = {
+  CONFIRMED: 'confirmed',
+} as const;
+export type OutboundOrderStatus =
+  (typeof OutboundOrderStatus)[keyof typeof OutboundOrderStatus];
+
+export const OutboundOrderType = {
+  SALES: 'sales_outbound',
+  LOSS: 'loss_outbound',
+  INVENTORY_LOSS: 'inventory_loss_outbound',
+  OTHER: 'other',
+} as const;
+export type OutboundOrderType =
+  (typeof OutboundOrderType)[keyof typeof OutboundOrderType];
+
 export const ReceiptOrderType = {
   PURCHASE_RECEIPT: 'purchase_receipt',
   SALES_RETURN_RECEIPT: 'sales_return_receipt',

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -38,6 +38,7 @@ import { PurchaseOrdersModule } from './modules/purchase-orders/purchase-orders.
 import { ReceiptOrdersModule } from './modules/receipt-orders/receipt-orders.module';
 import { InventoryModule } from './modules/inventory/inventory.module';
 import { OperationLogsModule } from './modules/operation-logs/operation-logs.module';
+import { OutboundOrdersModule } from './modules/outbound-orders/outbound-orders.module';
 import databaseConfig from './config/database.config';
 import { createLoggerConfig } from './config/logger.config';
 
@@ -72,6 +73,7 @@ import { createLoggerConfig } from './config/logger.config';
     LogisticsOrdersModule,
     PurchaseOrdersModule,
     ReceiptOrdersModule,
+    OutboundOrdersModule,
     InventoryModule,
     ProductCategoriesModule,
     SuppliersModule,

--- a/apps/api/src/migrations/20260503000100-create-outbound-orders.ts
+++ b/apps/api/src/migrations/20260503000100-create-outbound-orders.ts
@@ -1,0 +1,383 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+  TableIndex,
+} from 'typeorm';
+
+export class CreateOutboundOrders20260503000100 implements MigrationInterface {
+  name = 'CreateOutboundOrders20260503000100';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'outbound_orders',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'outbound_code', type: 'varchar', length: '40' },
+          { name: 'logistics_order_id', type: 'bigint', unsigned: true },
+          { name: 'logistics_order_code', type: 'varchar', length: '40' },
+          { name: 'shipping_demand_id', type: 'bigint', unsigned: true },
+          { name: 'shipping_demand_code', type: 'varchar', length: '40' },
+          { name: 'sales_order_id', type: 'bigint', unsigned: true },
+          { name: 'sales_order_code', type: 'varchar', length: '40' },
+          { name: 'outbound_user_id', type: 'bigint', unsigned: true },
+          { name: 'outbound_user_name', type: 'varchar', length: '100' },
+          { name: 'outbound_date', type: 'date' },
+          { name: 'outbound_type', type: 'varchar', length: '40' },
+          { name: 'sales_company_id', type: 'bigint', unsigned: true },
+          { name: 'sales_company_name', type: 'varchar', length: '200' },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_name', type: 'varchar', length: '200' },
+          { name: 'status', type: 'varchar', length: '20' },
+          {
+            name: 'sales_total_amount',
+            type: 'decimal',
+            precision: 18,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'cost_total_amount',
+            type: 'decimal',
+            precision: 18,
+            scale: 2,
+            default: 0,
+          },
+          { name: 'remark', type: 'text', isNullable: true },
+          {
+            name: 'source_action_key',
+            type: 'varchar',
+            length: '160',
+            isNullable: true,
+          },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'created_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'updated_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('outbound_orders', [
+      new TableIndex({
+        name: 'uq_outbound_orders_outbound_code',
+        columnNames: ['outbound_code'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'uq_outbound_orders_source_action_key',
+        columnNames: ['source_action_key'],
+        isUnique: true,
+      }),
+      new TableIndex({
+        name: 'idx_outbound_orders_logistics_order_id',
+        columnNames: ['logistics_order_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_orders_shipping_demand_id',
+        columnNames: ['shipping_demand_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_orders_sales_order_id',
+        columnNames: ['sales_order_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_orders_status',
+        columnNames: ['status'],
+      }),
+    ]);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'outbound_order_items',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'outbound_order_id', type: 'bigint', unsigned: true },
+          { name: 'logistics_order_item_id', type: 'bigint', unsigned: true },
+          { name: 'shipping_demand_item_id', type: 'bigint', unsigned: true },
+          { name: 'sales_order_item_id', type: 'bigint', unsigned: true },
+          { name: 'sku_id', type: 'bigint', unsigned: true },
+          { name: 'sku_code', type: 'varchar', length: '100' },
+          {
+            name: 'product_name_cn',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'product_name_en',
+            type: 'varchar',
+            length: '255',
+            isNullable: true,
+          },
+          {
+            name: 'unit_name',
+            type: 'varchar',
+            length: '50',
+            isNullable: true,
+          },
+          { name: 'planned_quantity', type: 'int', default: 0 },
+          { name: 'previous_outbound_quantity', type: 'int', default: 0 },
+          { name: 'outbound_quantity', type: 'int', default: 0 },
+          { name: 'warehouse_id', type: 'bigint', unsigned: true },
+          { name: 'warehouse_name', type: 'varchar', length: '200' },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'created_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'updated_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('outbound_order_items', [
+      new TableIndex({
+        name: 'idx_outbound_order_items_outbound_order_id',
+        columnNames: ['outbound_order_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_order_items_logistics_order_item_id',
+        columnNames: ['logistics_order_item_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_order_items_shipping_demand_item_id',
+        columnNames: ['shipping_demand_item_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_order_items_sku_id',
+        columnNames: ['sku_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_order_items_warehouse_id',
+        columnNames: ['warehouse_id'],
+      }),
+    ]);
+
+    await queryRunner.createTable(
+      new Table({
+        name: 'outbound_allocation_consumptions',
+        columns: [
+          {
+            name: 'id',
+            type: 'bigint',
+            unsigned: true,
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'outbound_order_item_id', type: 'bigint', unsigned: true },
+          {
+            name: 'shipping_demand_allocation_id',
+            type: 'bigint',
+            unsigned: true,
+          },
+          { name: 'inventory_batch_id', type: 'bigint', unsigned: true },
+          { name: 'consumed_quantity', type: 'int', default: 0 },
+          {
+            name: 'created_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updated_at',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+            onUpdate: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'created_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+          {
+            name: 'updated_by',
+            type: 'varchar',
+            length: '100',
+            isNullable: true,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndices('outbound_allocation_consumptions', [
+      new TableIndex({
+        name: 'idx_outbound_alloc_consumptions_outbound_item_id',
+        columnNames: ['outbound_order_item_id'],
+      }),
+      new TableIndex({
+        name: 'idx_outbound_alloc_consumptions_allocation_id',
+        columnNames: ['shipping_demand_allocation_id'],
+      }),
+      new TableIndex({
+        name: 'uq_outbound_alloc_consumptions_item_allocation',
+        columnNames: [
+          'outbound_order_item_id',
+          'shipping_demand_allocation_id',
+        ],
+        isUnique: true,
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('outbound_orders', [
+      new TableForeignKey({
+        name: 'fk_outbound_orders_logistics_order_id',
+        columnNames: ['logistics_order_id'],
+        referencedTableName: 'logistics_orders',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('outbound_order_items', [
+      new TableForeignKey({
+        name: 'fk_outbound_order_items_outbound_order_id',
+        columnNames: ['outbound_order_id'],
+        referencedTableName: 'outbound_orders',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        name: 'fk_outbound_order_items_logistics_order_item_id',
+        columnNames: ['logistics_order_item_id'],
+        referencedTableName: 'logistics_order_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        name: 'fk_outbound_order_items_shipping_demand_item_id',
+        columnNames: ['shipping_demand_item_id'],
+        referencedTableName: 'shipping_demand_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+      new TableForeignKey({
+        name: 'fk_outbound_order_items_warehouse_id',
+        columnNames: ['warehouse_id'],
+        referencedTableName: 'warehouses',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+
+    await queryRunner.createForeignKeys('outbound_allocation_consumptions', [
+      new TableForeignKey({
+        name: 'fk_outbound_alloc_consumptions_outbound_item_id',
+        columnNames: ['outbound_order_item_id'],
+        referencedTableName: 'outbound_order_items',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+      new TableForeignKey({
+        name: 'fk_outbound_alloc_consumptions_allocation_id',
+        columnNames: ['shipping_demand_allocation_id'],
+        referencedTableName: 'shipping_demand_inventory_allocations',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+      }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const tableName of [
+      'outbound_allocation_consumptions',
+      'outbound_order_items',
+      'outbound_orders',
+    ]) {
+      const table = await queryRunner.getTable(tableName);
+      if (table) {
+        for (const foreignKey of table.foreignKeys) {
+          await queryRunner.dropForeignKey(tableName, foreignKey);
+        }
+      }
+    }
+
+    for (const indexName of [
+      'idx_outbound_alloc_consumptions_outbound_item_id',
+      'idx_outbound_alloc_consumptions_allocation_id',
+      'uq_outbound_alloc_consumptions_item_allocation',
+    ]) {
+      await queryRunner.dropIndex('outbound_allocation_consumptions', indexName);
+    }
+    await queryRunner.dropTable('outbound_allocation_consumptions');
+
+    for (const indexName of [
+      'idx_outbound_order_items_outbound_order_id',
+      'idx_outbound_order_items_logistics_order_item_id',
+      'idx_outbound_order_items_shipping_demand_item_id',
+      'idx_outbound_order_items_sku_id',
+      'idx_outbound_order_items_warehouse_id',
+    ]) {
+      await queryRunner.dropIndex('outbound_order_items', indexName);
+    }
+    await queryRunner.dropTable('outbound_order_items');
+
+    for (const indexName of [
+      'uq_outbound_orders_outbound_code',
+      'uq_outbound_orders_source_action_key',
+      'idx_outbound_orders_logistics_order_id',
+      'idx_outbound_orders_shipping_demand_id',
+      'idx_outbound_orders_sales_order_id',
+      'idx_outbound_orders_status',
+    ]) {
+      await queryRunner.dropIndex('outbound_orders', indexName);
+    }
+    await queryRunner.dropTable('outbound_orders');
+  }
+}

--- a/apps/api/src/modules/outbound-orders/dto/create-outbound-order.dto.ts
+++ b/apps/api/src/modules/outbound-orders/dto/create-outbound-order.dto.ts
@@ -1,0 +1,70 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsDateString,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { OutboundOrderType } from '@infitek/shared';
+
+export class CreateOutboundOrderItemDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  logisticsOrderItemId: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  outboundQuantity: number;
+}
+
+export class CreateOutboundOrderDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  logisticsOrderId: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  outboundUserId: number;
+
+  @IsDateString()
+  outboundDate: string;
+
+  @IsString()
+  @IsIn(Object.values(OutboundOrderType))
+  outboundType: OutboundOrderType;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  salesCompanyId: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  warehouseId: number;
+
+  @IsString()
+  @MaxLength(160)
+  requestKey: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(1000)
+  remark?: string;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CreateOutboundOrderItemDto)
+  items: CreateOutboundOrderItemDto[];
+}

--- a/apps/api/src/modules/outbound-orders/dto/query-outbound-create-prefill.dto.ts
+++ b/apps/api/src/modules/outbound-orders/dto/query-outbound-create-prefill.dto.ts
@@ -1,0 +1,9 @@
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class QueryOutboundCreatePrefillDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  logisticsOrderId: number;
+}

--- a/apps/api/src/modules/outbound-orders/entities/outbound-allocation-consumption.entity.ts
+++ b/apps/api/src/modules/outbound-orders/entities/outbound-allocation-consumption.entity.ts
@@ -1,0 +1,42 @@
+import { Expose } from 'class-transformer';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { ShippingDemandInventoryAllocation } from '../../shipping-demands/entities/shipping-demand-inventory-allocation.entity';
+import { OutboundOrderItem } from './outbound-order-item.entity';
+
+@Entity('outbound_allocation_consumptions')
+@Index('idx_outbound_alloc_consumptions_outbound_item_id', ['outboundOrderItemId'])
+@Index('idx_outbound_alloc_consumptions_allocation_id', ['shippingDemandAllocationId'])
+@Index('uq_outbound_alloc_consumptions_item_allocation', [
+  'outboundOrderItemId',
+  'shippingDemandAllocationId',
+])
+export class OutboundAllocationConsumption extends BaseEntity {
+  @Column({ name: 'outbound_order_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  outboundOrderItemId: number;
+
+  @ManyToOne(() => OutboundOrderItem, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'outbound_order_item_id' })
+  outboundOrderItem?: OutboundOrderItem;
+
+  @Column({
+    name: 'shipping_demand_allocation_id',
+    type: 'bigint',
+    unsigned: true,
+  })
+  @Expose()
+  shippingDemandAllocationId: number;
+
+  @ManyToOne(() => ShippingDemandInventoryAllocation, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'shipping_demand_allocation_id' })
+  shippingDemandAllocation?: ShippingDemandInventoryAllocation;
+
+  @Column({ name: 'inventory_batch_id', type: 'bigint', unsigned: true })
+  @Expose()
+  inventoryBatchId: number;
+
+  @Column({ name: 'consumed_quantity', type: 'int', default: 0 })
+  @Expose()
+  consumedQuantity: number;
+}

--- a/apps/api/src/modules/outbound-orders/entities/outbound-order-item.entity.ts
+++ b/apps/api/src/modules/outbound-orders/entities/outbound-order-item.entity.ts
@@ -1,0 +1,99 @@
+import { Expose } from 'class-transformer';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { LogisticsOrderItem } from '../../logistics-orders/entities/logistics-order-item.entity';
+import { ShippingDemandItem } from '../../shipping-demands/entities/shipping-demand-item.entity';
+import { OutboundOrder } from './outbound-order.entity';
+
+@Entity('outbound_order_items')
+@Index('idx_outbound_order_items_outbound_order_id', ['outboundOrderId'])
+@Index('idx_outbound_order_items_logistics_order_item_id', ['logisticsOrderItemId'])
+@Index('idx_outbound_order_items_shipping_demand_item_id', ['shippingDemandItemId'])
+@Index('idx_outbound_order_items_sku_id', ['skuId'])
+@Index('idx_outbound_order_items_warehouse_id', ['warehouseId'])
+export class OutboundOrderItem extends BaseEntity {
+  @Column({ name: 'outbound_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  outboundOrderId: number;
+
+  @ManyToOne(() => OutboundOrder, (outboundOrder) => outboundOrder.items, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'outbound_order_id' })
+  outboundOrder?: OutboundOrder;
+
+  @Column({ name: 'logistics_order_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  logisticsOrderItemId: number;
+
+  @ManyToOne(() => LogisticsOrderItem, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'logistics_order_item_id' })
+  logisticsOrderItem?: LogisticsOrderItem;
+
+  @Column({ name: 'shipping_demand_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  shippingDemandItemId: number;
+
+  @ManyToOne(() => ShippingDemandItem, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'shipping_demand_item_id' })
+  shippingDemandItem?: ShippingDemandItem;
+
+  @Column({ name: 'sales_order_item_id', type: 'bigint', unsigned: true })
+  @Expose()
+  salesOrderItemId: number;
+
+  @Column({ name: 'sku_id', type: 'bigint', unsigned: true })
+  @Expose()
+  skuId: number;
+
+  @Column({ name: 'sku_code', type: 'varchar', length: 100 })
+  @Expose()
+  skuCode: string;
+
+  @Column({
+    name: 'product_name_cn',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  @Expose()
+  productNameCn: string | null;
+
+  @Column({
+    name: 'product_name_en',
+    type: 'varchar',
+    length: 255,
+    nullable: true,
+  })
+  @Expose()
+  productNameEn: string | null;
+
+  @Column({
+    name: 'unit_name',
+    type: 'varchar',
+    length: 50,
+    nullable: true,
+  })
+  @Expose()
+  unitName: string | null;
+
+  @Column({ name: 'planned_quantity', type: 'int', default: 0 })
+  @Expose()
+  plannedQuantity: number;
+
+  @Column({ name: 'previous_outbound_quantity', type: 'int', default: 0 })
+  @Expose()
+  previousOutboundQuantity: number;
+
+  @Column({ name: 'outbound_quantity', type: 'int', default: 0 })
+  @Expose()
+  outboundQuantity: number;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'warehouse_name', type: 'varchar', length: 200 })
+  @Expose()
+  warehouseName: string;
+}

--- a/apps/api/src/modules/outbound-orders/entities/outbound-order.entity.ts
+++ b/apps/api/src/modules/outbound-orders/entities/outbound-order.entity.ts
@@ -1,0 +1,130 @@
+import { Expose } from 'class-transformer';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
+import { OutboundOrderStatus, OutboundOrderType } from '@infitek/shared';
+import { BaseEntity } from '../../../common/entities/base.entity';
+import { LogisticsOrder } from '../../logistics-orders/entities/logistics-order.entity';
+import { OutboundOrderItem } from './outbound-order-item.entity';
+
+@Entity('outbound_orders')
+@Unique('uq_outbound_orders_outbound_code', ['outboundCode'])
+@Unique('uq_outbound_orders_source_action_key', ['sourceActionKey'])
+@Index('idx_outbound_orders_logistics_order_id', ['logisticsOrderId'])
+@Index('idx_outbound_orders_shipping_demand_id', ['shippingDemandId'])
+@Index('idx_outbound_orders_sales_order_id', ['salesOrderId'])
+@Index('idx_outbound_orders_status', ['status'])
+export class OutboundOrder extends BaseEntity {
+  @Column({ name: 'outbound_code', type: 'varchar', length: 40 })
+  @Expose()
+  outboundCode: string;
+
+  @Column({ name: 'logistics_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  logisticsOrderId: number;
+
+  @ManyToOne(() => LogisticsOrder, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'logistics_order_id' })
+  logisticsOrder?: LogisticsOrder;
+
+  @Column({ name: 'logistics_order_code', type: 'varchar', length: 40 })
+  @Expose()
+  logisticsOrderCode: string;
+
+  @Column({ name: 'shipping_demand_id', type: 'bigint', unsigned: true })
+  @Expose()
+  shippingDemandId: number;
+
+  @Column({ name: 'shipping_demand_code', type: 'varchar', length: 40 })
+  @Expose()
+  shippingDemandCode: string;
+
+  @Column({ name: 'sales_order_id', type: 'bigint', unsigned: true })
+  @Expose()
+  salesOrderId: number;
+
+  @Column({ name: 'sales_order_code', type: 'varchar', length: 40 })
+  @Expose()
+  salesOrderCode: string;
+
+  @Column({ name: 'outbound_user_id', type: 'bigint', unsigned: true })
+  @Expose()
+  outboundUserId: number;
+
+  @Column({ name: 'outbound_user_name', type: 'varchar', length: 100 })
+  @Expose()
+  outboundUserName: string;
+
+  @Column({ name: 'outbound_date', type: 'date' })
+  @Expose()
+  outboundDate: string;
+
+  @Column({ name: 'outbound_type', type: 'varchar', length: 40 })
+  @Expose()
+  outboundType: OutboundOrderType;
+
+  @Column({ name: 'sales_company_id', type: 'bigint', unsigned: true })
+  @Expose()
+  salesCompanyId: number;
+
+  @Column({ name: 'sales_company_name', type: 'varchar', length: 200 })
+  @Expose()
+  salesCompanyName: string;
+
+  @Column({ name: 'warehouse_id', type: 'bigint', unsigned: true })
+  @Expose()
+  warehouseId: number;
+
+  @Column({ name: 'warehouse_name', type: 'varchar', length: 200 })
+  @Expose()
+  warehouseName: string;
+
+  @Column({ name: 'status', type: 'varchar', length: 20 })
+  @Expose()
+  status: OutboundOrderStatus;
+
+  @Column({
+    name: 'sales_total_amount',
+    type: 'decimal',
+    precision: 18,
+    scale: 2,
+    default: 0,
+  })
+  @Expose()
+  salesTotalAmount: string;
+
+  @Column({
+    name: 'cost_total_amount',
+    type: 'decimal',
+    precision: 18,
+    scale: 2,
+    default: 0,
+  })
+  @Expose()
+  costTotalAmount: string;
+
+  @Column({ name: 'remark', type: 'text', nullable: true })
+  @Expose()
+  remark: string | null;
+
+  @Column({
+    name: 'source_action_key',
+    type: 'varchar',
+    length: 160,
+    nullable: true,
+  })
+  @Expose()
+  sourceActionKey: string | null;
+
+  @OneToMany(() => OutboundOrderItem, (item) => item.outboundOrder, {
+    cascade: false,
+  })
+  @Expose()
+  items?: OutboundOrderItem[];
+}

--- a/apps/api/src/modules/outbound-orders/outbound-orders.controller.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { CreateOutboundOrderDto } from './dto/create-outbound-order.dto';
+import { QueryOutboundCreatePrefillDto } from './dto/query-outbound-create-prefill.dto';
+import { OutboundOrdersService } from './outbound-orders.service';
+
+@Controller('outbound-orders')
+export class OutboundOrdersController {
+  constructor(
+    private readonly outboundOrdersService: OutboundOrdersService,
+  ) {}
+
+  @Get('create-prefill')
+  getCreatePrefill(@Query() query: QueryOutboundCreatePrefillDto) {
+    return this.outboundOrdersService.getCreatePrefill(query.logisticsOrderId);
+  }
+
+  @Post()
+  create(
+    @Body() dto: CreateOutboundOrderDto,
+    @CurrentUser() user: { username?: string },
+  ) {
+    return this.outboundOrdersService.create(dto, user?.username);
+  }
+}

--- a/apps/api/src/modules/outbound-orders/outbound-orders.module.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.module.ts
@@ -1,0 +1,46 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InventoryModule } from '../inventory/inventory.module';
+import { LogisticsOrdersModule } from '../logistics-orders/logistics-orders.module';
+import { LogisticsOrderItem } from '../logistics-orders/entities/logistics-order-item.entity';
+import { LogisticsOrder } from '../logistics-orders/entities/logistics-order.entity';
+import { Company } from '../master-data/companies/entities/company.entity';
+import { Warehouse } from '../master-data/warehouses/entities/warehouse.entity';
+import { SalesOrder } from '../sales-orders/entities/sales-order.entity';
+import { SalesOrderItem } from '../sales-orders/entities/sales-order-item.entity';
+import { ShippingDemandInventoryAllocation } from '../shipping-demands/entities/shipping-demand-inventory-allocation.entity';
+import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
+import { ShippingDemand } from '../shipping-demands/entities/shipping-demand.entity';
+import { User } from '../users/entities/user.entity';
+import { OutboundOrdersController } from './outbound-orders.controller';
+import { OutboundOrdersRepository } from './outbound-orders.repository';
+import { OutboundOrdersService } from './outbound-orders.service';
+import { OutboundAllocationConsumption } from './entities/outbound-allocation-consumption.entity';
+import { OutboundOrderItem } from './entities/outbound-order-item.entity';
+import { OutboundOrder } from './entities/outbound-order.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      OutboundOrder,
+      OutboundOrderItem,
+      OutboundAllocationConsumption,
+      LogisticsOrder,
+      LogisticsOrderItem,
+      ShippingDemand,
+      ShippingDemandItem,
+      ShippingDemandInventoryAllocation,
+      SalesOrder,
+      SalesOrderItem,
+      Company,
+      User,
+      Warehouse,
+    ]),
+    InventoryModule,
+    LogisticsOrdersModule,
+  ],
+  controllers: [OutboundOrdersController],
+  providers: [OutboundOrdersRepository, OutboundOrdersService],
+  exports: [OutboundOrdersService],
+})
+export class OutboundOrdersModule {}

--- a/apps/api/src/modules/outbound-orders/outbound-orders.repository.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.repository.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { OutboundAllocationConsumption } from './entities/outbound-allocation-consumption.entity';
+import { OutboundOrderItem } from './entities/outbound-order-item.entity';
+import { OutboundOrder } from './entities/outbound-order.entity';
+
+@Injectable()
+export class OutboundOrdersRepository {
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+    @InjectRepository(OutboundOrder)
+    private readonly outboundOrderRepo: Repository<OutboundOrder>,
+    @InjectRepository(OutboundOrderItem)
+    private readonly outboundOrderItemRepo: Repository<OutboundOrderItem>,
+    @InjectRepository(OutboundAllocationConsumption)
+    private readonly outboundAllocationConsumptionRepo: Repository<OutboundAllocationConsumption>,
+  ) {}
+
+  createQueryRunner() {
+    return this.dataSource.createQueryRunner();
+  }
+
+  findBySourceActionKey(sourceActionKey: string): Promise<OutboundOrder | null> {
+    return this.outboundOrderRepo.findOne({
+      where: { sourceActionKey },
+      relations: { items: true },
+      order: { items: { id: 'ASC' } },
+    });
+  }
+
+  findById(id: number): Promise<OutboundOrder | null> {
+    return this.outboundOrderRepo.findOne({
+      where: { id },
+      relations: { items: true },
+      order: { items: { id: 'ASC' } },
+    });
+  }
+}

--- a/apps/api/src/modules/outbound-orders/outbound-orders.service.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.service.ts
@@ -1,0 +1,1379 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  LogisticsOrderStatus,
+  OutboundOrderStatus,
+  OutboundOrderType,
+  SalesOrderStatus,
+  ShippingDemandAllocationStatus,
+  ShippingDemandStatus,
+} from '@infitek/shared';
+import { In, QueryRunner, Repository } from 'typeorm';
+import { InventoryService } from '../inventory/inventory.service';
+import { Company } from '../master-data/companies/entities/company.entity';
+import { PurchaseOrderItem } from '../purchase-orders/entities/purchase-order-item.entity';
+import { User } from '../users/entities/user.entity';
+import { OperationLog, OperationLogAction } from '../operation-logs/entities/operation-log.entity';
+import { Warehouse } from '../master-data/warehouses/entities/warehouse.entity';
+import { LogisticsOrderItem } from '../logistics-orders/entities/logistics-order-item.entity';
+import { LogisticsOrder } from '../logistics-orders/entities/logistics-order.entity';
+import { SalesOrderItem } from '../sales-orders/entities/sales-order-item.entity';
+import { SalesOrder } from '../sales-orders/entities/sales-order.entity';
+import { ShippingDemandInventoryAllocation } from '../shipping-demands/entities/shipping-demand-inventory-allocation.entity';
+import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
+import { ShippingDemand } from '../shipping-demands/entities/shipping-demand.entity';
+import { CreateOutboundOrderDto } from './dto/create-outbound-order.dto';
+import { OutboundOrdersRepository } from './outbound-orders.repository';
+import { OutboundAllocationConsumption } from './entities/outbound-allocation-consumption.entity';
+import { OutboundOrderItem } from './entities/outbound-order-item.entity';
+import { OutboundOrder } from './entities/outbound-order.entity';
+
+const MAX_OUTBOUND_ORDER_CODE_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 25;
+
+export interface OutboundPrefillItem {
+  logisticsOrderItemId: number;
+  shippingDemandItemId: number;
+  salesOrderItemId: number;
+  skuId: number;
+  skuCode: string;
+  productNameCn: string | null;
+  productNameEn: string | null;
+  unitName: string | null;
+  purchaseSubject: string | null;
+  salesUnitPrice: string | null;
+  costUnitPrice: string | null;
+  plannedQuantity: number;
+  outboundQuantity: number;
+  remainingQuantity: number;
+}
+
+interface PreparedOutboundLine {
+  logisticsItem: LogisticsOrderItem;
+  demandItem: ShippingDemandItem;
+  requestedQuantity: number;
+  remainingQuantity: number;
+  warehouseId: number;
+  warehouseName: string;
+  salesUnitPrice: number;
+  costUnitPrice: number;
+  allocations: Array<{ allocation: ShippingDemandInventoryAllocation; quantity: number }>;
+}
+
+export interface OutboundOrderCreatePrefillResult {
+  logisticsOrder: {
+    id: number;
+    orderCode: string;
+    shippingDemandId: number;
+    shippingDemandCode: string;
+    salesOrderId: number;
+    salesOrderCode: string;
+    status: LogisticsOrderStatus;
+    logisticsProviderName: string;
+    transportationMethod: LogisticsOrder['transportationMethod'];
+  };
+  items: OutboundPrefillItem[];
+}
+
+interface AllocationConsumptionResult {
+  allocationId: number;
+  inventoryBatchId: number;
+  consumedQuantity: number;
+}
+
+interface ShippingDemandStatusChange {
+  demand: ShippingDemand;
+  oldStatus: ShippingDemandStatus;
+}
+
+interface SalesOrderStatusChange {
+  order: SalesOrder;
+  oldStatus: SalesOrderStatus;
+}
+
+@Injectable()
+export class OutboundOrdersService {
+  constructor(
+    private readonly outboundOrdersRepository: OutboundOrdersRepository,
+    private readonly inventoryService: InventoryService,
+  ) {}
+
+  async getCreatePrefill(
+    logisticsOrderId: number,
+  ): Promise<OutboundOrderCreatePrefillResult> {
+    const queryRunner = this.outboundOrdersRepository.createQueryRunner();
+    try {
+      await queryRunner.connect();
+      const logisticsOrder = await this.findLogisticsOrderForOutbound(
+        queryRunner,
+        logisticsOrderId,
+      );
+      const demandItemById = await this.findShippingDemandItemsById(
+        queryRunner,
+        (logisticsOrder.items ?? []).map((item) =>
+          Number(item.shippingDemandItemId),
+        ),
+      );
+      const items = this.buildPrefillItems(
+        logisticsOrder.items ?? [],
+        demandItemById,
+        await this.findSalesPriceBySalesOrderItemId(
+          queryRunner,
+          (logisticsOrder.items ?? []).map((item) =>
+            Number(item.salesOrderItemId),
+          ),
+        ),
+        await this.findPurchaseCostByDemandItemId(
+          queryRunner,
+          (logisticsOrder.items ?? []).map((item) =>
+            Number(item.shippingDemandItemId),
+          ),
+        ),
+      );
+      if (!items.length) {
+        throw new BadRequestException({
+          code: 'OUTBOUND_ORDER_NO_REMAINING_ITEMS',
+          message: '当前物流单没有可继续出库的货物明细',
+        });
+      }
+
+      return {
+        logisticsOrder: {
+          id: Number(logisticsOrder.id),
+          orderCode: logisticsOrder.orderCode,
+          shippingDemandId: Number(logisticsOrder.shippingDemandId),
+          shippingDemandCode: logisticsOrder.shippingDemandCode,
+          salesOrderId: Number(logisticsOrder.salesOrderId),
+          salesOrderCode: logisticsOrder.salesOrderCode,
+          status: logisticsOrder.status,
+          logisticsProviderName: logisticsOrder.logisticsProviderName,
+          transportationMethod: logisticsOrder.transportationMethod,
+        },
+        items,
+      };
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async create(dto: CreateOutboundOrderDto, operator?: string) {
+    const existing = await this.outboundOrdersRepository.findBySourceActionKey(
+      dto.requestKey,
+    );
+    if (existing) {
+      return this.findById(Number(existing.id));
+    }
+
+    const outboundOrderId = await this.executeWithOutboundOrderCodeRetry(
+      async (queryRunner) => {
+        const existingInTx =
+          await queryRunner.manager.getRepository(OutboundOrder).findOne({
+            where: { sourceActionKey: dto.requestKey },
+          });
+        if (existingInTx) {
+          return Number(existingInTx.id);
+        }
+
+        const outboundOrder = await this.createInTransaction(
+          queryRunner,
+          dto,
+          operator,
+        );
+        return Number(outboundOrder.id);
+      },
+    );
+
+    return this.findById(outboundOrderId);
+  }
+
+  async findById(id: number): Promise<OutboundOrder> {
+    const outboundOrder = await this.outboundOrdersRepository.findById(id);
+    if (!outboundOrder) {
+      throw new NotFoundException('发货出库单不存在');
+    }
+    return outboundOrder;
+  }
+
+  private buildPrefillItems(
+    items: LogisticsOrderItem[],
+    demandItemById: Map<number, ShippingDemandItem>,
+    salesPriceBySalesOrderItemId: Map<number, string | null>,
+    purchaseCostByDemandItemId: Map<number, string | null>,
+  ): OutboundPrefillItem[] {
+    return items
+      .map((item) => {
+        const plannedQuantity = Number(item.plannedQuantity ?? 0);
+        const outboundQuantity = Number(item.outboundQuantity ?? 0);
+        const demandItem = demandItemById.get(Number(item.shippingDemandItemId));
+        return {
+          logisticsOrderItemId: Number(item.id),
+          shippingDemandItemId: Number(item.shippingDemandItemId),
+          salesOrderItemId: Number(item.salesOrderItemId),
+          skuId: Number(item.skuId),
+          skuCode: item.skuCode,
+          productNameCn: item.productNameCn ?? null,
+          productNameEn: item.productNameEn ?? null,
+          unitName: item.unitName ?? null,
+          purchaseSubject: demandItem?.purchaseSupplierName ?? null,
+          salesUnitPrice:
+            salesPriceBySalesOrderItemId.get(Number(item.salesOrderItemId)) ??
+            demandItem?.unitPrice ??
+            null,
+          costUnitPrice:
+            purchaseCostByDemandItemId.get(Number(item.shippingDemandItemId)) ??
+            null,
+          plannedQuantity,
+          outboundQuantity,
+          remainingQuantity: Math.max(0, plannedQuantity - outboundQuantity),
+        };
+      })
+      .filter((item) => item.remainingQuantity > 0)
+      .sort((a, b) => a.logisticsOrderItemId - b.logisticsOrderItemId);
+  }
+
+  private async findShippingDemandItemsById(
+    queryRunner: QueryRunner,
+    shippingDemandItemIds: number[],
+  ): Promise<Map<number, ShippingDemandItem>> {
+    if (!shippingDemandItemIds.length) {
+      return new Map();
+    }
+
+    const items = await queryRunner.manager.getRepository(ShippingDemandItem).find({
+      where: { id: In(shippingDemandItemIds) },
+    });
+
+    return new Map(items.map((item) => [Number(item.id), item]));
+  }
+
+  private async findSalesPriceBySalesOrderItemId(
+    queryRunner: QueryRunner,
+    salesOrderItemIds: number[],
+  ): Promise<Map<number, string | null>> {
+    if (!salesOrderItemIds.length) {
+      return new Map();
+    }
+
+    const items = await queryRunner.manager.getRepository(SalesOrderItem).find({
+      where: { id: In(salesOrderItemIds) },
+    });
+
+    return new Map(
+      items.map((item) => [Number(item.id), item.unitPrice ?? null]),
+    );
+  }
+
+  private async findPurchaseCostByDemandItemId(
+    queryRunner: QueryRunner,
+    shippingDemandItemIds: number[],
+  ): Promise<Map<number, string | null>> {
+    if (!shippingDemandItemIds.length) {
+      return new Map();
+    }
+
+    const items = await queryRunner.manager
+      .getRepository(PurchaseOrderItem)
+      .createQueryBuilder('item')
+      .innerJoin('item.purchaseOrder', 'purchaseOrder')
+      .where('item.shipping_demand_item_id IN (:...shippingDemandItemIds)', {
+        shippingDemandItemIds,
+      })
+      .orderBy('purchaseOrder.created_at', 'DESC')
+      .addOrderBy('item.id', 'DESC')
+      .getMany();
+
+    const costByDemandItemId = new Map<number, string | null>();
+    for (const item of items) {
+      const demandItemId = Number(item.shippingDemandItemId);
+      if (!demandItemId || costByDemandItemId.has(demandItemId)) {
+        continue;
+      }
+      costByDemandItemId.set(demandItemId, item.unitPrice ?? null);
+    }
+
+    return costByDemandItemId;
+  }
+
+  private async createInTransaction(
+    queryRunner: QueryRunner,
+    dto: CreateOutboundOrderDto,
+    operator?: string,
+  ): Promise<OutboundOrder> {
+    const logisticsOrder = await this.findLogisticsOrderForOutbound(
+      queryRunner,
+      dto.logisticsOrderId,
+      true,
+    );
+    const lines = await this.prepareOutboundLines(queryRunner, logisticsOrder, dto);
+
+    const outboundOrderRepo = queryRunner.manager.getRepository(OutboundOrder);
+    const outboundItemRepo = queryRunner.manager.getRepository(OutboundOrderItem);
+    const consumptionRepo = queryRunner.manager.getRepository(
+      OutboundAllocationConsumption,
+    );
+    const outboundUser = await this.resolveOutboundUser(
+      queryRunner,
+      Number(dto.outboundUserId),
+    );
+    const salesCompany = await this.resolveSalesCompany(
+      queryRunner,
+      Number(dto.salesCompanyId),
+    );
+
+    const outboundCode = await this.generateOutboundCode(queryRunner);
+
+    const savedOutboundOrder = await outboundOrderRepo.save(
+      outboundOrderRepo.create({
+        outboundCode,
+        logisticsOrderId: Number(logisticsOrder.id),
+        logisticsOrderCode: logisticsOrder.orderCode,
+        shippingDemandId: Number(logisticsOrder.shippingDemandId),
+        shippingDemandCode: logisticsOrder.shippingDemandCode,
+        salesOrderId: Number(logisticsOrder.salesOrderId),
+        salesOrderCode: logisticsOrder.salesOrderCode,
+        outboundUserId: Number(dto.outboundUserId),
+        outboundUserName: outboundUser.name || outboundUser.username,
+        outboundDate: dto.outboundDate,
+        outboundType: dto.outboundType,
+        salesCompanyId: Number(dto.salesCompanyId),
+        salesCompanyName: salesCompany.nameCn,
+        warehouseId: Number(dto.warehouseId),
+        warehouseName: lines[0]?.warehouseName ?? '',
+        status: OutboundOrderStatus.CONFIRMED,
+        salesTotalAmount: this.decimal(
+          lines.reduce(
+            (sum, line) => sum + line.salesUnitPrice * line.requestedQuantity,
+            0,
+          ),
+        ),
+        costTotalAmount: this.decimal(
+          lines.reduce(
+            (sum, line) => sum + line.costUnitPrice * line.requestedQuantity,
+            0,
+          ),
+        ),
+        remark: dto.remark?.trim() || null,
+        sourceActionKey: dto.requestKey,
+        createdBy: operator,
+        updatedBy: operator,
+      }),
+    );
+
+    const savedItems = await outboundItemRepo.save(
+      lines.map((line) =>
+        outboundItemRepo.create({
+          outboundOrderId: Number(savedOutboundOrder.id),
+          logisticsOrderItemId: Number(line.logisticsItem.id),
+          shippingDemandItemId: Number(line.demandItem.id),
+          salesOrderItemId: Number(line.demandItem.salesOrderItemId),
+          skuId: Number(line.logisticsItem.skuId),
+          skuCode: line.logisticsItem.skuCode,
+          productNameCn: line.logisticsItem.productNameCn ?? null,
+          productNameEn: line.logisticsItem.productNameEn ?? null,
+          unitName: line.logisticsItem.unitName ?? null,
+          plannedQuantity: Number(line.logisticsItem.plannedQuantity ?? 0),
+          previousOutboundQuantity: Number(
+            line.logisticsItem.outboundQuantity ?? 0,
+          ),
+          outboundQuantity: line.requestedQuantity,
+          warehouseId: line.warehouseId,
+          warehouseName: line.warehouseName,
+          createdBy: operator,
+          updatedBy: operator,
+        }),
+      ),
+    );
+
+    const shippingDemandItemIds = [
+      ...new Set(lines.map((line) => Number(line.demandItem.id))),
+    ];
+    const salesOrderItemIds = [
+      ...new Set(lines.map((line) => Number(line.demandItem.salesOrderItemId))),
+    ];
+    const demandIds = [...new Set(lines.map((line) => Number(line.demandItem.shippingDemandId)))];
+    const demandItemRepo = queryRunner.manager.getRepository(ShippingDemandItem);
+    const salesOrderItemRepo = queryRunner.manager.getRepository(SalesOrderItem);
+    const logisticsOrderItemRepo = queryRunner.manager.getRepository(LogisticsOrderItem);
+    const allocationRepo = queryRunner.manager.getRepository(
+      ShippingDemandInventoryAllocation,
+    );
+
+    const savedItemByLogisticsItemId = new Map(
+      savedItems.map((item) => [Number(item.logisticsOrderItemId), item]),
+    );
+
+    for (const line of lines) {
+      const outboundItem = savedItemByLogisticsItemId.get(
+        Number(line.logisticsItem.id),
+      );
+      if (!outboundItem) continue;
+
+      const inventoryAllocations = line.allocations.map((item) => ({
+        batchId: Number(item.allocation.inventoryBatchId),
+        quantity: item.quantity,
+      }));
+      const itemActionKey = `${dto.requestKey}:item:${outboundItem.id}`;
+
+      await this.inventoryService.deductLockedStockInTransaction(queryRunner, {
+        skuId: Number(line.logisticsItem.skuId),
+        warehouseId: line.warehouseId,
+        allocations: inventoryAllocations,
+        sourceDocumentType: 'outbound_order',
+        sourceDocumentId: Number(savedOutboundOrder.id),
+        sourceDocumentItemId: Number(outboundItem.id),
+        sourceActionKey: itemActionKey,
+        operator,
+      });
+
+      const consumptionRows: AllocationConsumptionResult[] = [];
+      for (const allocationLine of line.allocations) {
+        allocationLine.allocation.lockedQuantity =
+          Number(allocationLine.allocation.lockedQuantity ?? 0) -
+          allocationLine.quantity;
+        allocationLine.allocation.shippedQuantity =
+          Number(allocationLine.allocation.shippedQuantity ?? 0) +
+          allocationLine.quantity;
+        allocationLine.allocation.status =
+          Number(allocationLine.allocation.lockedQuantity ?? 0) === 0
+            ? ShippingDemandAllocationStatus.SHIPPED
+            : ShippingDemandAllocationStatus.ACTIVE;
+        if (operator !== undefined) {
+          allocationLine.allocation.updatedBy = operator;
+        }
+        await allocationRepo.save(allocationLine.allocation);
+        consumptionRows.push({
+          allocationId: Number(allocationLine.allocation.id),
+          inventoryBatchId: Number(allocationLine.allocation.inventoryBatchId),
+          consumedQuantity: allocationLine.quantity,
+        });
+      }
+
+      await consumptionRepo.save(
+        consumptionRows.map((row) =>
+          consumptionRepo.create({
+            outboundOrderItemId: Number(outboundItem.id),
+            shippingDemandAllocationId: row.allocationId,
+            inventoryBatchId: row.inventoryBatchId,
+            consumedQuantity: row.consumedQuantity,
+            createdBy: operator,
+            updatedBy: operator,
+          }),
+        ),
+      );
+    }
+
+    await this.refreshShippingDemandItemQuantities(
+      queryRunner,
+      shippingDemandItemIds,
+      operator,
+    );
+    await this.refreshLogisticsOrderItemOutboundQuantities(
+      queryRunner,
+      [Number(logisticsOrder.id)],
+      operator,
+    );
+    await this.refreshSalesOrderItemShippedQuantities(
+      queryRunner,
+      salesOrderItemIds,
+      operator,
+    );
+
+    const refreshedDemands = await this.findShippingDemandsForUpdate(
+      queryRunner,
+      demandIds,
+    );
+    const demandStatusChanges = await this.updateShippingDemandStatusesAfterOutbound(
+      queryRunner,
+      refreshedDemands,
+      operator,
+    );
+    const salesOrderStatusChanges = await this.updateSalesOrderStatusesAfterOutbound(
+      queryRunner,
+      refreshedDemands,
+      operator,
+    );
+    await this.updateLogisticsOrderStatusAfterOutbound(
+      queryRunner,
+      logisticsOrder,
+      operator,
+    );
+
+    await this.writeCreateOperationLog(
+      queryRunner,
+      savedOutboundOrder,
+      logisticsOrder,
+      lines,
+      operator,
+    );
+    await this.writeShippingDemandStatusOperationLogs(
+      queryRunner,
+      savedOutboundOrder,
+      demandStatusChanges,
+      operator,
+    );
+    await this.writeSalesOrderStatusOperationLogs(
+      queryRunner,
+      savedOutboundOrder,
+      salesOrderStatusChanges,
+      operator,
+    );
+    await this.writeLogisticsOrderOutboundOperationLog(
+      queryRunner,
+      logisticsOrder,
+      savedOutboundOrder,
+      lines,
+      operator,
+    );
+
+    return savedOutboundOrder;
+  }
+
+  private async prepareOutboundLines(
+    queryRunner: QueryRunner,
+    logisticsOrder: LogisticsOrder,
+    dto: CreateOutboundOrderDto,
+  ): Promise<PreparedOutboundLine[]> {
+    const duplicatedLogisticsItemIds = this.findDuplicatedIds(
+      dto.items.map((item) => Number(item.logisticsOrderItemId)),
+    );
+    if (duplicatedLogisticsItemIds.length) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_DUPLICATE_LOGISTICS_ITEM',
+        message: `存在重复的物流单明细：${duplicatedLogisticsItemIds.join('、')}`,
+      });
+    }
+
+    const requestedByLogisticsItemId = new Map(
+      dto.items.map((item) => [Number(item.logisticsOrderItemId), item]),
+    );
+    const warehouses = await this.resolveWarehouses(
+      queryRunner,
+      [Number(dto.warehouseId)],
+    );
+    const logisticsItems = (logisticsOrder.items ?? []).sort(
+      (a, b) => Number(a.id) - Number(b.id),
+    );
+    if (!logisticsItems.length) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_ITEMS_EMPTY',
+        message: '当前物流单没有货物明细，无法创建发货出库单',
+      });
+    }
+
+    const demandItemIds = logisticsItems.map((item) =>
+      Number(item.shippingDemandItemId),
+    );
+    const demandItems = await queryRunner.manager.getRepository(ShippingDemandItem).find({
+      where: { id: In(demandItemIds) },
+    });
+    const demandItemById = new Map(
+      demandItems.map((item) => [Number(item.id), item]),
+    );
+    const salesPriceBySalesOrderItemId =
+      await this.findSalesPriceBySalesOrderItemId(
+        queryRunner,
+        logisticsItems.map((item) => Number(item.salesOrderItemId)),
+      );
+    const purchaseCostByDemandItemId =
+      await this.findPurchaseCostByDemandItemId(queryRunner, demandItemIds);
+
+    const lines: PreparedOutboundLine[] = [];
+    for (const logisticsItem of logisticsItems) {
+      const requested = requestedByLogisticsItemId.get(Number(logisticsItem.id));
+      if (!requested) {
+        continue;
+      }
+      if (!Number.isInteger(requested.outboundQuantity) || requested.outboundQuantity <= 0) {
+        throw new BadRequestException({
+          code: 'OUTBOUND_ORDER_QUANTITY_INVALID',
+          message: `${logisticsItem.skuCode} 的实际出库数量必须为正整数`,
+        });
+      }
+
+      const demandItem = demandItemById.get(Number(logisticsItem.shippingDemandItemId));
+      if (!demandItem) {
+        throw new BadRequestException({
+          code: 'OUTBOUND_ORDER_DEMAND_ITEM_NOT_FOUND',
+          message: `${logisticsItem.skuCode} 缺少关联发货需求明细，无法出库`,
+        });
+      }
+
+      const plannedQuantity = Number(logisticsItem.plannedQuantity ?? 0);
+      const outboundQuantity = Number(logisticsItem.outboundQuantity ?? 0);
+      const remainingQuantity = Math.max(0, plannedQuantity - outboundQuantity);
+      if (requested.outboundQuantity > remainingQuantity) {
+        throw new BadRequestException({
+          code: 'OUTBOUND_ORDER_QUANTITY_EXCEEDS_REMAINING',
+          message: `${logisticsItem.skuCode} 的实际出库数量不能超过剩余可出库数量 ${remainingQuantity}`,
+        });
+      }
+
+      const warehouse = warehouses.get(Number(dto.warehouseId));
+      if (!warehouse) {
+        throw new BadRequestException({
+          code: 'OUTBOUND_ORDER_WAREHOUSE_NOT_FOUND',
+          message: `${logisticsItem.skuCode} 的出库仓库不存在`,
+        });
+      }
+
+      const allocations = await this.pickAllocationsForOutbound(
+        queryRunner,
+        demandItem,
+        Number(dto.warehouseId),
+        requested.outboundQuantity,
+      );
+
+      lines.push({
+        logisticsItem,
+        demandItem,
+        requestedQuantity: requested.outboundQuantity,
+        remainingQuantity,
+        warehouseId: Number(dto.warehouseId),
+        warehouseName: warehouse.name,
+        salesUnitPrice: Number(
+          salesPriceBySalesOrderItemId.get(Number(logisticsItem.salesOrderItemId)) ??
+            demandItem.unitPrice ??
+            0,
+        ),
+        costUnitPrice: Number(
+          purchaseCostByDemandItemId.get(Number(demandItem.id)) ?? 0,
+        ),
+        allocations,
+      });
+    }
+
+    if (!lines.length) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_ITEMS_EMPTY',
+        message: '至少需要填写一条出库数量大于 0 的明细',
+      });
+    }
+    if (lines.length !== requestedByLogisticsItemId.size) {
+      const existingIds = new Set(logisticsItems.map((item) => Number(item.id)));
+      const missingIds = [...requestedByLogisticsItemId.keys()].filter(
+        (id) => !existingIds.has(id),
+      );
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_ITEM_NOT_IN_LOGISTICS_ORDER',
+        message: `以下物流单明细不属于当前物流单：${missingIds.join('、')}`,
+      });
+    }
+
+    return lines;
+  }
+
+  private async pickAllocationsForOutbound(
+    queryRunner: QueryRunner,
+    demandItem: ShippingDemandItem,
+    warehouseId: number,
+    quantity: number,
+  ) {
+    const allocations = await queryRunner.manager
+      .getRepository(ShippingDemandInventoryAllocation)
+      .createQueryBuilder('allocation')
+      .where('allocation.shipping_demand_item_id = :shippingDemandItemId', {
+        shippingDemandItemId: Number(demandItem.id),
+      })
+      .andWhere('allocation.warehouse_id = :warehouseId', {
+        warehouseId,
+      })
+      .andWhere('allocation.status = :status', {
+        status: ShippingDemandAllocationStatus.ACTIVE,
+      })
+      .andWhere('allocation.locked_quantity > 0')
+      .leftJoinAndSelect('allocation.inventoryBatch', 'inventoryBatch')
+      .orderBy('inventoryBatch.receipt_date', 'ASC')
+      .addOrderBy('inventoryBatch.id', 'ASC')
+      .addOrderBy('allocation.id', 'ASC')
+      .setLock('pessimistic_write')
+      .getMany();
+
+    let remaining = quantity;
+    const picked: Array<{
+      allocation: ShippingDemandInventoryAllocation;
+      quantity: number;
+    }> = [];
+
+    for (const allocation of allocations) {
+      if (remaining <= 0) break;
+      const lockedQuantity = Number(allocation.lockedQuantity ?? 0);
+      if (lockedQuantity <= 0) continue;
+      const consumedQuantity = Math.min(lockedQuantity, remaining);
+      picked.push({ allocation, quantity: consumedQuantity });
+      remaining -= consumedQuantity;
+    }
+
+    if (remaining > 0) {
+      const availableLocked = picked.reduce((sum, item) => sum + item.quantity, 0);
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_LOCKED_QUANTITY_EXCEEDED',
+        message: `${demandItem.skuCode} 的出库数量超过本发货需求在该仓库的锁定量`,
+        availableLocked,
+      });
+    }
+
+    return picked;
+  }
+
+  private async resolveWarehouses(
+    queryRunner: QueryRunner,
+    warehouseIds: number[],
+  ): Promise<Map<number, { id: number; name: string }>> {
+    if (!warehouseIds.length) return new Map();
+    const warehouses = await queryRunner.manager.getRepository(Warehouse).find({
+      where: { id: In(warehouseIds) },
+    });
+    return new Map(
+      warehouses.map((warehouse) => [
+        Number(warehouse.id),
+        { id: Number(warehouse.id), name: warehouse.name },
+      ]),
+    );
+  }
+
+  private async resolveOutboundUser(
+    queryRunner: QueryRunner,
+    outboundUserId: number,
+  ): Promise<User> {
+    const user = await queryRunner.manager.getRepository(User).findOne({
+      where: { id: outboundUserId },
+    });
+    if (!user) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_USER_NOT_FOUND',
+        message: '出库员不存在',
+      });
+    }
+    return user;
+  }
+
+  private async resolveSalesCompany(
+    queryRunner: QueryRunner,
+    salesCompanyId: number,
+  ): Promise<Company> {
+    const company = await queryRunner.manager.getRepository(Company).findOne({
+      where: { id: salesCompanyId },
+    });
+    if (!company) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_COMPANY_NOT_FOUND',
+        message: '销售主体不存在',
+      });
+    }
+    return company;
+  }
+
+  private async refreshShippingDemandItemQuantities(
+    queryRunner: QueryRunner,
+    shippingDemandItemIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!shippingDemandItemIds.length) return;
+
+    const rows = await queryRunner.manager
+      .getRepository(ShippingDemandInventoryAllocation)
+      .createQueryBuilder('allocation')
+      .select('allocation.shipping_demand_item_id', 'shippingDemandItemId')
+      .addSelect('SUM(allocation.locked_quantity)', 'lockedQuantity')
+      .addSelect('SUM(allocation.shipped_quantity)', 'shippedQuantity')
+      .where('allocation.shipping_demand_item_id IN (:...shippingDemandItemIds)', {
+        shippingDemandItemIds,
+      })
+      .groupBy('allocation.shipping_demand_item_id')
+      .getRawMany<{
+        shippingDemandItemId: string;
+        lockedQuantity: string;
+        shippedQuantity: string;
+      }>();
+
+    const snapshotByItemId = new Map(
+      rows.map((row) => [
+        Number(row.shippingDemandItemId),
+        {
+          lockedRemainingQuantity: Number(row.lockedQuantity ?? 0),
+          shippedQuantity: Number(row.shippedQuantity ?? 0),
+        },
+      ]),
+    );
+
+    const repo = queryRunner.manager.getRepository(ShippingDemandItem);
+    const items = await repo.find({
+      where: { id: In(shippingDemandItemIds) },
+    });
+
+    for (const item of items) {
+      const snapshot = snapshotByItemId.get(Number(item.id));
+      item.lockedRemainingQuantity = snapshot?.lockedRemainingQuantity ?? 0;
+      item.shippedQuantity = snapshot?.shippedQuantity ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await repo.save(items);
+  }
+
+  private async refreshLogisticsOrderItemOutboundQuantities(
+    queryRunner: QueryRunner,
+    logisticsOrderIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!logisticsOrderIds.length) return;
+
+    const rows = await queryRunner.manager
+      .getRepository(OutboundOrderItem)
+      .createQueryBuilder('item')
+      .innerJoin('item.outboundOrder', 'outboundOrder')
+      .select('item.logistics_order_item_id', 'logisticsOrderItemId')
+      .addSelect('SUM(item.outbound_quantity)', 'outboundQuantity')
+      .where('outboundOrder.logistics_order_id IN (:...logisticsOrderIds)', {
+        logisticsOrderIds,
+      })
+      .groupBy('item.logistics_order_item_id')
+      .getRawMany<{
+        logisticsOrderItemId: string;
+        outboundQuantity: string;
+      }>();
+
+    const quantityByItemId = new Map(
+      rows.map((row) => [
+        Number(row.logisticsOrderItemId),
+        Number(row.outboundQuantity ?? 0),
+      ]),
+    );
+
+    const logisticsItemRepo = queryRunner.manager.getRepository(LogisticsOrderItem);
+    const logisticsItems = await logisticsItemRepo
+      .createQueryBuilder('item')
+      .where('item.logistics_order_id IN (:...logisticsOrderIds)', {
+        logisticsOrderIds,
+      })
+      .getMany();
+
+    for (const item of logisticsItems) {
+      item.outboundQuantity = quantityByItemId.get(Number(item.id)) ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await logisticsItemRepo.save(logisticsItems);
+  }
+
+  private async refreshSalesOrderItemShippedQuantities(
+    queryRunner: QueryRunner,
+    salesOrderItemIds: number[],
+    operator?: string,
+  ): Promise<void> {
+    if (!salesOrderItemIds.length) return;
+
+    const rows = await queryRunner.manager
+      .getRepository(ShippingDemandItem)
+      .createQueryBuilder('item')
+      .innerJoin('item.shippingDemand', 'demand')
+      .select('item.sales_order_item_id', 'salesOrderItemId')
+      .addSelect('SUM(item.purchase_required_quantity)', 'purchaseQuantity')
+      .addSelect('SUM(item.stock_required_quantity)', 'useStockQuantity')
+      .addSelect('SUM(item.locked_remaining_quantity)', 'lockedQuantity')
+      .addSelect('SUM(item.shipped_quantity)', 'shippedQuantity')
+      .where('item.sales_order_item_id IN (:...salesOrderItemIds)', {
+        salesOrderItemIds,
+      })
+      .andWhere('demand.status != :voided', {
+        voided: ShippingDemandStatus.VOIDED,
+      })
+      .groupBy('item.sales_order_item_id')
+      .getRawMany<{
+        salesOrderItemId: string;
+        purchaseQuantity: string;
+        useStockQuantity: string;
+        lockedQuantity: string;
+        shippedQuantity: string;
+      }>();
+
+    const snapshotByItemId = new Map(
+      rows.map((row) => [
+        Number(row.salesOrderItemId),
+        {
+          purchaseQuantity: Number(row.purchaseQuantity ?? 0),
+          useStockQuantity: Number(row.useStockQuantity ?? 0),
+          preparedQuantity:
+            Number(row.lockedQuantity ?? 0) + Number(row.shippedQuantity ?? 0),
+          shippedQuantity: Number(row.shippedQuantity ?? 0),
+        },
+      ]),
+    );
+
+    const repo = queryRunner.manager.getRepository(SalesOrderItem);
+    const items = await repo.find({
+      where: { id: In(salesOrderItemIds) },
+    });
+
+    for (const item of items) {
+      const snapshot = snapshotByItemId.get(Number(item.id));
+      item.purchaseQuantity = snapshot?.purchaseQuantity ?? 0;
+      item.useStockQuantity = snapshot?.useStockQuantity ?? 0;
+      item.preparedQuantity = snapshot?.preparedQuantity ?? 0;
+      item.shippedQuantity = snapshot?.shippedQuantity ?? 0;
+      if (operator !== undefined) {
+        item.updatedBy = operator;
+      }
+    }
+
+    await repo.save(items);
+  }
+
+  private async findShippingDemandsForUpdate(
+    queryRunner: QueryRunner,
+    demandIds: number[],
+  ): Promise<ShippingDemand[]> {
+    if (!demandIds.length) return [];
+
+    return queryRunner.manager
+      .getRepository(ShippingDemand)
+      .createQueryBuilder('demand')
+      .leftJoinAndSelect('demand.items', 'items')
+      .setLock('pessimistic_write')
+      .where('demand.id IN (:...demandIds)', { demandIds })
+      .orderBy('demand.id', 'ASC')
+      .addOrderBy('items.id', 'ASC')
+      .getMany();
+  }
+
+  private async updateShippingDemandStatusesAfterOutbound(
+    queryRunner: QueryRunner,
+    demands: ShippingDemand[],
+    operator?: string,
+  ): Promise<ShippingDemandStatusChange[]> {
+    const repo = queryRunner.manager.getRepository(ShippingDemand);
+    const changes: ShippingDemandStatusChange[] = [];
+
+    for (const demand of demands) {
+      if (demand.status === ShippingDemandStatus.VOIDED) {
+        continue;
+      }
+
+      const oldStatus = demand.status as ShippingDemandStatus;
+      const items = demand.items ?? [];
+      const allShipped =
+        items.length > 0 &&
+        items.every(
+          (item) =>
+            Number(item.shippedQuantity ?? 0) >=
+            Number(item.requiredQuantity ?? 0),
+        );
+      const anyShipped = items.some(
+        (item) => Number(item.shippedQuantity ?? 0) > 0,
+      );
+
+      let nextStatus = oldStatus;
+      if (allShipped) {
+        nextStatus = ShippingDemandStatus.SHIPPED;
+      } else if (anyShipped) {
+        nextStatus = ShippingDemandStatus.PARTIALLY_SHIPPED;
+      }
+
+      if (nextStatus === oldStatus) continue;
+
+      demand.status = nextStatus;
+      if (operator !== undefined) {
+        demand.updatedBy = operator;
+      }
+      const savedDemand = await repo.save(demand);
+      changes.push({
+        demand: savedDemand,
+        oldStatus,
+      });
+    }
+
+    return changes;
+  }
+
+  private async updateSalesOrderStatusesAfterOutbound(
+    queryRunner: QueryRunner,
+    demands: ShippingDemand[],
+    operator?: string,
+  ): Promise<SalesOrderStatusChange[]> {
+    const salesOrderIds = [
+      ...new Set(demands.map((demand) => Number(demand.salesOrderId))),
+    ];
+    if (!salesOrderIds.length) return [];
+
+    const demandRows = await queryRunner.manager
+      .getRepository(ShippingDemand)
+      .createQueryBuilder('demand')
+      .select('demand.sales_order_id', 'salesOrderId')
+      .addSelect('MAX(CASE WHEN demand.status = :shipped THEN 1 ELSE 0 END)', 'hasShipped')
+      .addSelect(
+        'MIN(CASE WHEN demand.status = :shipped THEN 1 ELSE 0 END)',
+        'allShipped',
+      )
+      .where('demand.sales_order_id IN (:...salesOrderIds)', { salesOrderIds })
+      .andWhere('demand.status != :voided', {
+        voided: ShippingDemandStatus.VOIDED,
+      })
+      .setParameters({ shipped: ShippingDemandStatus.SHIPPED })
+      .groupBy('demand.sales_order_id')
+      .getRawMany<{
+        salesOrderId: string;
+        hasShipped: string;
+        allShipped: string;
+      }>();
+
+    const statusBySalesOrderId = new Map<number, SalesOrderStatus>();
+    for (const row of demandRows) {
+      const hasShipped = Number(row.hasShipped ?? 0) === 1;
+      const allShipped = Number(row.allShipped ?? 0) === 1;
+      if (allShipped) {
+        statusBySalesOrderId.set(Number(row.salesOrderId), SalesOrderStatus.SHIPPED);
+      } else if (hasShipped) {
+        statusBySalesOrderId.set(
+          Number(row.salesOrderId),
+          SalesOrderStatus.PARTIALLY_SHIPPED,
+        );
+      }
+    }
+
+    const repo = queryRunner.manager.getRepository(SalesOrder);
+    const orders = await repo
+      .createQueryBuilder('salesOrder')
+      .setLock('pessimistic_write')
+      .where('salesOrder.id IN (:...salesOrderIds)', { salesOrderIds })
+      .getMany();
+
+    const changes: SalesOrderStatusChange[] = [];
+    for (const order of orders) {
+      const nextStatus = statusBySalesOrderId.get(Number(order.id));
+      if (!nextStatus || nextStatus === order.status) continue;
+      const oldStatus = order.status as SalesOrderStatus;
+      order.status = nextStatus;
+      if (operator !== undefined) {
+        order.updatedBy = operator;
+      }
+      changes.push({
+        order: await repo.save(order),
+        oldStatus,
+      });
+    }
+
+    return changes;
+  }
+
+  private async updateLogisticsOrderStatusAfterOutbound(
+    queryRunner: QueryRunner,
+    logisticsOrder: LogisticsOrder,
+    operator?: string,
+  ): Promise<void> {
+    const items = await queryRunner.manager.getRepository(LogisticsOrderItem).find({
+      where: { logisticsOrderId: Number(logisticsOrder.id) },
+    });
+    const allItemsShipped = items.every((item) => {
+      const plannedQuantity = Number(item.plannedQuantity ?? 0);
+      const outboundQuantity = Number(item.outboundQuantity ?? 0);
+      return outboundQuantity >= plannedQuantity;
+    });
+    if (!allItemsShipped) return;
+
+    const repo = queryRunner.manager.getRepository(LogisticsOrder);
+    logisticsOrder.status = LogisticsOrderStatus.SHIPPED;
+    if (operator !== undefined) {
+      logisticsOrder.updatedBy = operator;
+    }
+    await repo.save(logisticsOrder);
+  }
+
+  private async findLogisticsOrderForOutbound(
+    queryRunner: QueryRunner,
+    logisticsOrderId: number,
+    lock = false,
+  ): Promise<LogisticsOrder> {
+    const qb = queryRunner.manager
+      .getRepository(LogisticsOrder)
+      .createQueryBuilder('logisticsOrder')
+      .leftJoinAndSelect('logisticsOrder.items', 'items')
+      .where('logisticsOrder.id = :logisticsOrderId', { logisticsOrderId })
+      .orderBy('items.id', 'ASC');
+
+    if (lock) {
+      qb.setLock('pessimistic_write');
+    }
+
+    const logisticsOrder = await qb.getOne();
+    if (!logisticsOrder) {
+      throw new NotFoundException('物流单不存在');
+    }
+    if (logisticsOrder.status !== LogisticsOrderStatus.CONFIRMED) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_LOGISTICS_STATUS_INVALID',
+        message: '只有已确认的物流单可以创建发货出库单',
+      });
+    }
+
+    const hasRemainingItems = (logisticsOrder.items ?? []).some((item) => {
+      const plannedQuantity = Number(item.plannedQuantity ?? 0);
+      const outboundQuantity = Number(item.outboundQuantity ?? 0);
+      return plannedQuantity - outboundQuantity > 0;
+    });
+    if (!hasRemainingItems) {
+      throw new BadRequestException({
+        code: 'OUTBOUND_ORDER_LOGISTICS_FULLY_SHIPPED',
+        message: '当前物流单已经全部出库，无需重复创建发货出库单',
+      });
+    }
+
+    return logisticsOrder;
+  }
+
+  private async writeCreateOperationLog(
+    queryRunner: QueryRunner,
+    outboundOrder: OutboundOrder,
+    logisticsOrder: LogisticsOrder,
+    lines: PreparedOutboundLine[],
+    operator?: string,
+  ): Promise<void> {
+    const repo = queryRunner.manager.getRepository(OperationLog);
+    await repo.save(
+      repo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.CREATE,
+        resourceType: 'outbound-orders',
+        resourceId: String(outboundOrder.id),
+        resourcePath: '/api/outbound-orders',
+        requestSummary: {
+          sourceAction: 'confirm_outbound_order_from_logistics_order',
+          logisticsOrderId: Number(logisticsOrder.id),
+          logisticsOrderCode: logisticsOrder.orderCode,
+          itemCount: lines.length,
+          totalQuantity: lines.reduce(
+            (sum, line) => sum + line.requestedQuantity,
+            0,
+          ),
+        },
+        changeSummary: [
+          {
+            field: 'status',
+            fieldLabel: '出库单状态',
+            oldValue: null,
+            newValue: OutboundOrderStatus.CONFIRMED,
+          },
+          {
+            field: 'outboundType',
+            fieldLabel: '出库类型',
+            oldValue: null,
+            newValue: outboundOrder.outboundType ?? OutboundOrderType.SALES,
+          },
+        ],
+      }),
+    );
+  }
+
+  private async writeShippingDemandStatusOperationLogs(
+    queryRunner: QueryRunner,
+    outboundOrder: OutboundOrder,
+    changes: ShippingDemandStatusChange[],
+    operator?: string,
+  ): Promise<void> {
+    if (!changes.length) return;
+    const repo = queryRunner.manager.getRepository(OperationLog);
+
+    for (const change of changes) {
+      await repo.save(
+        repo.create({
+          operator: operator ?? 'system',
+          operatorId: null,
+          action: OperationLogAction.UPDATE,
+          resourceType: 'shipping-demands',
+          resourceId: String(change.demand.id),
+          resourcePath: `/api/outbound-orders/${outboundOrder.id}`,
+          requestSummary: {
+            sourceAction: 'outbound_order_confirmed',
+            outboundOrderId: Number(outboundOrder.id),
+            outboundCode: outboundOrder.outboundCode,
+          },
+          changeSummary: [
+            {
+              field: 'status',
+              fieldLabel: '发货需求状态',
+              oldValue: change.oldStatus,
+              newValue: change.demand.status,
+            },
+          ],
+        }),
+      );
+    }
+  }
+
+  private async writeSalesOrderStatusOperationLogs(
+    queryRunner: QueryRunner,
+    outboundOrder: OutboundOrder,
+    changes: SalesOrderStatusChange[],
+    operator?: string,
+  ): Promise<void> {
+    if (!changes.length) return;
+    const repo = queryRunner.manager.getRepository(OperationLog);
+
+    for (const change of changes) {
+      await repo.save(
+        repo.create({
+          operator: operator ?? 'system',
+          operatorId: null,
+          action: OperationLogAction.UPDATE,
+          resourceType: 'sales-orders',
+          resourceId: String(change.order.id),
+          resourcePath: `/api/outbound-orders/${outboundOrder.id}`,
+          requestSummary: {
+            sourceAction: 'outbound_order_confirmed',
+            outboundOrderId: Number(outboundOrder.id),
+            outboundCode: outboundOrder.outboundCode,
+          },
+          changeSummary: [
+            {
+              field: 'status',
+              fieldLabel: '销售订单状态',
+              oldValue: change.oldStatus,
+              newValue: change.order.status,
+            },
+          ],
+        }),
+      );
+    }
+  }
+
+  private async writeLogisticsOrderOutboundOperationLog(
+    queryRunner: QueryRunner,
+    logisticsOrder: LogisticsOrder,
+    outboundOrder: OutboundOrder,
+    lines: PreparedOutboundLine[],
+    operator?: string,
+  ): Promise<void> {
+    const repo = queryRunner.manager.getRepository(OperationLog);
+    await repo.save(
+      repo.create({
+        operator: operator ?? 'system',
+        operatorId: null,
+        action: OperationLogAction.UPDATE,
+        resourceType: 'logistics-orders',
+        resourceId: String(logisticsOrder.id),
+        resourcePath: `/api/outbound-orders/${outboundOrder.id}`,
+        requestSummary: {
+          sourceAction: 'outbound_order_confirmed',
+          outboundOrderId: Number(outboundOrder.id),
+          outboundCode: outboundOrder.outboundCode,
+        },
+        changeSummary: [
+          {
+            field: 'outboundSummary',
+            fieldLabel: '出库结果',
+            oldValue: null,
+            newValue: lines.map((line) => ({
+              logisticsOrderItemId: Number(line.logisticsItem.id),
+              skuCode: line.logisticsItem.skuCode,
+              productNameCn: line.logisticsItem.productNameCn,
+              productNameEn: line.logisticsItem.productNameEn,
+              warehouseName: line.warehouseName,
+              outboundQuantity: line.requestedQuantity,
+            })),
+          },
+        ],
+      }),
+    );
+  }
+
+  private async generateOutboundCode(queryRunner: QueryRunner): Promise<string> {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const prefix = `QTCK${year}${month}${day}`;
+    const latest = await queryRunner.manager
+      .getRepository(OutboundOrder)
+      .createQueryBuilder('outboundOrder')
+      .setLock('pessimistic_write')
+      .where('outboundOrder.outbound_code LIKE :prefix', {
+        prefix: `${prefix}%`,
+      })
+      .orderBy('outboundOrder.outbound_code', 'DESC')
+      .getOne();
+    const lastNumber = latest?.outboundCode
+      ? Number(latest.outboundCode.slice(prefix.length))
+      : 0;
+    return `${prefix}${String(lastNumber + 1).padStart(4, '0')}`;
+  }
+
+  private async executeWithOutboundOrderCodeRetry<T>(
+    operation: (queryRunner: QueryRunner) => Promise<T>,
+  ): Promise<T> {
+    let retryCount = 0;
+    while (true) {
+      const queryRunner = this.outboundOrdersRepository.createQueryRunner();
+      let transactionStarted = false;
+      try {
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+        transactionStarted = true;
+        const result = await operation(queryRunner);
+        await queryRunner.commitTransaction();
+        return result;
+      } catch (error) {
+        if (transactionStarted) {
+          await queryRunner.rollbackTransaction();
+        }
+
+        if (
+          this.isRetryableConcurrencyError(error) &&
+          retryCount < MAX_OUTBOUND_ORDER_CODE_RETRIES
+        ) {
+          retryCount += 1;
+          await this.delay(INITIAL_RETRY_DELAY_MS * 2 ** (retryCount - 1));
+          continue;
+        }
+
+        if (this.isRetryableConcurrencyError(error)) {
+          throw new ConflictException({
+            code: 'CONCURRENT_UPDATE',
+            message: '发货出库并发更新失败，请稍后重试',
+          });
+        }
+
+        throw error;
+      } finally {
+        await queryRunner.release();
+      }
+    }
+  }
+
+  private isRetryableConcurrencyError(error: unknown): boolean {
+    const maybeError = error as { code?: string; errno?: number };
+    return (
+      maybeError?.code === 'ER_LOCK_DEADLOCK' ||
+      maybeError?.errno === 1213 ||
+      maybeError?.code === 'ER_DUP_ENTRY' ||
+      maybeError?.errno === 1062
+    );
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private findDuplicatedIds(ids: number[]): number[] {
+    const seen = new Set<number>();
+    const duplicated = new Set<number>();
+    for (const id of ids) {
+      if (seen.has(id)) {
+        duplicated.add(id);
+      }
+      seen.add(id);
+    }
+    return [...duplicated].sort((a, b) => a - b);
+  }
+
+  private decimal(value: number): string {
+    return value.toFixed(2);
+  }
+}

--- a/apps/api/src/modules/outbound-orders/tests/outbound-orders.service.spec.ts
+++ b/apps/api/src/modules/outbound-orders/tests/outbound-orders.service.spec.ts
@@ -1,0 +1,11 @@
+import { OutboundOrdersService } from '../outbound-orders.service';
+
+describe('OutboundOrdersService', () => {
+  it('is defined', () => {
+    const repository = {
+      findById: jest.fn(),
+    };
+    const service = new OutboundOrdersService(repository as any);
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,6 +70,7 @@ import PurchaseOrderFormPage from "./pages/purchase-orders/form";
 import ReceiptOrdersListPage from "./pages/receipt-orders/index";
 import ReceiptOrderDetailPage from "./pages/receipt-orders/detail";
 import ReceiptOrderFormPage from "./pages/receipt-orders/form";
+import OutboundOrderFormPage from "./pages/outbound-orders/form";
 import InventoryPage from "./pages/inventory/index";
 import InventoryTransactionsPage from "./pages/inventory/transactions";
 import HomePage from "./pages/home/index";
@@ -502,6 +503,10 @@ function App() {
                   <Route
                     path="/receipt-orders/create"
                     element={<ReceiptOrderFormPage />}
+                  />
+                  <Route
+                    path="/outbound-orders/create"
+                    element={<OutboundOrderFormPage />}
                   />
                   <Route
                     path="/inventory/transactions"

--- a/apps/web/src/api/outbound-orders.api.ts
+++ b/apps/web/src/api/outbound-orders.api.ts
@@ -1,0 +1,124 @@
+import { OutboundOrderStatus, OutboundOrderType } from "@infitek/shared";
+import request from "./request";
+
+function normalizeApiError(error: unknown): never {
+  if (typeof error === "object" && error !== null) throw error;
+  throw { message: "请求失败，请稍后重试" };
+}
+
+export interface OutboundOrderPrefillItem {
+  logisticsOrderItemId: number;
+  shippingDemandItemId: number;
+  salesOrderItemId: number;
+  skuId: number;
+  skuCode: string;
+  productNameCn?: string | null;
+  productNameEn?: string | null;
+  unitName?: string | null;
+  purchaseSubject?: string | null;
+  salesUnitPrice?: string | null;
+  costUnitPrice?: string | null;
+  plannedQuantity: number;
+  outboundQuantity: number;
+  remainingQuantity: number;
+}
+
+export interface OutboundOrderPrefill {
+  logisticsOrder: {
+    id: number;
+    orderCode: string;
+    shippingDemandId: number;
+    shippingDemandCode: string;
+    salesOrderId: number;
+    salesOrderCode: string;
+    status: string;
+    logisticsProviderName?: string | null;
+    transportationMethod?: string | null;
+  };
+  items: OutboundOrderPrefillItem[];
+}
+
+export interface CreateOutboundOrderPayload {
+  logisticsOrderId: number;
+  outboundUserId: number;
+  outboundDate: string;
+  outboundType: OutboundOrderType;
+  salesCompanyId: number;
+  warehouseId: number;
+  requestKey: string;
+  remark?: string;
+  items: Array<{
+    logisticsOrderItemId: number;
+    outboundQuantity: number;
+  }>;
+}
+
+export interface OutboundOrderItem {
+  id: number;
+  logisticsOrderItemId: number;
+  shippingDemandItemId: number;
+  salesOrderItemId: number;
+  skuId: number;
+  skuCode: string;
+  productNameCn?: string | null;
+  productNameEn?: string | null;
+  unitName?: string | null;
+  plannedQuantity: number;
+  previousOutboundQuantity: number;
+  outboundQuantity: number;
+  warehouseId: number;
+  warehouseName: string;
+}
+
+export interface OutboundOrder {
+  id: number;
+  outboundCode: string;
+  logisticsOrderId: number;
+  logisticsOrderCode: string;
+  shippingDemandId: number;
+  shippingDemandCode: string;
+  salesOrderId: number;
+  salesOrderCode: string;
+  outboundUserId: number;
+  outboundUserName: string;
+  outboundDate: string;
+  outboundType: OutboundOrderType;
+  salesCompanyId: number;
+  salesCompanyName: string;
+  warehouseId: number;
+  warehouseName: string;
+  status: OutboundOrderStatus;
+  salesTotalAmount: string;
+  costTotalAmount: string;
+  remark?: string | null;
+  items?: OutboundOrderItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const OUTBOUND_ORDER_STATUS_LABELS: Record<OutboundOrderStatus, string> = {
+  [OutboundOrderStatus.CONFIRMED]: "已确认",
+};
+
+export const OUTBOUND_ORDER_TYPE_LABELS: Record<OutboundOrderType, string> = {
+  [OutboundOrderType.SALES]: "销售出库",
+  [OutboundOrderType.LOSS]: "报损出库",
+  [OutboundOrderType.INVENTORY_LOSS]: "盘亏出库",
+  [OutboundOrderType.OTHER]: "其他",
+};
+
+export const getOutboundOrderCreatePrefill = (
+  logisticsOrderId: number,
+): Promise<OutboundOrderPrefill> =>
+  request
+    .get<unknown, OutboundOrderPrefill>("/outbound-orders/create-prefill", {
+      params: { logisticsOrderId },
+    })
+    .catch(normalizeApiError);
+
+export const createOutboundOrder = (
+  payload: CreateOutboundOrderPayload,
+): Promise<OutboundOrder> =>
+  request
+    .post<unknown, OutboundOrder>("/outbound-orders", payload)
+    .catch(normalizeApiError);

--- a/apps/web/src/components/ActivityTimeline.tsx
+++ b/apps/web/src/components/ActivityTimeline.tsx
@@ -301,6 +301,11 @@ const RESOURCE_ENUM_VALUE_LABELS: Record<
       other: "其它",
     },
   },
+  "outbound-orders": {
+    status: {
+      confirmed: "已确认",
+    },
+  },
   "logistics-providers": {
     status: {
       合作: "合作",

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -148,6 +148,14 @@ const BREADCRUMB_ROUTES: BreadcrumbRoute[] = [
     ],
   },
   {
+    pattern: /^\/outbound-orders\/create$/,
+    items: [
+      { title: "商务管理", path: COMMERCE_SECTION_PATH },
+      { title: "物流单", path: "/logistics-orders" },
+      { title: "创建发货出库单" },
+    ],
+  },
+  {
     pattern: /^\/logistics-orders$/,
     items: [
       { title: "商务管理", path: COMMERCE_SECTION_PATH },

--- a/apps/web/src/pages/logistics-orders/detail.tsx
+++ b/apps/web/src/pages/logistics-orders/detail.tsx
@@ -258,6 +258,11 @@ export default function LogisticsOrderDetailPage() {
   const canEditTracking =
     data?.status === LogisticsOrderStatus.CONFIRMED ||
     data?.status === LogisticsOrderStatus.SHIPPED;
+  const canCreateOutbound =
+    data?.status === LogisticsOrderStatus.CONFIRMED &&
+    (data?.items ?? []).some(
+      (item) => Number(item.plannedQuantity ?? 0) > Number(item.outboundQuantity ?? 0),
+    );
 
   const openTrackingEdit = () => {
     trackingForm.setFieldsValue({
@@ -310,6 +315,16 @@ export default function LogisticsOrderDetailPage() {
                   {canEditTracking ? (
                     <Button type="primary" onClick={openTrackingEdit}>
                       编辑物流跟踪
+                    </Button>
+                  ) : null}
+                  {canCreateOutbound ? (
+                    <Button
+                      type="primary"
+                      onClick={() =>
+                        navigate(`/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`)
+                      }
+                    >
+                      创建发货出库单
                     </Button>
                   ) : null}
                 </Space>
@@ -522,7 +537,21 @@ export default function LogisticsOrderDetailPage() {
               />
               <MetaItem
                 label="出库单"
-                value="发货出库单将在 Story 7.3 接入"
+                value={
+                  canCreateOutbound ? (
+                    <Button
+                      type="link"
+                      style={{ padding: 0 }}
+                      onClick={() =>
+                        navigate(`/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`)
+                      }
+                    >
+                      创建发货出库单
+                    </Button>
+                  ) : (
+                    "当前物流单无剩余待出库数量"
+                  )
+                }
                 full
               />
             </div>

--- a/apps/web/src/pages/outbound-orders/form.tsx
+++ b/apps/web/src/pages/outbound-orders/form.tsx
@@ -1,0 +1,536 @@
+import { App, Button, InputNumber, Popconfirm, Result, Skeleton, Table } from "antd";
+import {
+  ProForm,
+  ProFormDatePicker,
+  ProFormSelect,
+  ProFormText,
+  ProFormTextArea,
+  type ProFormInstance,
+} from "@ant-design/pro-components";
+import dayjs from "dayjs";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { OutboundOrderType, type OutboundOrderType as OutboundOrderTypeValue } from "@infitek/shared";
+import { createOutboundOrder, getOutboundOrderCreatePrefill, OUTBOUND_ORDER_TYPE_LABELS, type CreateOutboundOrderPayload, type OutboundOrderPrefillItem } from "../../api/outbound-orders.api";
+import { getCompanies } from "../../api/companies.api";
+import { getUsers } from "../../api/users.api";
+import { getWarehouses } from "../../api/warehouses.api";
+import { AnchorNav, SectionCard, displayOrDash } from "../master-data/components/page-scaffold";
+import "../master-data/master-page.css";
+
+interface OutboundOrderFormValues {
+  logisticsOrderCode?: string;
+  shippingDemandCode?: string;
+  salesOrderCode?: string;
+  outboundUserId?: number;
+  outboundDate?: string;
+  outboundType?: OutboundOrderTypeValue;
+  salesCompanyId?: number;
+  warehouseId?: number;
+  remark?: string;
+}
+
+interface EditableOutboundItem extends OutboundOrderPrefillItem {
+  inputOutboundQuantity?: number;
+}
+
+function parsePositiveIntParam(value: string | null) {
+  const normalized = value?.trim();
+  if (!normalized || !/^\d+$/.test(normalized)) return undefined;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function buildRequestKey(logisticsOrderId: number) {
+  return `outbound:${logisticsOrderId}:${Date.now()}`;
+}
+
+function getProductName(item: OutboundOrderPrefillItem) {
+  return item.productNameCn ?? item.productNameEn ?? "—";
+}
+
+export default function OutboundOrderFormPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { message, notification } = App.useApp();
+  const formRef = useRef<ProFormInstance<OutboundOrderFormValues>>(undefined);
+  const [editableItems, setEditableItems] = useState<EditableOutboundItem[]>([]);
+  const [searchParams] = useSearchParams();
+  const logisticsOrderId = parsePositiveIntParam(searchParams.get("logisticsOrderId"));
+  const requestKey = useMemo(
+    () => (logisticsOrderId ? buildRequestKey(logisticsOrderId) : ""),
+    [logisticsOrderId],
+  );
+
+  const prefillQuery = useQuery({
+    queryKey: ["outbound-order-create-prefill", logisticsOrderId],
+    queryFn: () => getOutboundOrderCreatePrefill(logisticsOrderId as number),
+    enabled: Boolean(logisticsOrderId),
+  });
+
+  const warehouseQuery = useQuery({
+    queryKey: ["outbound-order-warehouses"],
+    queryFn: () => getWarehouses({ page: 1, pageSize: 500 }),
+  });
+
+  const userQuery = useQuery({
+    queryKey: ["outbound-order-users"],
+    queryFn: () => getUsers(1, 200),
+  });
+
+  const companyQuery = useQuery({
+    queryKey: ["outbound-order-companies"],
+    queryFn: () => getCompanies({ page: 1, pageSize: 200 }),
+  });
+
+  const warehouseOptions = useMemo(
+    () =>
+      (warehouseQuery.data?.list ?? []).map((warehouse) => ({
+        label: `${warehouse.name}${warehouse.warehouseCode ? ` (${warehouse.warehouseCode})` : ""}`,
+        value: Number(warehouse.id),
+      })),
+    [warehouseQuery.data],
+  );
+
+  const userOptions = useMemo(
+    () =>
+      (userQuery.data?.list ?? []).map((user) => ({
+        label: user.name || user.username,
+        value: Number(user.id),
+      })),
+    [userQuery.data],
+  );
+
+  const companyOptions = useMemo(
+    () =>
+      (companyQuery.data?.list ?? []).map((company) => ({
+        label: company.nameCn,
+        value: Number(company.id),
+      })),
+    [companyQuery.data],
+  );
+
+  const outboundTypeOptions = useMemo(
+    () =>
+      Object.entries(OUTBOUND_ORDER_TYPE_LABELS).map(([value, label]) => ({
+        label,
+        value,
+      })),
+    [],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateOutboundOrderPayload) =>
+      createOutboundOrder(payload),
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({
+        queryKey: ["logistics-order-detail", created.logisticsOrderId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["logistics-orders"] });
+      queryClient.invalidateQueries({
+        queryKey: ["shipping-demand-detail", created.shippingDemandId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["sales-order-detail", created.salesOrderId],
+      });
+      notification.success({
+        message: "发货出库已确认",
+        description: `${created.outboundCode} 已完成出库确认。`,
+        duration: 5,
+      });
+      navigate(`/logistics-orders/${created.logisticsOrderId}`);
+    },
+  });
+
+  const initialValues = useMemo(() => {
+    const data = prefillQuery.data;
+    return {
+      logisticsOrderCode: data?.logisticsOrder.orderCode,
+      shippingDemandCode: data?.logisticsOrder.shippingDemandCode,
+      salesOrderCode: data?.logisticsOrder.salesOrderCode,
+      outboundDate: dayjs().format("YYYY-MM-DD"),
+      outboundType: OutboundOrderType.SALES,
+      warehouseId: undefined,
+    } satisfies Partial<OutboundOrderFormValues>;
+  }, [prefillQuery.data]);
+
+  const totals = useMemo(() => {
+    return editableItems.reduce(
+      (acc, item) => {
+        const quantity = Number(item.inputOutboundQuantity ?? 0);
+        const salesUnitPrice = Number(item.salesUnitPrice ?? 0);
+        const costUnitPrice = Number(item.costUnitPrice ?? 0);
+        return {
+          salesTotalAmount: acc.salesTotalAmount + salesUnitPrice * quantity,
+          costTotalAmount: acc.costTotalAmount + costUnitPrice * quantity,
+        };
+      },
+      { salesTotalAmount: 0, costTotalAmount: 0 },
+    );
+  }, [editableItems]);
+
+  useEffect(() => {
+    const items = prefillQuery.data?.items ?? [];
+    setEditableItems(
+      items.map((item) => ({
+        ...item,
+        inputOutboundQuantity: item.remainingQuantity,
+      })),
+    );
+  }, [prefillQuery.data]);
+
+  if (!logisticsOrderId) {
+    return (
+      <Result
+        status="404"
+        title="缺少物流单"
+        extra={
+          <Button type="primary" onClick={() => navigate("/logistics-orders")}>
+            返回物流单
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (prefillQuery.isLoading) {
+    return <Skeleton active paragraph={{ rows: 6 }} />;
+  }
+
+  if (prefillQuery.isError || !prefillQuery.data) {
+    return (
+      <Result
+        status="error"
+        title="发货出库预填信息加载失败"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => prefillQuery.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate(`/logistics-orders/${logisticsOrderId}`)}>
+            返回物流单
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  if (!editableItems.length) {
+    return (
+      <Result
+        status="warning"
+        title="当前物流单没有可继续出库的货物明细"
+        extra={
+          <Button type="primary" onClick={() => navigate(`/logistics-orders/${logisticsOrderId}`)}>
+            返回物流单
+          </Button>
+        }
+      />
+      );
+  }
+
+  const anchors = [
+    { key: "source", label: "来源信息" },
+    { key: "items", label: "出库明细" },
+    { key: "remark", label: "备注" },
+  ];
+
+  const handleItemChange = (
+    logisticsOrderItemId: number,
+    patch: Partial<EditableOutboundItem>,
+  ) => {
+    setEditableItems((current) =>
+      current.map((item) =>
+        item.logisticsOrderItemId === logisticsOrderItemId
+          ? { ...item, ...patch }
+          : item,
+      ),
+    );
+  };
+
+  const validateItems = () => {
+    for (const item of editableItems) {
+      if (
+        !Number.isInteger(item.inputOutboundQuantity) ||
+        Number(item.inputOutboundQuantity) <= 0
+      ) {
+        throw new Error(`${item.skuCode} 的实际出库数量必须为正整数`);
+      }
+      if (Number(item.inputOutboundQuantity) > Number(item.remainingQuantity)) {
+        throw new Error(
+          `${item.skuCode} 的实际出库数量不能超过剩余可出库数量 ${item.remainingQuantity}`,
+        );
+      }
+    }
+  };
+
+  function formatMoney(value: number) {
+    return value.toLocaleString("zh-CN", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  }
+
+  const columns = [
+    {
+      title: "SKU编码",
+      dataIndex: "skuCode",
+      key: "skuCode",
+      width: 140,
+      fixed: "left" as const,
+    },
+    {
+      title: "产品名称",
+      key: "productName",
+      width: 200,
+      render: (_: unknown, record: OutboundOrderPrefillItem) => getProductName(record),
+    },
+    {
+      title: "单位",
+      dataIndex: "unitName",
+      key: "unitName",
+      width: 90,
+      render: displayOrDash,
+    },
+    {
+      title: "批次出库数量",
+      key: "editableQuantity",
+      width: 150,
+      align: "right" as const,
+      render: (_: unknown, record: EditableOutboundItem) => (
+        <InputNumber
+          min={1}
+          max={record.remainingQuantity}
+          precision={0}
+          style={{ width: "100%" }}
+          value={record.inputOutboundQuantity}
+          onChange={(value) =>
+            handleItemChange(record.logisticsOrderItemId, {
+              inputOutboundQuantity: typeof value === "number" ? value : undefined,
+            })
+          }
+        />
+      ),
+    },
+    {
+      title: "批次号",
+      key: "batchNo",
+      width: 260,
+      render: () => "按已锁定批次 FIFO 自动分配，允许跨批次",
+    },
+    {
+      title: "采购主体",
+      dataIndex: "purchaseSubject",
+      key: "purchaseSubject",
+      width: 180,
+      render: displayOrDash,
+    },
+    {
+      title: "销售单价",
+      key: "salesUnitPrice",
+      width: 120,
+      align: "right" as const,
+      render: (_: unknown, record: EditableOutboundItem) =>
+        record.salesUnitPrice ? formatMoney(Number(record.salesUnitPrice)) : "—",
+    },
+    {
+      title: "销售合计",
+      key: "salesAmount",
+      width: 120,
+      align: "right" as const,
+      render: (_: unknown, record: EditableOutboundItem) => {
+        const unitPrice = Number(record.salesUnitPrice ?? 0);
+        const quantity = Number(record.inputOutboundQuantity ?? 0);
+        if (!unitPrice || !quantity) return "—";
+        return formatMoney(unitPrice * quantity);
+      },
+    },
+    {
+      title: "成本单价",
+      key: "costUnitPrice",
+      width: 120,
+      align: "right" as const,
+      render: (_: unknown, record: EditableOutboundItem) =>
+        record.costUnitPrice ? formatMoney(Number(record.costUnitPrice)) : "—",
+    },
+    {
+      title: "成本合计",
+      key: "costAmount",
+      width: 120,
+      align: "right" as const,
+      render: (_: unknown, record: EditableOutboundItem) => {
+        const unitPrice = Number(record.costUnitPrice ?? 0);
+        const quantity = Number(record.inputOutboundQuantity ?? 0);
+        if (!unitPrice || !quantity) return "—";
+        return formatMoney(unitPrice * quantity);
+      },
+    },
+  ];
+
+  return (
+    <div className="master-page master-form-page">
+      <div className="master-page-header">
+        <div className="master-page-heading">
+          <div className="master-page-title">创建发货出库单</div>
+          <div className="master-page-description">
+            {displayOrDash(prefillQuery.data.logisticsOrder.orderCode)} /{" "}
+            {displayOrDash(prefillQuery.data.logisticsOrder.shippingDemandCode)}
+          </div>
+        </div>
+      </div>
+
+      <ProForm<OutboundOrderFormValues>
+        formRef={formRef}
+        submitter={false}
+        initialValues={initialValues}
+        onFinish={async (values) => {
+          try {
+            if (!values.warehouseId) {
+              message.error("请选择出库仓库");
+              return false;
+            }
+            if (!values.outboundUserId) {
+              message.error("请选择出库员");
+              return false;
+            }
+            if (!values.outboundDate) {
+              message.error("请选择出库日期");
+              return false;
+            }
+            if (!values.outboundType) {
+              message.error("请选择出库类型");
+              return false;
+            }
+            if (!values.salesCompanyId) {
+              message.error("请选择销售主体");
+              return false;
+            }
+            validateItems();
+          } catch (error) {
+            message.error(
+              error instanceof Error ? error.message : "请检查出库明细填写",
+            );
+            return false;
+          }
+          const payload: CreateOutboundOrderPayload = {
+            logisticsOrderId,
+            outboundUserId: Number(values.outboundUserId),
+            outboundDate: values.outboundDate,
+            outboundType: values.outboundType,
+            salesCompanyId: Number(values.salesCompanyId),
+            warehouseId: Number(values.warehouseId),
+            requestKey,
+            remark: values.remark?.trim() || undefined,
+            items: editableItems.map((item) => ({
+              logisticsOrderItemId: Number(item.logisticsOrderItemId),
+              outboundQuantity: Number(item.inputOutboundQuantity),
+            })),
+          };
+          await createMutation.mutateAsync(payload);
+        }}
+      >
+        <div className="master-detail-layout">
+          <AnchorNav anchors={anchors} activeKey="source" onChange={() => undefined} />
+
+          <div className="master-detail-main">
+            <SectionCard id="source" title="来源信息">
+              <div className="master-meta-grid">
+                <ProFormText name="logisticsOrderCode" label="物流单号" readonly />
+                <ProFormText name="shippingDemandCode" label="发货需求编号" readonly />
+                <ProFormText name="salesOrderCode" label="销售订单号" readonly />
+                <ProFormSelect
+                  name="outboundUserId"
+                  label="出库员"
+                  options={userOptions}
+                  fieldProps={{ showSearch: true, optionFilterProp: "label" }}
+                />
+                <ProFormDatePicker
+                  name="outboundDate"
+                  label="出库日期"
+                  fieldProps={{ style: { width: "100%" } }}
+                />
+                <ProFormSelect
+                  name="outboundType"
+                  label="出库类型"
+                  options={outboundTypeOptions}
+                />
+                <ProFormSelect
+                  name="salesCompanyId"
+                  label="销售主体"
+                  options={companyOptions}
+                  fieldProps={{ showSearch: true, optionFilterProp: "label" }}
+                />
+                <ProFormSelect
+                  name="warehouseId"
+                  label="出库仓库"
+                  options={warehouseOptions}
+                  fieldProps={{ showSearch: true, optionFilterProp: "label" }}
+                />
+                <ProFormText
+                  label="销售总金额"
+                  readonly
+                  fieldProps={{
+                    value: formatMoney(totals.salesTotalAmount),
+                  }}
+                />
+                <ProFormText
+                  label="出库成本金额"
+                  readonly
+                  fieldProps={{
+                    value: formatMoney(totals.costTotalAmount),
+                  }}
+                />
+              </div>
+            </SectionCard>
+
+            <SectionCard id="items" title="出库明细">
+              <Table<OutboundOrderPrefillItem>
+                rowKey="logisticsOrderItemId"
+                columns={columns}
+                dataSource={editableItems}
+                pagination={false}
+                scroll={{ x: 1600 }}
+              />
+              <div
+                style={{
+                  marginTop: 12,
+                  color: "#64748B",
+                  fontSize: 12,
+                  lineHeight: "20px",
+                }}
+              >
+                批次处理规则：系统按发货需求已锁定库存执行先进先出；若锁定量分布在多个批次，本次出库会自动跨批次消费。
+              </div>
+            </SectionCard>
+
+            <SectionCard id="remark" title="备注">
+              <ProFormTextArea
+                name="remark"
+                label="仓库出库说明"
+                placeholder="填写本次发货出库的补充说明"
+                fieldProps={{ maxLength: 1000, showCount: true }}
+              />
+            </SectionCard>
+
+            <div className="master-page-footer">
+              <Popconfirm
+                title="确认执行发货出库？"
+                description="确认后将扣减实际库存并释放对应锁定量。"
+                okText="确认出库"
+                cancelText="取消"
+                onConfirm={() => formRef.current?.submit()}
+              >
+                <Button type="primary" loading={createMutation.isPending}>
+                  确认出库
+                </Button>
+              </Popconfirm>
+              <Button onClick={() => navigate(`/logistics-orders/${logisticsOrderId}`)}>
+                返回物流单
+              </Button>
+            </div>
+          </div>
+        </div>
+      </ProForm>
+    </div>
+  );
+}

--- a/packages/shared/src/enums/outbound-order-status.enum.ts
+++ b/packages/shared/src/enums/outbound-order-status.enum.ts
@@ -1,0 +1,6 @@
+export const OutboundOrderStatus = {
+  CONFIRMED: 'confirmed',
+} as const;
+
+export type OutboundOrderStatus =
+  (typeof OutboundOrderStatus)[keyof typeof OutboundOrderStatus];

--- a/packages/shared/src/enums/outbound-order-type.enum.ts
+++ b/packages/shared/src/enums/outbound-order-type.enum.ts
@@ -1,0 +1,9 @@
+export const OutboundOrderType = {
+  SALES: 'sales_outbound',
+  LOSS: 'loss_outbound',
+  INVENTORY_LOSS: 'inventory_loss_outbound',
+  OTHER: 'other',
+} as const;
+
+export type OutboundOrderType =
+  (typeof OutboundOrderType)[keyof typeof OutboundOrderType];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,6 +40,8 @@ export * from "./enums/inventory-batch-source-type.enum";
 export * from "./enums/inventory-change-type.enum";
 export * from "./enums/receipt-order-status.enum";
 export * from "./enums/receipt-order-type.enum";
+export * from "./enums/outbound-order-status.enum";
+export * from "./enums/outbound-order-type.enum";
 export * from "./enums/domestic-trade-type.enum";
 export * from "./enums/payment-term.enum";
 export * from "./enums/trade-term.enum";

--- a/packages/shared/src/types/operation-log-field-labels.ts
+++ b/packages/shared/src/types/operation-log-field-labels.ts
@@ -437,6 +437,19 @@ export const RESOURCE_OPERATION_LOG_FIELD_LABELS: Record<string, Record<string, 
     items: '货物明细',
     packages: '装箱信息',
   },
+  'outbound-orders': {
+    outboundCode: '出库单号',
+    logisticsOrderId: '物流单',
+    logisticsOrderCode: '物流单号',
+    shippingDemandId: '发货需求',
+    shippingDemandCode: '发货需求编号',
+    salesOrderId: '销售订单',
+    salesOrderCode: '销售订单号',
+    status: '出库单状态',
+    remark: '备注',
+    items: '出库明细',
+    outboundSummary: '出库结果',
+  },
 };
 
 export function resolveOperationLogFieldLabel(


### PR DESCRIPTION
## Summary
- add outbound orders backend module, migration, and shared enums for story 7-3
- implement outbound create-confirm flow with allocation FIFO consumption, inventory deduction, and quantity rollups
- add outbound create page and logistics detail entry, aligned to confirmed field requirements

## Test plan
- pnpm --filter api build
- pnpm --filter web build
- pnpm --filter api exec jest modules/outbound-orders/tests --runInBand
- pnpm --filter api exec jest modules/logistics-orders/tests --runInBand
- pnpm --filter api exec jest modules/shipping-demands/tests/shipping-demands.service.spec.ts --runInBand
- pnpm --filter api exec jest modules/inventory/tests/inventory.service.spec.ts --runInBand
- git diff --check