### PR TITLE
Fix outbound order visibility and logistics refresh flow

### DIFF
--- a/apps/api/src/modules/outbound-orders/dto/query-outbound-order.dto.ts
+++ b/apps/api/src/modules/outbound-orders/dto/query-outbound-order.dto.ts
@@ -1,0 +1,26 @@
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
+import { OutboundOrderStatus, OutboundOrderType } from '@infitek/shared';
+import { BaseQueryDto } from '../../../common/dto/base-query.dto';
+
+export class QueryOutboundOrderDto extends BaseQueryDto {
+  @IsOptional()
+  @IsIn(Object.values(OutboundOrderStatus))
+  status?: OutboundOrderStatus;
+
+  @IsOptional()
+  @IsIn(Object.values(OutboundOrderType))
+  outboundType?: OutboundOrderType;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  logisticsOrderId?: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  shippingDemandId?: number;
+}

--- a/apps/api/src/modules/outbound-orders/outbound-orders.controller.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.controller.ts
@@ -1,6 +1,15 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
 import { CreateOutboundOrderDto } from './dto/create-outbound-order.dto';
+import { QueryOutboundOrderDto } from './dto/query-outbound-order.dto';
 import { QueryOutboundCreatePrefillDto } from './dto/query-outbound-create-prefill.dto';
 import { OutboundOrdersService } from './outbound-orders.service';
 
@@ -10,9 +19,19 @@ export class OutboundOrdersController {
     private readonly outboundOrdersService: OutboundOrdersService,
   ) {}
 
+  @Get()
+  findAll(@Query() query: QueryOutboundOrderDto) {
+    return this.outboundOrdersService.findAll(query);
+  }
+
   @Get('create-prefill')
   getCreatePrefill(@Query() query: QueryOutboundCreatePrefillDto) {
     return this.outboundOrdersService.getCreatePrefill(query.logisticsOrderId);
+  }
+
+  @Get(':id')
+  findById(@Param('id', ParseIntPipe) id: number) {
+    return this.outboundOrdersService.findById(id);
   }
 
   @Post()

--- a/apps/api/src/modules/outbound-orders/outbound-orders.repository.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.repository.ts
@@ -4,6 +4,11 @@ import { DataSource, Repository } from 'typeorm';
 import { OutboundAllocationConsumption } from './entities/outbound-allocation-consumption.entity';
 import { OutboundOrderItem } from './entities/outbound-order-item.entity';
 import { OutboundOrder } from './entities/outbound-order.entity';
+import { QueryOutboundOrderDto } from './dto/query-outbound-order.dto';
+
+function escapeLike(value: string): string {
+  return value.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
 
 @Injectable()
 export class OutboundOrdersRepository {
@@ -36,5 +41,69 @@ export class OutboundOrdersRepository {
       relations: { items: true },
       order: { items: { id: 'ASC' } },
     });
+  }
+
+  async findAll(query: QueryOutboundOrderDto) {
+    const {
+      keyword,
+      status,
+      outboundType,
+      logisticsOrderId,
+      shippingDemandId,
+      page = 1,
+      pageSize = 20,
+    } = query;
+
+    const qb = this.outboundOrderRepo.createQueryBuilder('outboundOrder');
+    const normalizedKeyword = keyword?.trim();
+
+    if (normalizedKeyword) {
+      qb.andWhere(
+        `(outboundOrder.outbound_code LIKE :kw ESCAPE '\\\\'
+          OR outboundOrder.logistics_order_code LIKE :kw ESCAPE '\\\\'
+          OR outboundOrder.shipping_demand_code LIKE :kw ESCAPE '\\\\'
+          OR outboundOrder.sales_order_code LIKE :kw ESCAPE '\\\\'
+          OR outboundOrder.outbound_user_name LIKE :kw ESCAPE '\\\\'
+          OR outboundOrder.warehouse_name LIKE :kw ESCAPE '\\\\')`,
+        { kw: `%${escapeLike(normalizedKeyword)}%` },
+      );
+    }
+
+    if (status) {
+      qb.andWhere('outboundOrder.status = :status', { status });
+    }
+
+    if (outboundType) {
+      qb.andWhere('outboundOrder.outbound_type = :outboundType', {
+        outboundType,
+      });
+    }
+
+    if (logisticsOrderId != null) {
+      qb.andWhere('outboundOrder.logistics_order_id = :logisticsOrderId', {
+        logisticsOrderId,
+      });
+    }
+
+    if (shippingDemandId != null) {
+      qb.andWhere('outboundOrder.shipping_demand_id = :shippingDemandId', {
+        shippingDemandId,
+      });
+    }
+
+    const [list, total] = await qb
+      .orderBy('outboundOrder.created_at', 'DESC')
+      .addOrderBy('outboundOrder.id', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    return {
+      list,
+      total,
+      page,
+      pageSize,
+      totalPages: Math.ceil(total / pageSize),
+    };
   }
 }

--- a/apps/api/src/modules/outbound-orders/outbound-orders.service.ts
+++ b/apps/api/src/modules/outbound-orders/outbound-orders.service.ts
@@ -27,6 +27,7 @@ import { ShippingDemandInventoryAllocation } from '../shipping-demands/entities/
 import { ShippingDemandItem } from '../shipping-demands/entities/shipping-demand-item.entity';
 import { ShippingDemand } from '../shipping-demands/entities/shipping-demand.entity';
 import { CreateOutboundOrderDto } from './dto/create-outbound-order.dto';
+import { QueryOutboundOrderDto } from './dto/query-outbound-order.dto';
 import { OutboundOrdersRepository } from './outbound-orders.repository';
 import { OutboundAllocationConsumption } from './entities/outbound-allocation-consumption.entity';
 import { OutboundOrderItem } from './entities/outbound-order-item.entity';
@@ -106,6 +107,10 @@ export class OutboundOrdersService {
     private readonly outboundOrdersRepository: OutboundOrdersRepository,
     private readonly inventoryService: InventoryService,
   ) {}
+
+  findAll(query: QueryOutboundOrderDto) {
+    return this.outboundOrdersRepository.findAll(query);
+  }
 
   async getCreatePrefill(
     logisticsOrderId: number,

--- a/apps/api/src/modules/outbound-orders/tests/outbound-orders.service.spec.ts
+++ b/apps/api/src/modules/outbound-orders/tests/outbound-orders.service.spec.ts
@@ -9,12 +9,14 @@ import { OperationLog } from '../../operation-logs/entities/operation-log.entity
 import { SalesOrder } from '../../sales-orders/entities/sales-order.entity';
 import { ShippingDemand } from '../../shipping-demands/entities/shipping-demand.entity';
 import { OutboundOrdersService } from '../outbound-orders.service';
+import { OutboundOrder } from '../entities/outbound-order.entity';
 
 describe('OutboundOrdersService', () => {
   const outboundOrdersRepository = {
     createQueryRunner: jest.fn(),
     findById: jest.fn(),
     findBySourceActionKey: jest.fn(),
+    findAll: jest.fn(),
   };
   const inventoryService = {
     deductLockedStockInTransaction: jest.fn(),
@@ -32,6 +34,30 @@ describe('OutboundOrdersService', () => {
 
   it('is defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('delegates outbound order list query to repository', async () => {
+    const expected = {
+      list: [{ id: 1, outboundCode: 'QTCK202605060001' }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    };
+    outboundOrdersRepository.findAll.mockResolvedValue(expected);
+
+    const result = await service.findAll({
+      keyword: 'QTCK',
+      page: 1,
+      pageSize: 20,
+    } as any);
+
+    expect(outboundOrdersRepository.findAll).toHaveBeenCalledWith({
+      keyword: 'QTCK',
+      page: 1,
+      pageSize: 20,
+    });
+    expect(result).toBe(expected);
   });
 
   it('pushes sales order to partially shipped when any active demand is partially shipped', async () => {
@@ -193,6 +219,59 @@ describe('OutboundOrdersService', () => {
 
     expect(result).toBeNull();
     expect(save).not.toHaveBeenCalled();
+  });
+
+  it('updates logistics order to shipped when all outbound quantities are completed', async () => {
+    const savedOrders: LogisticsOrder[] = [];
+    const queryRunner = {
+      manager: {
+        getRepository: jest.fn((entity) => {
+          if (entity === LogisticsOrderItem) {
+            return {
+              find: jest.fn().mockResolvedValue([
+                { plannedQuantity: 5, outboundQuantity: 5 },
+                { plannedQuantity: 3, outboundQuantity: 3 },
+              ]),
+            };
+          }
+          if (entity === LogisticsOrder) {
+            return {
+              save: jest.fn(async (order) => {
+                savedOrders.push(order);
+                return order;
+              }),
+            };
+          }
+          throw new Error('Unexpected repository');
+        }),
+      },
+    };
+
+    const result = await (service as any).updateLogisticsOrderStatusAfterOutbound(
+      queryRunner,
+      {
+        id: 200,
+        status: LogisticsOrderStatus.CONFIRMED,
+        updatedBy: null,
+      } as LogisticsOrder,
+      'admin',
+    );
+
+    expect(result).toEqual({
+      order: expect.objectContaining({
+        id: 200,
+        status: LogisticsOrderStatus.SHIPPED,
+        updatedBy: 'admin',
+      }),
+      oldStatus: LogisticsOrderStatus.CONFIRMED,
+    });
+    expect(savedOrders).toEqual([
+      expect.objectContaining({
+        id: 200,
+        status: LogisticsOrderStatus.SHIPPED,
+        updatedBy: 'admin',
+      }),
+    ]);
   });
 
   it('writes logistics status change into operation log when outbound completes shipment', async () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -70,6 +70,8 @@ import PurchaseOrderFormPage from "./pages/purchase-orders/form";
 import ReceiptOrdersListPage from "./pages/receipt-orders/index";
 import ReceiptOrderDetailPage from "./pages/receipt-orders/detail";
 import ReceiptOrderFormPage from "./pages/receipt-orders/form";
+import OutboundOrdersListPage from "./pages/outbound-orders/index";
+import OutboundOrderDetailPage from "./pages/outbound-orders/detail";
 import OutboundOrderFormPage from "./pages/outbound-orders/form";
 import InventoryPage from "./pages/inventory/index";
 import InventoryTransactionsPage from "./pages/inventory/transactions";
@@ -503,6 +505,14 @@ function App() {
                   <Route
                     path="/receipt-orders/create"
                     element={<ReceiptOrderFormPage />}
+                  />
+                  <Route
+                    path="/outbound-orders"
+                    element={<OutboundOrdersListPage />}
+                  />
+                  <Route
+                    path="/outbound-orders/:id"
+                    element={<OutboundOrderDetailPage />}
                   />
                   <Route
                     path="/outbound-orders/create"

--- a/apps/web/src/api/outbound-orders.api.ts
+++ b/apps/web/src/api/outbound-orders.api.ts
@@ -96,6 +96,24 @@ export interface OutboundOrder {
   updatedAt: string;
 }
 
+export interface OutboundOrdersListParams {
+  keyword?: string;
+  status?: OutboundOrderStatus;
+  outboundType?: OutboundOrderType;
+  logisticsOrderId?: number;
+  shippingDemandId?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface OutboundOrdersListData {
+  list: OutboundOrder[];
+  total: number;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+}
+
 export const OUTBOUND_ORDER_STATUS_LABELS: Record<OutboundOrderStatus, string> = {
   [OutboundOrderStatus.CONFIRMED]: "已确认",
 };
@@ -121,4 +139,16 @@ export const createOutboundOrder = (
 ): Promise<OutboundOrder> =>
   request
     .post<unknown, OutboundOrder>("/outbound-orders", payload)
+    .catch(normalizeApiError);
+
+export const getOutboundOrders = (
+  params: OutboundOrdersListParams,
+): Promise<OutboundOrdersListData> =>
+  request
+    .get<unknown, OutboundOrdersListData>("/outbound-orders", { params })
+    .catch(normalizeApiError);
+
+export const getOutboundOrderById = (id: number): Promise<OutboundOrder> =>
+  request
+    .get<unknown, OutboundOrder>(`/outbound-orders/${id}`)
     .catch(normalizeApiError);

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -156,6 +156,21 @@ const BREADCRUMB_ROUTES: BreadcrumbRoute[] = [
     ],
   },
   {
+    pattern: /^\/outbound-orders$/,
+    items: [
+      { title: "库存管理", path: INVENTORY_SECTION_PATH },
+      { title: "发货出库" },
+    ],
+  },
+  {
+    pattern: /^\/outbound-orders\/[a-zA-Z0-9\-_]+$/,
+    items: [
+      { title: "库存管理", path: INVENTORY_SECTION_PATH },
+      { title: "发货出库", path: "/outbound-orders" },
+      { title: "发货出库单详情" },
+    ],
+  },
+  {
     pattern: /^\/logistics-orders$/,
     items: [
       { title: "商务管理", path: COMMERCE_SECTION_PATH },

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -97,6 +97,7 @@ const menuItems = [
     children: [
       { key: '/inventory', label: '库存查询', exact: true },
       { key: '/receipt-orders', label: '收货入库' },
+      { key: '/outbound-orders', label: '发货出库' },
       { key: '/inventory/transactions', label: '库存变动流水' },
     ],
   },

--- a/apps/web/src/pages/logistics-orders/detail.tsx
+++ b/apps/web/src/pages/logistics-orders/detail.tsx
@@ -263,6 +263,9 @@ export default function LogisticsOrderDetailPage() {
     (data?.items ?? []).some(
       (item) => Number(item.plannedQuantity ?? 0) > Number(item.outboundQuantity ?? 0),
     );
+  const hasOutboundOrders = (data?.items ?? []).some(
+    (item) => Number(item.outboundQuantity ?? 0) > 0,
+  );
 
   const openTrackingEdit = () => {
     trackingForm.setFieldsValue({
@@ -312,6 +315,17 @@ export default function LogisticsOrderDetailPage() {
                   >
                     查看发货需求
                   </Button>
+                  {hasOutboundOrders ? (
+                    <Button
+                      onClick={() =>
+                        navigate(
+                          `/outbound-orders?logisticsOrderId=${logisticsOrderId}`,
+                        )
+                      }
+                    >
+                      查看发货出库单
+                    </Button>
+                  ) : null}
                   {canEditTracking ? (
                     <Button type="primary" onClick={openTrackingEdit}>
                       编辑物流跟踪
@@ -324,7 +338,7 @@ export default function LogisticsOrderDetailPage() {
                         navigate(`/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`)
                       }
                     >
-                      创建发货出库单
+                      {hasOutboundOrders ? "继续创建发货出库单" : "创建发货出库单"}
                     </Button>
                   ) : null}
                 </Space>
@@ -538,12 +552,41 @@ export default function LogisticsOrderDetailPage() {
               <MetaItem
                 label="出库单"
                 value={
-                  canCreateOutbound ? (
+                  hasOutboundOrders ? (
+                    <Space wrap size={12}>
+                      <Button
+                        type="link"
+                        style={{ padding: 0 }}
+                        onClick={() =>
+                          navigate(
+                            `/outbound-orders?logisticsOrderId=${logisticsOrderId}`,
+                          )
+                        }
+                      >
+                        查看关联发货出库单
+                      </Button>
+                      {canCreateOutbound ? (
+                        <Button
+                          type="link"
+                          style={{ padding: 0 }}
+                          onClick={() =>
+                            navigate(
+                              `/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`,
+                            )
+                          }
+                        >
+                          继续创建发货出库单
+                        </Button>
+                      ) : null}
+                    </Space>
+                  ) : canCreateOutbound ? (
                     <Button
                       type="link"
                       style={{ padding: 0 }}
                       onClick={() =>
-                        navigate(`/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`)
+                        navigate(
+                          `/outbound-orders/create?logisticsOrderId=${logisticsOrderId}`,
+                        )
                       }
                     >
                       创建发货出库单

--- a/apps/web/src/pages/outbound-orders/detail.tsx
+++ b/apps/web/src/pages/outbound-orders/detail.tsx
@@ -1,0 +1,363 @@
+import { Button, Empty, Result, Skeleton, Space, Table } from "antd";
+import { OutboundOrderStatus } from "@infitek/shared";
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ActivityTimeline } from "../../components/ActivityTimeline";
+import {
+  getOutboundOrderById,
+  OUTBOUND_ORDER_STATUS_LABELS,
+  OUTBOUND_ORDER_TYPE_LABELS,
+  type OutboundOrderItem,
+} from "../../api/outbound-orders.api";
+import {
+  AnchorNav,
+  MetaItem,
+  SectionCard,
+  SummaryMetaItem,
+  displayOrDash,
+} from "../master-data/components/page-scaffold";
+import "../master-data/master-page.css";
+
+const STATUS_STYLE_MAP: Record<string, { className: string; text: string }> = {
+  [OutboundOrderStatus.CONFIRMED]: {
+    className: "master-pill-success",
+    text: "已确认",
+  },
+};
+
+function formatMoney(value?: string | number | null) {
+  if (value == null || value === "") return "—";
+  const parsed = Number(value);
+  return Number.isFinite(parsed)
+    ? parsed.toLocaleString("zh-CN", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    : String(value);
+}
+
+function formatDate(value?: string | null) {
+  return value ? dayjs(value).format("YYYY-MM-DD") : "—";
+}
+
+export default function OutboundOrderDetailPage() {
+  const navigate = useNavigate();
+  const { id = "" } = useParams();
+  const outboundOrderId = Number(id);
+  const [activeAnchor, setActiveAnchor] = useState("basic");
+  const query = useQuery({
+    queryKey: ["outbound-order-detail", outboundOrderId],
+    queryFn: () => getOutboundOrderById(outboundOrderId),
+    enabled: Number.isInteger(outboundOrderId) && outboundOrderId > 0,
+  });
+
+  const anchors = [
+    { key: "basic", label: "基础信息" },
+    { key: "items", label: "出库明细" },
+    { key: "relations", label: "关联单据" },
+    { key: "remark", label: "备注" },
+    { key: "operation", label: "操作记录" },
+  ];
+
+  const itemColumns = [
+    {
+      title: "SKU",
+      dataIndex: "skuCode",
+      key: "skuCode",
+      width: 160,
+      fixed: "left" as const,
+    },
+    {
+      title: "产品名称",
+      key: "productName",
+      width: 220,
+      render: (_: unknown, record: OutboundOrderItem) =>
+        displayOrDash(record.productNameCn ?? record.productNameEn),
+    },
+    {
+      title: "单位",
+      dataIndex: "unitName",
+      key: "unitName",
+      width: 100,
+      render: displayOrDash,
+    },
+    {
+      title: "计划数量",
+      dataIndex: "plannedQuantity",
+      key: "plannedQuantity",
+      width: 100,
+      align: "right" as const,
+    },
+    {
+      title: "出库前累计已出",
+      dataIndex: "previousOutboundQuantity",
+      key: "previousOutboundQuantity",
+      width: 140,
+      align: "right" as const,
+    },
+    {
+      title: "本次出库数量",
+      dataIndex: "outboundQuantity",
+      key: "outboundQuantity",
+      width: 120,
+      align: "right" as const,
+    },
+    {
+      title: "出库仓库",
+      dataIndex: "warehouseName",
+      key: "warehouseName",
+      width: 220,
+      render: displayOrDash,
+    },
+  ];
+
+  if (!Number.isInteger(outboundOrderId) || outboundOrderId <= 0) {
+    return (
+      <Result
+        status="404"
+        title="发货出库单不存在"
+        extra={
+          <Button type="primary" onClick={() => navigate("/outbound-orders")}>
+            返回列表
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <Result
+        status="error"
+        title="发货出库单详情加载失败"
+        extra={[
+          <Button key="retry" type="primary" onClick={() => query.refetch()}>
+            重试
+          </Button>,
+          <Button key="back" onClick={() => navigate("/outbound-orders")}>
+            返回列表
+          </Button>,
+        ]}
+      />
+    );
+  }
+
+  const data = query.data;
+  const statusInfo =
+    STATUS_STYLE_MAP[data?.status ?? ""] ?? {
+      className: "master-pill-default",
+      text: data?.status ? OUTBOUND_ORDER_STATUS_LABELS[data.status] : "—",
+    };
+  const totalOutboundQuantity = (data?.items ?? []).reduce(
+    (sum, item) => sum + Number(item.outboundQuantity ?? 0),
+    0,
+  );
+
+  return (
+    <div className="master-page">
+      <div className="master-summary-card">
+        {query.isLoading && !data ? (
+          <Skeleton active paragraph={{ rows: 2 }} />
+        ) : (
+          <>
+            <div className="master-summary-code">
+              {displayOrDash(data?.outboundCode)}
+            </div>
+            <div className="master-summary-header">
+              <div className="master-summary-title-wrap">
+                <div className="master-summary-title-row">
+                  <div className="master-summary-title">
+                    {displayOrDash(data?.warehouseName)}
+                  </div>
+                  <span className={`master-pill ${statusInfo.className}`}>
+                    {statusInfo.text}
+                  </span>
+                </div>
+              </div>
+              <div className="master-summary-actions">
+                <Space wrap>
+                  <Button onClick={() => navigate("/outbound-orders")}>
+                    返回列表
+                  </Button>
+                  {data?.logisticsOrderId ? (
+                    <Button
+                      onClick={() =>
+                        navigate(`/logistics-orders/${data.logisticsOrderId}`)
+                      }
+                    >
+                      查看物流单
+                    </Button>
+                  ) : null}
+                  {data?.shippingDemandId ? (
+                    <Button
+                      onClick={() =>
+                        navigate(`/shipping-demands/${data.shippingDemandId}`)
+                      }
+                    >
+                      查看发货需求
+                    </Button>
+                  ) : null}
+                </Space>
+              </div>
+            </div>
+            <div className="master-summary-meta">
+              <SummaryMetaItem
+                label="出库类型"
+                value={
+                  data?.outboundType
+                    ? OUTBOUND_ORDER_TYPE_LABELS[data.outboundType]
+                    : "—"
+                }
+              />
+              <SummaryMetaItem
+                label="出库日期"
+                value={formatDate(data?.outboundDate)}
+              />
+              <SummaryMetaItem
+                label="本次出库总数量"
+                value={displayOrDash(totalOutboundQuantity)}
+              />
+              <SummaryMetaItem
+                label="出库员"
+                value={displayOrDash(data?.outboundUserName)}
+              />
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="master-detail-layout">
+        <AnchorNav
+          anchors={anchors}
+          activeKey={activeAnchor}
+          onChange={setActiveAnchor}
+        />
+        <div className="master-detail-main">
+          <SectionCard id="basic" title="基础信息">
+            <div className="master-meta-grid">
+              <MetaItem
+                label="出库单号"
+                value={displayOrDash(data?.outboundCode)}
+              />
+              <MetaItem
+                label="出库类型"
+                value={
+                  data?.outboundType
+                    ? OUTBOUND_ORDER_TYPE_LABELS[data.outboundType]
+                    : "—"
+                }
+              />
+              <MetaItem
+                label="状态"
+                value={
+                  <span className={`master-pill ${statusInfo.className}`}>
+                    {statusInfo.text}
+                  </span>
+                }
+              />
+              <MetaItem
+                label="出库仓库"
+                value={displayOrDash(data?.warehouseName)}
+              />
+              <MetaItem
+                label="出库日期"
+                value={formatDate(data?.outboundDate)}
+              />
+              <MetaItem
+                label="出库员"
+                value={displayOrDash(data?.outboundUserName)}
+              />
+              <MetaItem
+                label="销售主体"
+                value={displayOrDash(data?.salesCompanyName)}
+              />
+              <MetaItem
+                label="销售总金额"
+                value={formatMoney(data?.salesTotalAmount)}
+              />
+              <MetaItem
+                label="成本总金额"
+                value={formatMoney(data?.costTotalAmount)}
+              />
+              <MetaItem
+                label="创建时间"
+                value={formatDate(data?.createdAt)}
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard id="items" title="出库明细">
+            <Table<OutboundOrderItem>
+              rowKey="id"
+              pagination={false}
+              columns={itemColumns as never}
+              dataSource={data?.items ?? []}
+              scroll={{ x: 1200 }}
+              locale={{ emptyText: <Empty description="暂无出库明细" /> }}
+            />
+          </SectionCard>
+
+          <SectionCard id="relations" title="关联单据">
+            <div className="master-meta-grid">
+              <MetaItem
+                label="物流单号"
+                value={
+                  data?.logisticsOrderId ? (
+                    <Link to={`/logistics-orders/${data.logisticsOrderId}`}>
+                      {displayOrDash(data.logisticsOrderCode)}
+                    </Link>
+                  ) : (
+                    displayOrDash(data?.logisticsOrderCode)
+                  )
+                }
+              />
+              <MetaItem
+                label="发货需求编号"
+                value={
+                  data?.shippingDemandId ? (
+                    <Link to={`/shipping-demands/${data.shippingDemandId}`}>
+                      {displayOrDash(data.shippingDemandCode)}
+                    </Link>
+                  ) : (
+                    displayOrDash(data?.shippingDemandCode)
+                  )
+                }
+              />
+              <MetaItem
+                label="销售订单号"
+                value={
+                  data?.salesOrderId ? (
+                    <Link to={`/sales-orders/${data.salesOrderId}`}>
+                      {displayOrDash(data.salesOrderCode)}
+                    </Link>
+                  ) : (
+                    displayOrDash(data?.salesOrderCode)
+                  )
+                }
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard id="remark" title="备注">
+            <div className="master-meta-grid">
+              <MetaItem
+                label="仓库出库说明"
+                value={displayOrDash(data?.remark)}
+                full
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard id="operation" title="操作记录">
+            <ActivityTimeline
+              resourceType="outbound-orders"
+              resourceId={outboundOrderId}
+            />
+          </SectionCard>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/outbound-orders/form.tsx
+++ b/apps/web/src/pages/outbound-orders/form.tsx
@@ -124,22 +124,41 @@ export default function OutboundOrderFormPage() {
     mutationFn: (payload: CreateOutboundOrderPayload) =>
       createOutboundOrder(payload),
     onSuccess: (created) => {
-      queryClient.invalidateQueries({
+      queryClient.removeQueries({
+        queryKey: ["outbound-order-create-prefill", created.logisticsOrderId],
+        exact: true,
+      });
+      queryClient.removeQueries({
         queryKey: ["logistics-order-detail", created.logisticsOrderId],
+        exact: true,
       });
-      queryClient.invalidateQueries({ queryKey: ["logistics-orders"] });
-      queryClient.invalidateQueries({
+      queryClient.removeQueries({
         queryKey: ["shipping-demand-detail", created.shippingDemandId],
+        exact: true,
+      });
+      queryClient.removeQueries({
+        queryKey: ["sales-order-detail", created.salesOrderId],
+        exact: true,
+      });
+      queryClient.invalidateQueries({ queryKey: ["outbound-orders"] });
+      queryClient.invalidateQueries({ queryKey: ["logistics-orders"] });
+      queryClient.invalidateQueries({ queryKey: ["shipping-demands"] });
+      queryClient.invalidateQueries({ queryKey: ["sales-orders"] });
+      queryClient.invalidateQueries({
+        queryKey: ["operation-logs", "logistics-orders", created.logisticsOrderId],
       });
       queryClient.invalidateQueries({
-        queryKey: ["sales-order-detail", created.salesOrderId],
+        queryKey: ["operation-logs", "shipping-demands", created.shippingDemandId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["operation-logs", "sales-orders", created.salesOrderId],
       });
       notification.success({
         message: "发货出库已确认",
         description: `${created.outboundCode} 已完成出库确认。`,
         duration: 5,
       });
-      navigate(`/logistics-orders/${created.logisticsOrderId}`);
+      navigate(`/outbound-orders/${created.id}`);
     },
   });
 
@@ -249,18 +268,25 @@ export default function OutboundOrderFormPage() {
   };
 
   const validateItems = () => {
+    let hasPositiveQuantity = false;
     for (const item of editableItems) {
       if (
         !Number.isInteger(item.inputOutboundQuantity) ||
-        Number(item.inputOutboundQuantity) <= 0
+        Number(item.inputOutboundQuantity) < 0
       ) {
-        throw new Error(`${item.skuCode} 的实际出库数量必须为正整数`);
+        throw new Error(`${item.skuCode} 的实际出库数量必须为 0 或正整数`);
       }
       if (Number(item.inputOutboundQuantity) > Number(item.remainingQuantity)) {
         throw new Error(
           `${item.skuCode} 的实际出库数量不能超过剩余可出库数量 ${item.remainingQuantity}`,
         );
       }
+      if (Number(item.inputOutboundQuantity) > 0) {
+        hasPositiveQuantity = true;
+      }
+    }
+    if (!hasPositiveQuantity) {
+      throw new Error("至少需要填写一条出库数量大于 0 的明细");
     }
   };
 
@@ -299,7 +325,7 @@ export default function OutboundOrderFormPage() {
       align: "right" as const,
       render: (_: unknown, record: EditableOutboundItem) => (
         <InputNumber
-          min={1}
+          min={0}
           max={record.remainingQuantity}
           precision={0}
           style={{ width: "100%" }}
@@ -424,7 +450,7 @@ export default function OutboundOrderFormPage() {
             items: editableItems.map((item) => ({
               logisticsOrderItemId: Number(item.logisticsOrderItemId),
               outboundQuantity: Number(item.inputOutboundQuantity),
-            })),
+            })).filter((item) => item.outboundQuantity > 0),
           };
           await createMutation.mutateAsync(payload);
         }}

--- a/apps/web/src/pages/outbound-orders/index.tsx
+++ b/apps/web/src/pages/outbound-orders/index.tsx
@@ -1,0 +1,367 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { Button, Empty, Select, Space } from "antd";
+import { ProTable, type ProColumns } from "@ant-design/pro-components";
+import {
+  OutboundOrderStatus,
+  OutboundOrderType,
+  type OutboundOrderType as OutboundOrderTypeValue,
+} from "@infitek/shared";
+import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+import {
+  getOutboundOrders,
+  OUTBOUND_ORDER_STATUS_LABELS,
+  OUTBOUND_ORDER_TYPE_LABELS,
+  type OutboundOrder,
+} from "../../api/outbound-orders.api";
+import { SearchForm, type ActiveTag } from "../../components/common/SearchForm";
+import { useDebouncedValue } from "../../hooks/useDebounce";
+import "../master-data/master-page.css";
+
+const STATUS_OPTIONS = Object.values(OutboundOrderStatus).map((value) => ({
+  label: OUTBOUND_ORDER_STATUS_LABELS[value],
+  value,
+}));
+
+const TYPE_OPTIONS = Object.values(OutboundOrderType).map((value) => ({
+  label: OUTBOUND_ORDER_TYPE_LABELS[value],
+  value,
+}));
+
+const STATUS_STYLE_MAP: Record<string, { className: string; text: string }> = {
+  [OutboundOrderStatus.CONFIRMED]: {
+    className: "master-pill-success",
+    text: "已确认",
+  },
+};
+
+function parsePositiveIntParam(value: string | null) {
+  const normalized = value?.trim();
+  if (!normalized || !/^\d+$/.test(normalized)) return undefined;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function formatMoney(value?: string | number | null) {
+  if (value == null || value === "") return "—";
+  const parsed = Number(value);
+  return Number.isFinite(parsed)
+    ? parsed.toLocaleString("zh-CN", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })
+    : String(value);
+}
+
+function formatDate(value?: string | null) {
+  return value ? dayjs(value).format("YYYY-MM-DD") : "—";
+}
+
+function displayOrDash(value?: string | number | null) {
+  return value == null || value === "" ? "—" : String(value);
+}
+
+export default function OutboundOrdersListPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const logisticsOrderId = parsePositiveIntParam(
+    searchParams.get("logisticsOrderId"),
+  );
+  const shippingDemandId = parsePositiveIntParam(
+    searchParams.get("shippingDemandId"),
+  );
+  const [keywordInput, setKeywordInput] = useState("");
+  const [status, setStatus] = useState<OutboundOrderStatus | undefined>();
+  const [outboundType, setOutboundType] = useState<
+    OutboundOrderTypeValue | undefined
+  >();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const keyword = useDebouncedValue(keywordInput, 300).trim();
+  const hasFilters =
+    Boolean(keyword) ||
+    status != null ||
+    outboundType != null ||
+    logisticsOrderId != null ||
+    shippingDemandId != null;
+
+  const query = useQuery({
+    queryKey: [
+      "outbound-orders",
+      keyword,
+      status,
+      outboundType,
+      logisticsOrderId,
+      shippingDemandId,
+      page,
+      pageSize,
+    ],
+    placeholderData: (previousData) => previousData,
+    queryFn: () =>
+      getOutboundOrders({
+        keyword: keyword || undefined,
+        status,
+        outboundType,
+        logisticsOrderId,
+        shippingDemandId,
+        page,
+        pageSize,
+      }),
+  });
+
+  const clearAllFilters = () => {
+    setKeywordInput("");
+    setStatus(undefined);
+    setOutboundType(undefined);
+    setSearchParams({});
+    setPage(1);
+  };
+
+  const clearContextFilter = (key: "logisticsOrderId" | "shippingDemandId") => {
+    const next = new URLSearchParams(searchParams);
+    next.delete(key);
+    setSearchParams(next);
+    setPage(1);
+  };
+
+  const selectedStatus = STATUS_OPTIONS.find((item) => item.value === status);
+  const selectedOutboundType = TYPE_OPTIONS.find(
+    (item) => item.value === outboundType,
+  );
+
+  const columns: ProColumns<OutboundOrder>[] = useMemo(
+    () => [
+      {
+        title: "出库单号",
+        dataIndex: "outboundCode",
+        width: 180,
+        fixed: "left",
+        render: (_, record) => (
+          <Link to={`/outbound-orders/${record.id}`}>{record.outboundCode}</Link>
+        ),
+      },
+      {
+        title: "出库类型",
+        dataIndex: "outboundType",
+        width: 140,
+        render: (_, record) =>
+          OUTBOUND_ORDER_TYPE_LABELS[record.outboundType] ?? record.outboundType,
+      },
+      {
+        title: "状态",
+        dataIndex: "status",
+        width: 120,
+        render: (_, record) => {
+          const info = STATUS_STYLE_MAP[record.status] ?? {
+            className: "master-pill-default",
+            text: record.status,
+          };
+          return (
+            <span className={`master-pill ${info.className}`}>{info.text}</span>
+          );
+        },
+      },
+      {
+        title: "物流单号",
+        dataIndex: "logisticsOrderCode",
+        width: 180,
+        render: (_, record) => (
+          <Link to={`/logistics-orders/${record.logisticsOrderId}`}>
+            {displayOrDash(record.logisticsOrderCode)}
+          </Link>
+        ),
+      },
+      {
+        title: "发货需求编号",
+        dataIndex: "shippingDemandCode",
+        width: 160,
+        render: (_, record) => (
+          <Link to={`/shipping-demands/${record.shippingDemandId}`}>
+            {displayOrDash(record.shippingDemandCode)}
+          </Link>
+        ),
+      },
+      {
+        title: "销售订单号",
+        dataIndex: "salesOrderCode",
+        width: 180,
+        render: (_, record) => (
+          <Link to={`/sales-orders/${record.salesOrderId}`}>
+            {displayOrDash(record.salesOrderCode)}
+          </Link>
+        ),
+      },
+      {
+        title: "出库仓库",
+        dataIndex: "warehouseName",
+        width: 200,
+        render: (_, record) => displayOrDash(record.warehouseName),
+      },
+      {
+        title: "出库员",
+        dataIndex: "outboundUserName",
+        width: 140,
+        render: (_, record) => displayOrDash(record.outboundUserName),
+      },
+      {
+        title: "出库日期",
+        dataIndex: "outboundDate",
+        width: 120,
+        render: (_, record) => formatDate(record.outboundDate),
+      },
+      {
+        title: "销售总金额",
+        dataIndex: "salesTotalAmount",
+        width: 140,
+        align: "right",
+        render: (_, record) => formatMoney(record.salesTotalAmount),
+      },
+      {
+        title: "成本总金额",
+        dataIndex: "costTotalAmount",
+        width: 140,
+        align: "right",
+        render: (_, record) => formatMoney(record.costTotalAmount),
+      },
+      {
+        title: "创建时间",
+        dataIndex: "createdAt",
+        width: 160,
+        render: (_, record) => formatDate(record.createdAt),
+      },
+      {
+        title: "操作",
+        key: "actions",
+        width: 100,
+        fixed: "right",
+        render: (_, record) => (
+          <Button
+            type="link"
+            style={{ padding: 0 }}
+            onClick={() => navigate(`/outbound-orders/${record.id}`)}
+          >
+            查看
+          </Button>
+        ),
+      },
+    ],
+    [navigate],
+  );
+
+  const activeTags: ActiveTag[] = [];
+  if (selectedStatus) {
+    activeTags.push({
+      key: "status",
+      label: `状态: ${selectedStatus.label}`,
+      onClose: () => setStatus(undefined),
+    });
+  }
+  if (selectedOutboundType) {
+    activeTags.push({
+      key: "outboundType",
+      label: `出库类型: ${selectedOutboundType.label}`,
+      onClose: () => setOutboundType(undefined),
+    });
+  }
+  if (logisticsOrderId) {
+    activeTags.push({
+      key: "logisticsOrderId",
+      label: `物流单筛选: #${logisticsOrderId}`,
+      onClose: () => clearContextFilter("logisticsOrderId"),
+    });
+  }
+  if (shippingDemandId) {
+    activeTags.push({
+      key: "shippingDemandId",
+      label: `发货需求筛选: #${shippingDemandId}`,
+      onClose: () => clearContextFilter("shippingDemandId"),
+    });
+  }
+
+  return (
+    <div className="master-page">
+      <div className="master-page-header">
+        <div className="master-page-heading">
+          <div className="master-page-title">发货出库</div>
+          <div className="master-page-description">
+            查看物流单生成后的发货出库记录、仓库去向、出库员和关联单据。
+          </div>
+        </div>
+        <div className="master-page-actions">
+          {logisticsOrderId ? (
+            <Button onClick={() => navigate(`/logistics-orders/${logisticsOrderId}`)}>
+              返回物流单
+            </Button>
+          ) : null}
+          {shippingDemandId ? (
+            <Button onClick={() => navigate(`/shipping-demands/${shippingDemandId}`)}>
+              查看发货需求
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="master-list-shell">
+        <SearchForm
+          searchValue={keywordInput}
+          onSearchChange={setKeywordInput}
+          placeholder="快捷搜索 出库单号/物流单号/发货需求编号/销售订单号/出库员/仓库"
+          activeTags={activeTags}
+          onClearAll={hasFilters ? clearAllFilters : undefined}
+          onQuery={() => setPage(1)}
+          onReset={clearAllFilters}
+          advancedContent={
+            <Space wrap>
+              <Select
+                allowClear
+                placeholder="状态"
+                style={{ width: 160 }}
+                value={status}
+                options={STATUS_OPTIONS}
+                onChange={(value) => setStatus(value)}
+              />
+              <Select
+                allowClear
+                placeholder="出库类型"
+                style={{ width: 180 }}
+                value={outboundType}
+                options={TYPE_OPTIONS}
+                onChange={(value) => setOutboundType(value)}
+              />
+            </Space>
+          }
+        />
+
+        <div className="master-table-shell">
+          <ProTable<OutboundOrder>
+            rowKey="id"
+            search={false}
+            options={false}
+            toolBarRender={false}
+            columns={columns}
+            dataSource={query.data?.list ?? []}
+            loading={query.isLoading}
+            scroll={{ x: 1900 }}
+            pagination={{
+              current: page,
+              pageSize,
+              total: query.data?.total ?? 0,
+              showSizeChanger: true,
+              pageSizeOptions: [10, 20, 50],
+              showTotal: (total) => `共 ${total} 条记录`,
+              onChange: (nextPage, nextPageSize) => {
+                setPage(nextPage);
+                setPageSize(nextPageSize);
+              },
+            }}
+            locale={{
+              emptyText: <Empty description="暂无发货出库记录" />,
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/shipping-demands/detail.tsx
+++ b/apps/web/src/pages/shipping-demands/detail.tsx
@@ -1977,11 +1977,17 @@ export default function ShippingDemandDetailPage() {
               icon={<FileDoneOutlined />}
               label="出库单"
               count={outboundOrderCount}
-              disabled
+              disabled={outboundOrderCount === 0}
               disabledTooltip={
                 outboundOrderCount > 0
-                  ? "当前已存在关联出库单，正式列表入口待后续 Story 补齐"
-                  : "当前还没有关联出库单；正式列表入口待后续 Story 补齐"
+                  ? undefined
+                  : "当前还没有关联出库单；关联物流单执行发货后会在这里汇总查看"
+              }
+              onClick={
+                outboundOrderCount > 0
+                  ? () =>
+                      navigate(`/outbound-orders?shippingDemandId=${demandId}`)
+                  : undefined
               }
             />
           </div>


### PR DESCRIPTION
## Summary
- add outbound order list/detail routes, APIs, navigation entry, and related document jump links
- refresh logistics/outbound related frontend cache after creating outbound orders and route users to the created record
- support partial outbound creation while closing the logistics order immediately after full outbound

## Validation
- pnpm --filter api test -- outbound-orders.service.spec.ts
- pnpm --filter api build
- pnpm --filter web build