### PR TITLE
docs: add inventory menu split story

### DIFF
--- a/_bmad-output/implementation-artifacts/5-7-库存管理菜单拆分与页面边界整理.md
+++ b/_bmad-output/implementation-artifacts/5-7-库存管理菜单拆分与页面边界整理.md
@@ -1,0 +1,259 @@
+# Story 5.7: 库存管理菜单拆分与页面边界整理
+
+Status: ready-for-dev
+
+<!-- Note: 本 Story 来自 2026-05-27 已批准 Sprint Change Proposal。它是 Story 5.0/6.2 的信息架构补丁，不改变库存领域模型。 -->
+
+## Story
+
+As a 仓库人员和系统管理员,
+I want 将期初库存录入、可用库存查询、批次库存明细和库存变动流水拆分为独立菜单,
+so that 我可以按实际任务快速进入对应页面，避免在一个混合页面中查找操作入口。
+
+## Acceptance Criteria
+
+1. `库存管理` 侧边栏下展示独立子菜单：`期初库存录入`、`可用库存查询`、`批次库存明细`、`库存变动流水`、`收货入库`、`发货出库`。
+2. 旧路径 `/inventory` 不失效；访问时进入或重定向到 `可用库存查询`，不得回到首页兜底或空白页。
+3. `期初库存录入` 页面只承担 SKU、仓库、期初数量、入库日期录入和保存反馈；保存仍调用 `POST /api/inventory/opening-balances`；页面不得展示完整可用库存大表、批次明细大表或库存流水表。
+4. `可用库存查询` 页面展示 SKU+仓库维度的实际库存、锁定量、可用库存，支持 SKU/仓库筛选、空状态、加载态和错误态；查询仍调用 `GET /api/inventory/available`。
+5. `可用库存查询` 结果行支持跳转到对应 `批次库存明细` 和 `库存变动流水`，并携带 SKU/仓库筛选上下文。
+6. `批次库存明细` 页面展示批次号、SKU、仓库、批次数量、锁定量、批次可用、来源类型/来源单据、入库日期，支持 SKU/仓库筛选；优先复用 `GET /api/inventory/batches`。
+7. `库存变动流水` 页面继续作为独立页面存在；从可用库存或批次库存明细跳转进入时，能读取 URL 查询参数或等价路由状态并自动带入 SKU/仓库筛选；页面继续调用 `GET /api/inventory/transactions`。
+8. 面包屑、页面标题、浏览器路由和菜单高亮与新菜单一致；刷新任一新库存页面不丢失当前路由。
+9. 不改变 `inventory_summary`、`inventory_batch`、`inventory_transactions` 数据模型，不改变库存写入、锁定、解锁、入库、出库和流水幂等逻辑。
+10. 前端 API 调用继续通过 `apps/web/src/api/inventory.api.ts` 和 TanStack Query；组件内不得直接 axios。
+11. 若批次明细独立页需要补充分页或筛选参数，只允许小幅扩展查询 DTO/API 类型，并补充后端定向测试；不得改变库存数量口径。
+12. 验证通过：`pnpm --filter web build` 必须通过；若扩展后端批次查询接口，则运行相关 API 定向测试和 `pnpm --filter api build`。
+
+## Tasks / Subtasks
+
+- [ ] 路由、菜单和面包屑拆分（AC: 1, 2, 8）
+  - [ ] 在 `apps/web/src/App.tsx` 新增 `/inventory/opening-balances`、`/inventory/available`、`/inventory/batches` 路由，并保留 `/inventory -> /inventory/available` 兼容入口。
+  - [ ] 在 `apps/web/src/components/layout/Sidebar.tsx` 调整 `库存管理` 子菜单顺序和文案。
+  - [ ] 在 `apps/web/src/components/layout/AppLayout.tsx` 增加三个新库存页面的面包屑规则。
+  - [ ] 确认 `/inventory/transactions`、`/receipt-orders`、`/outbound-orders` 菜单高亮不被新 `/inventory/*` 匹配误伤。
+- [ ] 拆分库存页面并提取复用组件（AC: 3-7, 10）
+  - [ ] 将 `apps/web/src/pages/inventory/index.tsx` 中的期初录入逻辑拆到 `opening-balances.tsx`。
+  - [ ] 将可用库存汇总查询拆到 `available.tsx`。
+  - [ ] 将批次库存明细拆到 `batches.tsx`。
+  - [ ] 保留并对齐 `transactions.tsx` 的独立流水页，支持从 URL 或路由状态读取 `skuId`、`warehouseId`。
+  - [ ] 提取共享工具/组件，避免复制 `toNumberId`、SKU/仓库 option 构造、库存变动类型 Tag、来源单据链接等逻辑。
+- [ ] 页面交互与上下文跳转（AC: 4-8）
+  - [ ] 可用库存查询页提供行操作或清晰链接：查看批次、查看流水。
+  - [ ] 批次库存明细页提供查看流水入口，并携带 SKU/仓库筛选上下文。
+  - [ ] 确认页面标题、副标题、空状态、加载态、错误态符合 ERP 工作台风格。
+  - [ ] 确认刷新 `/inventory/opening-balances`、`/inventory/available`、`/inventory/batches`、`/inventory/transactions` 均能正常渲染。
+- [ ] 守住库存领域边界（AC: 9, 11）
+  - [ ] 不修改库存写入、锁定、解锁、入库、出库、流水幂等逻辑。
+  - [ ] 不新增临时库存 API、mock API 或前端硬编码库存数据。
+  - [ ] 如果必须扩展 `GET /api/inventory/batches`，只改查询参数/分页输出，保持数量字段含义不变。
+- [ ] 验证与记录（AC: 12）
+  - [ ] 运行 `pnpm --filter web build`。
+  - [ ] 若有后端改动，运行对应库存 API 定向测试和 `pnpm --filter api build`。
+  - [ ] 更新本 Story 的 Dev Agent Record、File List、Completion Notes。
+  - [ ] 实现与验证完成后，将 `sprint-status.yaml` 中 5.7 更新为 `done`，并将 `epic-5` 关回 `done`。
+
+## Dev Notes
+
+### Correct-Course Decision Authority
+
+本 Story 来自已批准的 Sprint Change Proposal：
+
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-27-inventory-menu-split.md`
+
+该提案确认本次变更是 **Direct Adjustment / Moderate scope**。问题是库存管理信息架构和页面职责边界不清，不是库存模型或接口能力失败。
+
+执行边界：
+
+- 拆菜单、拆路由、拆页面、提取复用组件。
+- 复用现有库存 API 和 TanStack Query 请求模式。
+- 不改库存领域模型、交易状态机、库存写事务或库存流水幂等。
+
+### Epic 5-7 Mandatory Flow Context
+
+本 Story 位于 Epic 5 补丁队列，但触达库存页面。开发前必须完整加载并遵守：
+
+- `_bmad-output/planning-artifacts/flow-cross-document-trigger.md`
+- `_bmad-output/planning-artifacts/flow-state-machine.md`
+- `_bmad-output/planning-artifacts/flow-quantity-data-lineage.md`
+
+与本 Story 直接相关的硬约束：
+
+- 库存数量权威来源是 `inventory_summary`、`inventory_batch`、`shipping_demand_inventory_allocations`、`inventory_transactions`。
+- 状态推进由领域动作服务和数量事实触发，前端不得提交目标状态。
+- 库存写动作必须通过后端领域服务和 `InventoryService`，不得为菜单拆分新增绕过写入链路的 API。
+- `inventory_transactions` 是审计流水，不允许为了页面便利改写历史流水含义。
+
+### Existing Implementation Context
+
+当前实现事实：
+
+- `apps/web/src/pages/inventory/index.tsx` 约 846 行，当前同时包含：
+  - 期初库存录入表单。
+  - 可用库存查询筛选和汇总指标。
+  - 批次库存明细表。
+  - 库存变动流水 Drawer。
+- `apps/web/src/pages/inventory/transactions.tsx` 已存在独立库存变动流水页。
+- `apps/web/src/pages/inventory/inventory.css` 被 `index.tsx` 和 `transactions.tsx` 共同使用，拆分时优先复用，不要引入另一套不一致样式。
+- `apps/web/src/api/inventory.api.ts` 已提供：
+  - `getAvailableInventory(params)`
+  - `getInventoryBatches(params)`
+  - `getInventoryTransactions(params)`
+  - `createOpeningInventory(payload)`
+- `apps/api/src/modules/inventory/inventory.controller.ts` 已提供：
+  - `GET /api/inventory/available`
+  - `GET /api/inventory/batches`
+  - `GET /api/inventory/transactions`
+  - `POST /api/inventory/opening-balances`
+- `QueryAvailableInventoryDto` 当前支持 `skuIds` 和 `warehouseId`，供 available 和 batches 共用。
+- `QueryInventoryTransactionDto` 当前支持 `skuId`、`warehouseId`、`changeType`、`startTime`、`endTime`、`page`、`pageSize`。
+
+### Recommended File Structure
+
+建议目标结构：
+
+```text
+apps/web/src/pages/inventory/
+  opening-balances.tsx
+  available.tsx
+  batches.tsx
+  transactions.tsx
+  inventory.css
+  components/
+    InventoryMetric.tsx
+    InventoryFilters.tsx
+    InventoryChangeTypeTag.tsx
+    SourceDocumentLink.tsx
+    inventory-page-utils.ts
+```
+
+允许根据实际复用程度调整文件名，但必须避免把所有新逻辑继续塞进 `index.tsx`。
+
+`index.tsx` 可删除、保留为 re-export，或保留很薄的兼容组件；路由层推荐直接用 `<Navigate to="/inventory/available" replace />`。
+
+### UI/UX Requirements
+
+遵守 `_bmad-output/planning-artifacts/ux-spec.md`：
+
+- ERP 操作台应信息密集、安静、可扫描。
+- 列表页结构使用页面标题/副标题、工具栏筛选、数据表格、分页或清晰总数。
+- 面包屑是唯一路径导航，不要在内容区重复渲染一套路径导航。
+- 每页最多一个 Primary 按钮：期初库存录入页的 Primary 是保存；查询页的 Primary 是查询或刷新。
+- 状态/数量提示使用颜色+文字双编码，不要只靠颜色。
+
+页面职责建议：
+
+- `期初库存录入`：低频写操作，表单独立、保存反馈明确。保存成功后可提示去可用库存查询查看结果，但不要把查询表塞回本页。
+- `可用库存查询`：日常库存汇总查询，展示实际库存、锁定量、可用库存和行级跳转。
+- `批次库存明细`：批次追溯和 FIFO 来源查询，展示 sourceType/sourceDocument/receiptDate。
+- `库存变动流水`：审计追溯，展示变动类型、delta、before/after、来源单据、操作人、操作时间。
+
+### API and Routing Notes
+
+推荐路由：
+
+```tsx
+<Route path="/inventory" element={<Navigate to="/inventory/available" replace />} />
+<Route path="/inventory/opening-balances" element={<InventoryOpeningBalancesPage />} />
+<Route path="/inventory/available" element={<InventoryAvailablePage />} />
+<Route path="/inventory/batches" element={<InventoryBatchesPage />} />
+<Route path="/inventory/transactions" element={<InventoryTransactionsPage />} />
+```
+
+推荐上下文跳转参数：
+
+- `/inventory/batches?skuIds=1&warehouseId=2`
+- `/inventory/transactions?skuId=1&warehouseId=2`
+
+注意当前 API 差异：
+
+- available/batches 使用 `skuIds`（逗号分隔，多 SKU）。
+- transactions 使用 `skuId`（单 SKU）。
+
+实现跳转时要做参数名转换，不要把 `skuIds` 直接传给 transactions。
+
+### Architecture Compliance
+
+- 前端请求必须在 `apps/web/src/api/*.api.ts` 封装，组件内不得直接 axios。
+- 服务端数据使用 TanStack Query；不要用 `useEffect + useState` 手写请求生命周期。
+- React Router 7 路由改动必须同时检查 `App.tsx`、`Sidebar.tsx`、`AppLayout.tsx` 的入口、高亮和面包屑。
+- 不要新增业务枚举；库存变动类型继续从 `@infitek/shared` 引用。
+- 如果拆组件时移动类型，保持 TypeScript ESM import；避免未使用变量导致 web build 失败。
+- 不提交 generated/dist 文件。
+
+### Previous Story Intelligence
+
+- Story 5.0 建立了 `InventoryModule`、库存双层表、期初录入、可用库存查询和前端库存基础入口。其 File List 是本 Story 主要参考。
+- Story 5.0 的后续修复曾处理“库存菜单点击进入首页”的问题：`库存管理` 父菜单和 `/inventory/*` 路由容易被兜底重定向误伤。本 Story 重做路由时必须回归旧路径。
+- Story 6.2 已补独立 `库存变动流水` 菜单和 `/inventory/transactions` 页面；本 Story 不应删除该独立页面，只需支持上下文参数并移除混合页依赖。
+- 最近修复 `spec-fix-inventory-transaction-source-order-link` 改善了流水来源单据展示；拆分 `SourceDocumentLink` 时应保留 `sourceDocumentCode`、`sourceDocumentLabel`、`sourceDocumentPath` 的显示和跳转能力。
+
+### Testing Requirements
+
+最低验证：
+
+```bash
+pnpm --filter web build
+```
+
+若只改前端，记录 web build 即可。若扩展后端批次查询接口或 DTO：
+
+```bash
+pnpm --filter api exec jest modules/inventory/tests --runInBand
+pnpm --filter api build
+pnpm --filter web build
+```
+
+建议人工检查：
+
+- `/inventory` 自动进入可用库存查询。
+- `/inventory/opening-balances` 只显示期初库存录入。
+- `/inventory/available` 能查询汇总库存，并能跳到批次/流水。
+- `/inventory/batches` 能独立按 SKU/仓库查看批次。
+- `/inventory/transactions?skuId=...&warehouseId=...` 能自动带入筛选。
+- 侧边栏展开库存管理时，高亮项准确。
+
+### Implementation Boundaries
+
+- 不重做库存基础数据模型。
+- 不修改库存写事务、死锁重试、行锁、库存流水幂等。
+- 不改发货需求、采购订单、收货、物流、出库领域逻辑。
+- 不新增临时 mock 数据或硬编码库存结果。
+- 不把 `库存变动流水` 重新塞回 `可用库存查询` 主页面。
+- 不为这次菜单拆分引入新的 UI 库或状态管理库。
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-27-inventory-menu-split.md`]
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story 5.7`]
+- [Source: `_bmad-output/implementation-artifacts/5-0-库存双层结构查询接口与期初录入.md`]
+- [Source: `_bmad-output/implementation-artifacts/6-2-库存变动流水.md`]
+- [Source: `_bmad-output/project-context.md#Frontend Framework Rules`]
+- [Source: `_bmad-output/project-context.md#Transaction & Domain Rules`]
+- [Source: `_bmad-output/planning-artifacts/ux-spec.md#3. 导航规范`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5 Codex
+
+### Debug Log References
+
+- Story created from approved correct-course proposal on 2026-05-27.
+- Worktree path during story creation: `/Users/chenkangping/.codex/worktrees/bbd1/infitek_erp`
+
+### Completion Notes List
+
+- Story context created; implementation not started.
+- Epic 5 reopened in sprint status because Story 5.7 is a post-retrospective patch.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/5-7-库存管理菜单拆分与页面边界整理.md`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|---|---:|---|---|
+| 2026-05-27 | 0.1 | 创建库存菜单拆分补丁 Story 上下文 | GPT-5 Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-05-27 (epic-6-8-retrospective)
+# last_updated: 2026-05-27 (story-5-7-created)
 # project: infitek_erp
 # project_key: NOKEY
 # tracking_system: file-system
@@ -39,7 +39,7 @@
 #   _bmad-output/planning-artifacts/flow-quantity-data-lineage.md
 
 generated: 2026-04-15
-last_updated: 2026-05-27 (epic-6-8-retrospective)
+last_updated: 2026-05-27 (story-5-7-created)
 project: infitek_erp
 
 project_key: NOKEY
@@ -106,7 +106,7 @@ development_status:
   # ─────────────────────────────────────────────────
   # Epic 5: 销售订单与发货需求管理
   # ─────────────────────────────────────────────────
-  epic-5: done
+  epic-5: in-progress
   5-1-销售订单创建与确认: done
   5-0-库存双层结构查询接口与期初录入: done
   5-2-销售订单列表与详情: done
@@ -114,6 +114,7 @@ development_status:
   5-4-发货需求枢纽详情页: done
   5-5-发货需求下游入口与完整作废逻辑: done
   5-6-发货需求待生成采购单状态纠偏: done
+  5-7-库存管理菜单拆分与页面边界整理: ready-for-dev
   epic-5-retrospective: done
 
   # ─────────────────────────────────────────────────

--- a/_bmad-output/planning-artifacts/epics.md
+++ b/_bmad-output/planning-artifacts/epics.md
@@ -1228,6 +1228,56 @@ So that 我可以从枢纽页一键操作，作废后系统状态干净彻底，
 **When** 查看详情页
 **Then** 不展示"作废"按钮（FR49 规则：离开待分配库存后不允许作废）
 
+### Story 5.7: 库存管理菜单拆分与页面边界整理
+
+As a 仓库人员和系统管理员,
+I want 将期初库存录入、可用库存查询、批次库存明细和库存变动流水拆分为独立菜单,
+So that 我可以按实际任务快速进入对应页面，避免在一个混合页面中查找操作入口。
+
+**Acceptance Criteria:**
+
+**Given** 授权用户打开左侧 `库存管理` 菜单
+**When** 菜单展开
+**Then** 展示独立子菜单：`期初库存录入`、`可用库存查询`、`批次库存明细`、`库存变动流水`、`收货入库`、`发货出库`
+
+**Given** 用户访问旧路径 `/inventory`
+**When** 路由匹配
+**Then** 系统不返回空白页或首页兜底，而是进入或重定向到 `可用库存查询`
+
+**Given** 用户进入 `期初库存录入` 页面
+**When** 页面加载完成
+**Then** 页面只承担 SKU、仓库、期初数量、入库日期录入和保存反馈
+**And** 保存仍调用 `POST /api/inventory/opening-balances`
+**And** 不在该页面内展示完整可用库存大表、批次库存明细大表或库存流水表
+
+**Given** 用户进入 `可用库存查询` 页面
+**When** 按 SKU 或仓库筛选
+**Then** 页面展示 SKU+仓库维度的实际库存、锁定量、可用库存
+**And** 查询仍调用 `GET /api/inventory/available`
+**And** 页面支持从结果行跳转到对应批次库存明细和库存变动流水，并携带 SKU/仓库筛选上下文
+
+**Given** 用户进入 `批次库存明细` 页面
+**When** 按 SKU 或仓库筛选
+**Then** 页面展示批次号、SKU、仓库、批次数量、锁定量、批次可用、来源类型/来源单据、入库日期
+**And** 查询优先复用 `GET /api/inventory/batches`
+**And** 如需补充分页或筛选参数，只允许小幅扩展查询 DTO，不改变库存写入逻辑或数量口径
+
+**Given** 用户进入 `库存变动流水` 页面
+**When** 页面从可用库存查询或批次库存明细跳转进入
+**Then** 页面可读取 URL 查询参数或等价路由状态，自动带入 SKU/仓库筛选
+**And** 页面继续调用 `GET /api/inventory/transactions`
+
+**Given** 本 Story 实现过程中涉及库存相关代码
+**When** 开发者修改页面、路由、菜单或 API 类型
+**Then** 不改变 `inventory_summary`、`inventory_batch`、`inventory_transactions` 数据模型
+**And** 不改变库存写入、锁定、解锁、入库、出库和流水幂等逻辑
+**And** 前端 API 调用继续通过 `apps/web/src/api/inventory.api.ts` 和 TanStack Query，不允许组件内直接 axios
+
+**Given** 开发完成
+**When** 运行验证
+**Then** `pnpm --filter web build` 通过
+**And** 若扩展后端批次查询接口，则补充相关定向测试并运行 `pnpm --filter api build`
+
 ## Epic 6: 采购订单与收货入库
 
 库存双层数据模型、期初录入和可用库存查询接口已在 Epic 5 Story 5.0 前置落地。Epic 6 不再重复创建库存基础表和查询接口，而是在采购订单、收货入库、请购型收货自动锁定、库存变动流水中消费同一 InventoryModule。采购分组预览面板（按供应商分组确认）同时落地。

--- a/_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-27-inventory-menu-split.md
+++ b/_bmad-output/planning-artifacts/sprint-change-proposal-2026-05-27-inventory-menu-split.md
@@ -1,0 +1,308 @@
+# Sprint Change Proposal: 库存管理菜单拆分与页面边界整理
+
+Date: 2026-05-27
+Project: infitek_erp
+Owner: friday
+Mode: Batch
+Skill: bmad-correct-course
+
+## 1. Issue Summary
+
+库存基础能力在 Story 5.0 为了支撑 Story 5.2 前置落地时，将期初库存录入、可用库存查询和批次库存明细集中放进 `apps/web/src/pages/inventory/index.tsx` 的同一个页面。Story 6.2 又在同一库存页面增加“查看变动流水”抽屉，同时补了独立的 `库存变动流水` 菜单。随着库存链路继续完成，这个入口已经从“临时便捷聚合页”变成了较重的混合工作台。
+
+当前问题不是库存模型或接口能力失败，而是信息架构和页面职责边界不清：
+
+- 期初库存录入是系统上线/初始化动作，属于低频写操作，需要独立菜单和明确二次确认语义。
+- 可用库存查询是日常查询入口，应聚焦 `SKU + 仓库` 的实际库存、锁定量、可用库存。
+- 批次库存明细是 FIFO、来源单据和批次追溯入口，应独立展示批次粒度，不应被塞在可用库存查询页底部。
+- 库存变动流水已经有独立菜单，但库存查询页仍内嵌流水抽屉，容易继续强化“所有库存东西都在一个页”的使用心智。
+
+支持证据：
+
+- Story 5.0 的 AC9 只要求“前端新增库存基础入口，可完成期初库存录入并查看 SKU+仓库库存查询结果”，当时为了效率合并实现。
+- Story 6.2 的 Dev Notes 明确记录当前库存页面“已有期初库存录入、可用库存汇总表、批次库存明细”，并在此基础上增加流水抽屉。
+- 当前代码 `apps/web/src/pages/inventory/index.tsx` 已约 846 行，包含期初录入表单、可用库存查询、批次库存表、库存流水 Drawer 多个职责。
+- 当前侧边栏 `库存管理` 下已有 `/inventory` 和 `/inventory/transactions`，但缺少独立的 `期初库存录入`、`可用库存查询`、`批次库存明细` 菜单项。
+
+## 2. Checklist Findings
+
+| Checklist Item | Status | Finding |
+|---|---|---|
+| 1.1 Triggering story | Done | 触发源是 Story 5.0 的库存基础聚合页实现；Story 6.2 又在该页叠加库存流水抽屉，使页面职责进一步膨胀。 |
+| 1.2 Core problem | Done | 问题类型为“已实现方案的信息架构边界不清”，不是库存模型、后端 API 或交易链路失败。 |
+| 1.3 Evidence | Done | `inventory/index.tsx` 集中多个库存工作流；PRD FR40/FR43 对期初录入、库存查询、历史流水本身是不同操作语义；用户反馈该菜单混乱。 |
+| 2.1 Current epic impact | Done | Epic 5、6 已 done，不需要回滚；以补丁 Story 方式整理页面与菜单即可。 |
+| 2.2 Epic-level changes | Action-needed | 建议在 Epic 5 或 Epic 8 增加补丁故事：库存管理菜单拆分与页面边界整理。 |
+| 2.3 Remaining epics impact | Done | 主交易链 Epic 6-8 已完成；本变更不改变采购、收货、物流、出库流程。 |
+| 2.4 New epic need | N/A | 不需要新增 Epic。 |
+| 2.5 Priority/order | Done | 应在继续增加库存相关功能前优先处理，避免后续功能继续叠加到混合页。 |
+| 3.1 PRD conflict | Action-needed | PRD FR40/FR43 无需改需求目标，但“库存台账/期初库存”表达应补充为独立菜单边界。 |
+| 3.2 Architecture conflict | Done | 不改变库存双层结构、事务、行锁、API 前缀或 shared 枚举；只调整前端路由/页面组织，必要时复用现有 API。 |
+| 3.3 UI/UX conflict | Action-needed | 需要更新库存管理导航、面包屑、页面标题、快捷跳转和页面职责。 |
+| 3.4 Other artifacts | Action-needed | 需更新 `epics.md`、新增补丁 Story、`sprint-status.yaml`；可选更新 `project-context.md` 的库存页面规则。 |
+| 4.1 Direct adjustment | Viable | 新增补丁 Story 拆分路由和页面，复用现有 API。Effort: Medium。Risk: Low-Medium。 |
+| 4.2 Rollback | Not viable | 回滚 Story 5.0/6.2 会破坏已完成库存基础与流水能力，收益低。 |
+| 4.3 MVP review | Not viable | MVP 仍成立，无需缩减范围。 |
+| 4.4 Recommended path | Done | 选择 Direct Adjustment。 |
+| 5.1-5.5 Proposal components | Done | 本文包含问题摘要、影响、详细变更、实现 handoff 和成功标准。 |
+| 6.1-6.2 Final review | Done | Proposal 已按 Batch 汇总。 |
+| 6.3 Approval | Action-needed | 需用户批准后再更新 sprint-status 和创建补丁 Story。 |
+| 6.4 sprint-status update | N/A before approval | 批准前不修改 sprint-status；批准后新增补丁 Story 条目。 |
+
+## 3. Impact Analysis
+
+### Epic Impact
+
+| Epic | Impact | Required Change |
+|---|---|---|
+| Epic 5 销售订单与发货需求管理 | Story 5.0 已完成库存基础能力，但前端入口边界过粗。 | 增加 Story 5.7 作为补丁，拆分库存基础页面和菜单；不改变 5.2/5.4 的库存消费方式。 |
+| Epic 6 采购订单与收货入库 | Story 6.2 已完成库存流水并补独立菜单。 | 保留 `库存变动流水` 独立菜单；从库存查询页移除或弱化内嵌流水抽屉，改为跳转独立流水页并带筛选参数。 |
+| Epic 7 物流单与发货出库 | 无业务影响。 | 不改变出库库存扣减、allocation 消费和流水写入。 |
+| Epic 8 发货需求枢纽库存决策 | 无状态机影响，但库存查询入口可作为运营辅助。 | 无需改状态机；可在 UI 上提供从可用库存行跳转批次/流水的上下文链接。 |
+
+### Artifact Conflicts
+
+| Artifact | Conflict | Change Needed |
+|---|---|---|
+| PRD FR40 | 期初库存录入被实现为库存查询页内的一段表单。 | 补充“期初库存录入为独立菜单/页面，面向初始化和纠正上线初始账面库存”。 |
+| PRD FR43 | “按 SKU 或仓库查询当前库存数量及历史变动流水”目前部分混在单页。 | 明确当前库存、批次明细、历史流水为库存管理下三个查询入口。 |
+| `epics.md` Story 5.0 | AC9 只说“库存基础入口”，容易继续允许单页聚合。 | 新增补丁 Story，约束页面拆分和路由兼容。 |
+| UX Spec / Sidebar | 库存管理菜单缺少细分项。 | 更新库存管理子菜单：期初库存录入、可用库存查询、批次库存明细、库存变动流水、收货入库、发货出库。 |
+| Implementation artifacts | Story 5.0/6.2 记录当前实现状态。 | 新增补丁 Story，不改写历史完成事实；在 Dev Notes 中引用 5.0/6.2。 |
+
+### Technical Impact
+
+- 前端路由建议新增：
+  - `/inventory/opening-balances`：期初库存录入
+  - `/inventory/available`：可用库存查询
+  - `/inventory/batches`：批次库存明细
+  - `/inventory/transactions`：库存变动流水（已存在）
+- `/inventory` 保持兼容，建议重定向到 `/inventory/available`，避免旧链接失效。
+- 侧边栏 `库存管理` 子菜单建议调整为：
+  - 期初库存录入
+  - 可用库存查询
+  - 批次库存明细
+  - 库存变动流水
+  - 收货入库
+  - 发货出库
+- `apps/web/src/pages/inventory/index.tsx` 应拆分为多个页面和共享组件：
+  - `opening-balances.tsx`
+  - `available.tsx`
+  - `batches.tsx`
+  - `transactions.tsx` 保留或轻微对齐筛选参数
+  - `components/` 提取库存指标、SKU/仓库筛选、变动类型 Tag、来源单据链接等复用组件
+- 现有 API 可优先复用：
+  - `POST /api/inventory/opening-balances`
+  - `GET /api/inventory/available`
+  - `GET /api/inventory/batches`
+  - `GET /api/inventory/transactions`
+- 如发现批次明细接口缺少独立页面所需筛选或分页，可在同一补丁 Story 内小幅扩展查询 DTO；不得改变库存写入逻辑、库存数量口径或交易状态机。
+
+## 4. Recommended Approach
+
+推荐路径：Direct Adjustment。
+
+范围分类：Moderate。
+
+理由：
+
+- 当前功能能力已经可用，不需要回滚库存基础、流水、收货或出库链路。
+- 用户反馈指向菜单和页面边界混乱，最小正确修复是拆路由、拆页面、拆菜单，而不是改库存领域模型。
+- 拆分后能减少后续库存功能继续堆到 `inventory/index.tsx` 的风险，也便于不同岗位按任务进入页面。
+- 本变更不影响 MVP 的核心端到端链路，只提升操作清晰度和维护性。
+
+建议新增补丁 Story：
+
+**Story 5.7: 库存管理菜单拆分与页面边界整理**
+
+As a 仓库人员和系统管理员,
+I want 将期初库存录入、可用库存查询、批次库存明细和库存变动流水拆分为独立菜单,
+so that 我可以按实际任务快速进入对应页面，避免在一个混合页面中查找操作入口。
+
+建议验收标准：
+
+1. `库存管理` 侧边栏下展示独立子菜单：`期初库存录入`、`可用库存查询`、`批次库存明细`、`库存变动流水`、`收货入库`、`发货出库`。
+2. `/inventory` 旧路径不失效，自动重定向或等价进入 `可用库存查询`。
+3. `期初库存录入` 页面只承担 SKU、仓库、期初数量、入库日期录入和保存后的反馈；不得混入可用库存大表或批次明细大表。
+4. `可用库存查询` 页面展示 SKU+仓库维度的实际库存、锁定量、可用库存，支持 SKU/仓库筛选、空状态、加载态和错误态。
+5. `批次库存明细` 页面展示批次号、SKU、仓库、批次数量、锁定量、批次可用、来源类型/来源单据、入库日期，支持 SKU/仓库筛选；如 API 已支持则复用现有接口。
+6. `库存变动流水` 页面继续作为独立页面存在，支持从可用库存或批次明细页面带筛选条件跳转；不再要求库存查询页内嵌完整流水 Drawer。
+7. 面包屑、页面标题和浏览器路由与新菜单一致；刷新页面不丢失当前路由。
+8. 不改变 `inventory_summary`、`inventory_batch`、`inventory_transactions` 数据模型，不改变库存写入、锁定、解锁、入库、出库、流水幂等逻辑。
+9. 前端 API 调用继续通过 `apps/web/src/api/inventory.api.ts` 和 TanStack Query；组件内不得直接 axios。
+10. 至少运行 `pnpm --filter web build`；若扩展后端批次查询接口，补充相关 API 定向测试并运行 `pnpm --filter api build`。
+
+## 5. Detailed Change Proposals
+
+### Proposal A — Sidebar Menu
+
+Target: `apps/web/src/components/layout/Sidebar.tsx`
+
+OLD:
+
+```ts
+children: [
+  { key: '/inventory', label: '库存查询', exact: true },
+  { key: '/receipt-orders', label: '收货入库' },
+  { key: '/outbound-orders', label: '发货出库' },
+  { key: '/inventory/transactions', label: '库存变动流水' },
+]
+```
+
+NEW:
+
+```ts
+children: [
+  { key: '/inventory/opening-balances', label: '期初库存录入' },
+  { key: '/inventory/available', label: '可用库存查询' },
+  { key: '/inventory/batches', label: '批次库存明细' },
+  { key: '/inventory/transactions', label: '库存变动流水' },
+  { key: '/receipt-orders', label: '收货入库' },
+  { key: '/outbound-orders', label: '发货出库' },
+]
+```
+
+Rationale: 菜单按用户任务拆分，避免“库存查询”承载写入、查询、追溯三类不同工作。
+
+### Proposal B — Routes
+
+Target: `apps/web/src/App.tsx`
+
+OLD:
+
+```tsx
+<Route path="/inventory/transactions" element={<InventoryTransactionsPage />} />
+<Route path="/inventory" element={<InventoryPage />} />
+<Route path="/inventory/*" element={<InventoryPage />} />
+```
+
+NEW:
+
+```tsx
+<Route path="/inventory" element={<Navigate to="/inventory/available" replace />} />
+<Route path="/inventory/opening-balances" element={<InventoryOpeningBalancesPage />} />
+<Route path="/inventory/available" element={<InventoryAvailablePage />} />
+<Route path="/inventory/batches" element={<InventoryBatchesPage />} />
+<Route path="/inventory/transactions" element={<InventoryTransactionsPage />} />
+```
+
+Rationale: 保留旧入口兼容，同时让每个库存工作流拥有明确路由。
+
+### Proposal C — Breadcrumbs
+
+Target: `apps/web/src/components/layout/AppLayout.tsx`
+
+OLD:
+
+```ts
+...createCrudBreadcrumbRoutes({
+  basePath: "/inventory",
+  sectionLabel: "库存管理",
+  sectionPath: INVENTORY_SECTION_PATH,
+  listLabel: "库存查询",
+}),
+```
+
+NEW:
+
+```ts
+...createCrudBreadcrumbRoutes({
+  basePath: "/inventory/opening-balances",
+  sectionLabel: "库存管理",
+  sectionPath: "/inventory/available",
+  listLabel: "期初库存录入",
+}),
+...createCrudBreadcrumbRoutes({
+  basePath: "/inventory/available",
+  sectionLabel: "库存管理",
+  sectionPath: "/inventory/available",
+  listLabel: "可用库存查询",
+}),
+...createCrudBreadcrumbRoutes({
+  basePath: "/inventory/batches",
+  sectionLabel: "库存管理",
+  sectionPath: "/inventory/available",
+  listLabel: "批次库存明细",
+}),
+```
+
+Rationale: 面包屑和菜单保持同一任务口径。
+
+### Proposal D — Page Split
+
+Target: `apps/web/src/pages/inventory/`
+
+OLD:
+
+```text
+index.tsx
+transactions.tsx
+inventory.css
+```
+
+NEW:
+
+```text
+opening-balances.tsx
+available.tsx
+batches.tsx
+transactions.tsx
+components/
+  InventoryMetric.tsx
+  InventoryFilters.tsx
+  InventoryChangeTypeTag.tsx
+  SourceDocumentLink.tsx
+inventory.css
+```
+
+Rationale: 将 846 行混合页拆成任务页面和复用组件，降低后续改动风险。
+
+### Proposal E — PRD/Epic Text
+
+Target: `_bmad-output/planning-artifacts/epics.md`
+
+Add after Story 5.0 or as补丁 story:
+
+```md
+### Story 5.7: 库存管理菜单拆分与页面边界整理
+
+As a 仓库人员和系统管理员,
+I want 将期初库存录入、可用库存查询、批次库存明细和库存变动流水拆分为独立菜单,
+so that 我可以按实际任务快速进入对应页面，避免在一个混合页面中查找操作入口。
+```
+
+Rationale: 以新补丁 Story 承载菜单拆分，不改写 Story 5.0/6.2 已完成事实。
+
+## 6. Implementation Handoff
+
+Scope: Moderate。
+
+Recommended handoff:
+
+- Product/Owner：批准本 proposal，并确认新菜单命名。
+- Developer agent：创建 Story 5.7，执行页面拆分、路由/菜单/面包屑更新和构建验证。
+- Reviewer：重点检查是否只做 UI/路由边界整理，未破坏库存写入、流水、收货、出库主链。
+
+Implementation sequence:
+
+1. 用户批准本 Sprint Change Proposal。
+2. 更新 `sprint-status.yaml`，新增 `5-7-库存管理菜单拆分与页面边界整理: backlog`。
+3. 运行 `bmad-create-story` 创建 Story 5.7。
+4. 使用 `start story 5-7` 进入实现。
+5. 完成后运行 code review，重点审路由兼容、菜单高亮、面包屑、页面职责和 build。
+
+Success criteria:
+
+- 用户进入库存管理时能清楚选择期初录入、可用库存查询、批次库存明细、库存变动流水。
+- 原 `/inventory` 入口不会 404。
+- 可用库存查询页不再承担期初录入和批次明细完整展示。
+- 期初库存录入页不再被日常查询表格淹没。
+- 批次库存明细可以独立筛选和查看 FIFO 来源。
+- 库存变动流水继续独立可查，并支持从其他库存页面带上下文跳转。
+- 库存数量模型和交易链路无回归。
+
+## 7. Approval
+
+Status: Approved by user on 2026-05-27.
+
+已批准继续执行 sprint-status 更新和补丁 Story 创建；本 proposal 不直接修改业务代码。


### PR DESCRIPTION
## Summary
- add approved Sprint Change Proposal for splitting inventory management menus
- add Story 5.7 for separating opening inventory, available inventory, batch details, and transaction ledger pages
- update sprint status to reopen Epic 5 and mark Story 5.7 ready for dev

## Tests
- Not run; documentation and BMAD planning artifacts only.