### PR TITLE
fix(auth): auto provision DingTalk login users

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -9,10 +9,12 @@ import { JwtStrategy } from './strategies/jwt.strategy';
 import { UsersModule } from '../users/users.module';
 import { DingtalkAuthClient } from './dingtalk-auth.client';
 import { DingtalkLoginSessionStore } from './dingtalk-login-session.store';
+import { DingtalkOrgUsersModule } from '../dingtalk-org-users/dingtalk-org-users.module';
 
 @Module({
   imports: [
     UsersModule,
+    DingtalkOrgUsersModule,
     PassportModule,
     ThrottlerModule.forRoot([
       {

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { UserStatus } from '@infitek/shared';
 import { DingtalkAuthClient } from './dingtalk-auth.client';
 import { DingtalkLoginSessionStore } from './dingtalk-login-session.store';
 import type { DingtalkConfig } from '../../config/dingtalk.config';
+import { DingtalkOrgUsersService } from '../dingtalk-org-users/dingtalk-org-users.service';
 
 @Injectable()
 export class AuthService {
@@ -20,6 +21,7 @@ export class AuthService {
     private readonly configService: ConfigService,
     private readonly dingtalkAuthClient: DingtalkAuthClient,
     private readonly dingtalkLoginSessionStore: DingtalkLoginSessionStore,
+    private readonly dingtalkOrgUsersService: DingtalkOrgUsersService,
   ) {}
 
   async login(username: string, password: string): Promise<{ accessToken: string }> {
@@ -64,7 +66,11 @@ export class AuthService {
       }
 
       const identity = await this.dingtalkAuthClient.exchangeCodeForIdentity(code);
-      const user = await this.usersService.findByDingtalkUnionId(identity.unionId);
+      let user = await this.usersService.findByDingtalkUnionId(identity.unionId);
+
+      if (!user) {
+        user = await this.dingtalkOrgUsersService.autoBindForLogin(identity);
+      }
 
       if (!user) {
         this.logger.warn(

--- a/apps/api/src/modules/auth/tests/auth.service.spec.ts
+++ b/apps/api/src/modules/auth/tests/auth.service.spec.ts
@@ -8,6 +8,7 @@ import { User } from '../../users/entities/user.entity';
 import { UserStatus } from '@infitek/shared';
 import { DingtalkAuthClient } from '../dingtalk-auth.client';
 import { DingtalkLoginSessionStore } from '../dingtalk-login-session.store';
+import { DingtalkOrgUsersService } from '../../dingtalk-org-users/dingtalk-org-users.service';
 
 // mock bcrypt 整个模块，避免 native addon 不可重定义问题
 jest.mock('bcrypt', () => ({
@@ -41,6 +42,7 @@ describe('AuthService', () => {
   let configService: jest.Mocked<ConfigService>;
   let dingtalkAuthClient: jest.Mocked<DingtalkAuthClient>;
   let dingtalkLoginSessionStore: jest.Mocked<DingtalkLoginSessionStore>;
+  let dingtalkOrgUsersService: jest.Mocked<DingtalkOrgUsersService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -87,6 +89,12 @@ describe('AuthService', () => {
             consumeLoginTicket: jest.fn(),
           },
         },
+        {
+          provide: DingtalkOrgUsersService,
+          useValue: {
+            autoBindForLogin: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -96,6 +104,7 @@ describe('AuthService', () => {
     configService = module.get(ConfigService);
     dingtalkAuthClient = module.get(DingtalkAuthClient);
     dingtalkLoginSessionStore = module.get(DingtalkLoginSessionStore);
+    dingtalkOrgUsersService = module.get(DingtalkOrgUsersService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -203,10 +212,39 @@ describe('AuthService', () => {
         avatar: null,
       });
       usersService.findByDingtalkUnionId.mockResolvedValue(null);
+      dingtalkOrgUsersService.autoBindForLogin.mockResolvedValue(null);
 
       const result = await service.handleDingtalkCallback('oauth-code', 'state-1');
 
       expect(result).toContain('error=DINGTALK_ACCOUNT_UNBOUND');
+    });
+
+    it('用户池存在唯一匹配时应自动绑定并返回 ticket', async () => {
+      dingtalkLoginSessionStore.consumeState.mockReturnValue();
+      dingtalkAuthClient.exchangeCodeForIdentity.mockResolvedValue({
+        unionId: 'union-auto-bind',
+        userId: 'dt-user-1',
+        openId: 'open-1',
+        nick: '张三',
+        avatar: 'https://example.com/avatar.png',
+      });
+      usersService.findByDingtalkUnionId.mockResolvedValue(null);
+      dingtalkOrgUsersService.autoBindForLogin.mockResolvedValue({
+        ...mockUser,
+        dingtalkUnionId: 'union-auto-bind',
+      });
+      dingtalkLoginSessionStore.createLoginTicket.mockReturnValue('ticket-auto-bind');
+
+      const result = await service.handleDingtalkCallback('oauth-code', 'state-1');
+
+      expect(dingtalkOrgUsersService.autoBindForLogin).toHaveBeenCalledWith({
+        unionId: 'union-auto-bind',
+        userId: 'dt-user-1',
+        openId: 'open-1',
+        nick: '张三',
+        avatar: 'https://example.com/avatar.png',
+      });
+      expect(result).toContain('ticket=ticket-auto-bind');
     });
 
     it('停用账号应跳转带 DINGTALK_ACCOUNT_DISABLED 错误码', async () => {

--- a/apps/api/src/modules/dingtalk-org-users/dingtalk-org-users.module.ts
+++ b/apps/api/src/modules/dingtalk-org-users/dingtalk-org-users.module.ts
@@ -11,5 +11,6 @@ import { DingtalkOrgUsersController } from './dingtalk-org-users.controller';
   imports: [TypeOrmModule.forFeature([DingtalkOrgUser]), UsersModule],
   controllers: [DingtalkOrgUsersController],
   providers: [DingtalkOrgUsersRepository, DingtalkOrgUsersClient, DingtalkOrgUsersService],
+  exports: [DingtalkOrgUsersService],
 })
 export class DingtalkOrgUsersModule {}

--- a/apps/api/src/modules/dingtalk-org-users/dingtalk-org-users.service.ts
+++ b/apps/api/src/modules/dingtalk-org-users/dingtalk-org-users.service.ts
@@ -162,6 +162,125 @@ export class DingtalkOrgUsersService {
     });
   }
 
+  async autoBindForLogin(identity: {
+    unionId: string;
+    userId: string | null;
+    openId: string | null;
+    nick: string | null;
+    avatar: string | null;
+  }) {
+    const record = await this.repository.findByUnionId(identity.unionId);
+    if (!record) {
+      return null;
+    }
+
+    const existingUser = await this.usersService.findByDingtalkUnionId(identity.unionId);
+    if (existingUser) {
+      await this.repository.update(record.id, {
+        status: DingtalkOrgUserStatus.BOUND,
+        suggestedUserId: existingUser.id,
+        matchReason: 'matched-by-existing-binding',
+        lastProcessedAt: new Date(),
+        processedBy: 'system',
+        updatedBy: 'system',
+      });
+      return existingUser;
+    }
+
+    const match = await this.evaluateMatch(
+      {
+        unionId: identity.unionId,
+        email: record.email,
+        mobile: record.mobile,
+        jobNumber: record.jobNumber,
+        nick: record.nick,
+      },
+      null,
+    );
+
+    if (match.status === DingtalkOrgUserStatus.CONFLICT) {
+      await this.repository.update(record.id, {
+        status: match.status,
+        suggestedUserId: match.suggestedUserId,
+        matchReason: match.matchReason,
+        lastProcessedAt: new Date(),
+        processedBy: 'system',
+        updatedBy: 'system',
+      });
+      return null;
+    }
+
+    let userId = match.suggestedUserId;
+
+    if (!userId) {
+      const createdUser = await this.usersService.createAutoProvisionedDingtalkUser(
+        {
+          nick: identity.nick ?? record.nick,
+          mobile: record.mobile,
+          email: record.email,
+          jobNumber: record.jobNumber,
+          dingtalkUserId: identity.userId ?? record.userId,
+          unionId: identity.unionId,
+        },
+        'admin',
+      );
+      userId = createdUser.id;
+    }
+
+    const user = await this.usersService.findById(userId);
+    if (!user || user.status !== UserStatus.ACTIVE) {
+      await this.repository.update(record.id, {
+        status: DingtalkOrgUserStatus.UNBOUND,
+        suggestedUserId: null,
+        matchReason: 'no-erp-match',
+        lastProcessedAt: new Date(),
+        processedBy: 'system',
+        updatedBy: 'system',
+      });
+      return null;
+    }
+
+    const boundUser = await this.bindIdentityToUser(userId, record, identity);
+
+    await this.repository.update(record.id, {
+      status: DingtalkOrgUserStatus.BOUND,
+      suggestedUserId: userId,
+      matchReason: match.suggestedUserId ? 'auto-bound-on-login' : 'auto-provisioned-on-login',
+      lastProcessedAt: new Date(),
+      processedBy: 'system',
+      updatedBy: 'system',
+      userId: identity.userId ?? record.userId,
+      openId: identity.openId ?? record.openId,
+      nick: identity.nick ?? record.nick,
+    });
+
+    return boundUser;
+  }
+
+  private async bindIdentityToUser(
+    userId: number,
+    record: Pick<DingtalkOrgUser, 'unionId' | 'userId' | 'openId' | 'nick'>,
+    identity: {
+      unionId: string;
+      userId: string | null;
+      openId: string | null;
+      nick: string | null;
+      avatar: string | null;
+    },
+  ) {
+    return this.usersService.bindDingtalkIdentity(
+      userId,
+      {
+        dingtalkUnionId: identity.unionId,
+        dingtalkUserId: identity.userId ?? record.userId ?? undefined,
+        dingtalkOpenId: identity.openId ?? record.openId ?? undefined,
+        dingtalkNick: identity.nick ?? record.nick ?? undefined,
+        dingtalkAvatar: identity.avatar ?? undefined,
+      },
+      'admin',
+    );
+  }
+
   private assertAdmin(operatorUsername: string) {
     if (operatorUsername !== 'admin') {
       throw new ForbiddenException('只有管理员可以执行钉钉组织同步操作');

--- a/apps/api/src/modules/dingtalk-org-users/tests/dingtalk-org-users.service.spec.ts
+++ b/apps/api/src/modules/dingtalk-org-users/tests/dingtalk-org-users.service.spec.ts
@@ -27,6 +27,7 @@ describe('DingtalkOrgUsersService', () => {
     findById: jest.fn(),
     findByIds: jest.fn(),
     findActiveMatchCandidates: jest.fn(),
+    createAutoProvisionedDingtalkUser: jest.fn(),
     bindDingtalkIdentity: jest.fn(),
     unbindDingtalkIdentity: jest.fn(),
   };
@@ -261,5 +262,150 @@ describe('DingtalkOrgUsersService', () => {
       }),
     );
     expect(result.status).toBe(DingtalkOrgUserStatus.UNBOUND);
+  });
+
+  it('登录时用户池唯一命中 ERP 用户应自动绑定并回写 BOUND', async () => {
+    repository.findByUnionId.mockResolvedValue({
+      id: 51,
+      unionId: 'union-51',
+      userId: 'dt-user-51',
+      openId: 'open-51',
+      nick: '自动绑定用户',
+      mobile: '13500000000',
+      email: 'autobind@example.com',
+      jobNumber: 'EMP-51',
+    });
+    usersService.findByDingtalkUnionId.mockResolvedValue(null);
+    usersService.findActiveMatchCandidates.mockResolvedValue([
+      {
+        id: 15,
+        username: 'autobind',
+        name: '自动绑定用户',
+        status: UserStatus.ACTIVE,
+        mobile: '13500000000',
+        email: 'autobind@example.com',
+        jobNumber: 'EMP-51',
+      },
+    ]);
+    usersService.findById.mockResolvedValue({
+      id: 15,
+      username: 'autobind',
+      name: '自动绑定用户',
+      status: UserStatus.ACTIVE,
+    });
+    usersService.bindDingtalkIdentity.mockResolvedValue({ id: 15, dingtalkUnionId: 'union-51' });
+    repository.update.mockResolvedValue({ id: 51, status: DingtalkOrgUserStatus.BOUND });
+
+    const result = await service.autoBindForLogin({
+      unionId: 'union-51',
+      userId: 'dt-user-51',
+      openId: 'open-51',
+      nick: '自动绑定用户',
+      avatar: 'https://example.com/avatar.png',
+    });
+
+    expect(usersService.bindDingtalkIdentity).toHaveBeenCalledWith(
+      15,
+      expect.objectContaining({
+        dingtalkUnionId: 'union-51',
+        dingtalkUserId: 'dt-user-51',
+        dingtalkOpenId: 'open-51',
+        dingtalkNick: '自动绑定用户',
+        dingtalkAvatar: 'https://example.com/avatar.png',
+      }),
+      'admin',
+    );
+    expect(repository.update).toHaveBeenCalledWith(
+      51,
+      expect.objectContaining({
+        status: DingtalkOrgUserStatus.BOUND,
+        suggestedUserId: 15,
+        matchReason: 'auto-bound-on-login',
+      }),
+    );
+    expect(result).toEqual({ id: 15, dingtalkUnionId: 'union-51' });
+  });
+
+  it('登录时如果用户池不存在当前用户应直接返回 null', async () => {
+    repository.findByUnionId.mockResolvedValue(null);
+
+    const result = await service.autoBindForLogin({
+      unionId: 'missing-union',
+      userId: null,
+      openId: null,
+      nick: null,
+      avatar: null,
+    });
+
+    expect(result).toBeNull();
+    expect(usersService.bindDingtalkIdentity).not.toHaveBeenCalled();
+  });
+
+  it('登录时用户池存在但无 ERP 匹配应自动创建用户并绑定', async () => {
+    repository.findByUnionId.mockResolvedValue({
+      id: 61,
+      unionId: 'union-61',
+      userId: 'dt-user-61',
+      openId: null,
+      nick: '陈康平',
+      mobile: null,
+      email: null,
+      jobNumber: '100526',
+    });
+    usersService.findByDingtalkUnionId.mockResolvedValue(null);
+    usersService.findActiveMatchCandidates.mockResolvedValue([]);
+    usersService.createAutoProvisionedDingtalkUser.mockResolvedValue({
+      id: 26,
+      username: '100526',
+      name: '陈康平',
+      status: UserStatus.ACTIVE,
+    });
+    usersService.findById.mockResolvedValue({
+      id: 26,
+      username: '100526',
+      name: '陈康平',
+      status: UserStatus.ACTIVE,
+    });
+    usersService.bindDingtalkIdentity.mockResolvedValue({ id: 26, dingtalkUnionId: 'union-61' });
+    repository.update.mockResolvedValue({ id: 61, status: DingtalkOrgUserStatus.BOUND });
+
+    const result = await service.autoBindForLogin({
+      unionId: 'union-61',
+      userId: 'dt-user-61',
+      openId: 'open-61',
+      nick: '陈康平',
+      avatar: null,
+    });
+
+    expect(usersService.createAutoProvisionedDingtalkUser).toHaveBeenCalledWith(
+      {
+        nick: '陈康平',
+        mobile: null,
+        email: null,
+        jobNumber: '100526',
+        dingtalkUserId: 'dt-user-61',
+        unionId: 'union-61',
+      },
+      'admin',
+    );
+    expect(usersService.bindDingtalkIdentity).toHaveBeenCalledWith(
+      26,
+      expect.objectContaining({
+        dingtalkUnionId: 'union-61',
+        dingtalkUserId: 'dt-user-61',
+        dingtalkOpenId: 'open-61',
+        dingtalkNick: '陈康平',
+      }),
+      'admin',
+    );
+    expect(repository.update).toHaveBeenCalledWith(
+      61,
+      expect.objectContaining({
+        status: DingtalkOrgUserStatus.BOUND,
+        suggestedUserId: 26,
+        matchReason: 'auto-provisioned-on-login',
+      }),
+    );
+    expect(result).toEqual({ id: 26, dingtalkUnionId: 'union-61' });
   });
 });

--- a/apps/api/src/modules/users/__tests__/users.service.spec.ts
+++ b/apps/api/src/modules/users/__tests__/users.service.spec.ts
@@ -110,6 +110,44 @@ describe('UsersService - Story 1-4 自动化测试', () => {
         }),
       );
     });
+
+    it('P1: 应该为钉钉自动建档生成可用用户名', async () => {
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_password');
+      mockRepository.findByUsername
+        .mockResolvedValueOnce({ id: 1, username: '100526' })
+        .mockResolvedValueOnce(null);
+      mockRepository.create.mockResolvedValue({
+        id: 9,
+        username: '100526_1',
+        name: '陈康平',
+        jobNumber: '100526',
+        status: UserStatus.ACTIVE,
+        createdBy: 'admin',
+        updatedBy: 'admin',
+      });
+
+      const result = await service.createAutoProvisionedDingtalkUser(
+        {
+          nick: '陈康平',
+          mobile: null,
+          email: null,
+          jobNumber: '100526',
+          dingtalkUserId: '620383957',
+          unionId: 'union-100526',
+        },
+        'admin',
+      );
+
+      expect(result.username).toBe('100526_1');
+      expect(mockRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          username: '100526_1',
+          name: '陈康平',
+          jobNumber: '100526',
+        }),
+      );
+      expect(bcrypt.hash).toHaveBeenCalled();
+    });
   });
 
   describe('AC1: 用户列表', () => {

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -5,6 +5,7 @@ import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { BindDingtalkDto } from './dto/bind-dingtalk.dto';
 import * as bcrypt from 'bcrypt';
+import { randomBytes } from 'node:crypto';
 import { UserStatus } from '@infitek/shared';
 import { QueryFailedError } from 'typeorm';
 
@@ -65,6 +66,33 @@ export class UsersService {
       createdBy: createdBy,
       updatedBy: createdBy,
     });
+  }
+
+  async createAutoProvisionedDingtalkUser(
+    profile: {
+      nick?: string | null;
+      mobile?: string | null;
+      email?: string | null;
+      jobNumber?: string | null;
+      dingtalkUserId?: string | null;
+      unionId: string;
+    },
+    createdBy: string,
+  ): Promise<User> {
+    const username = await this.generateAutoProvisionedUsername(profile);
+    const password = this.generateSystemPassword();
+
+    return this.create(
+      {
+        username,
+        name: profile.nick?.trim() || profile.jobNumber?.trim() || username,
+        mobile: profile.mobile ?? undefined,
+        email: profile.email ?? undefined,
+        jobNumber: profile.jobNumber ?? undefined,
+        password,
+      },
+      createdBy,
+    );
   }
 
   async update(id: number, updateUserDto: UpdateUserDto, updatedBy: string): Promise<User> {
@@ -175,5 +203,32 @@ export class UsersService {
       dingtalkBoundAt: null,
       updatedBy: operatorUsername,
     });
+  }
+
+  private async generateAutoProvisionedUsername(profile: {
+    jobNumber?: string | null;
+    dingtalkUserId?: string | null;
+    unionId: string;
+  }): Promise<string> {
+    const preferredBase =
+      profile.jobNumber?.trim() ||
+      profile.dingtalkUserId?.trim() ||
+      `dingtalk_${profile.unionId.slice(0, 12)}`;
+
+    const base = preferredBase.slice(0, 50);
+    let candidate = base;
+    let suffix = 1;
+
+    while (await this.usersRepository.findByUsername(candidate)) {
+      const suffixText = `_${suffix}`;
+      candidate = `${base.slice(0, Math.max(1, 50 - suffixText.length))}${suffixText}`;
+      suffix += 1;
+    }
+
+    return candidate;
+  }
+
+  private generateSystemPassword(): string {
+    return `Dt#${randomBytes(12).toString('hex')}`;
   }
 }


### PR DESCRIPTION
## Summary
- auto-bind DingTalk login identities from the org user pool during callback
- auto-provision a local ERP user when the DingTalk org user exists but no local user matches yet
- add targeted tests for callback login, org-user auto binding, and auto-provisioned username generation

## Testing
- pnpm test -- --runInBand modules/users/__tests__/users.service.spec.ts
- pnpm test -- --runInBand modules/dingtalk-org-users/tests/dingtalk-org-users.service.spec.ts
- pnpm test -- --runInBand modules/auth/tests/auth.service.spec.ts
